### PR TITLE
fix: Update error code expectation in test_pause_and_unpause.rs for paused contract

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/tests/test_pause_and_unpause.rs
+++ b/onchain/contracts/stello_pay_contract/src/tests/test_pause_and_unpause.rs
@@ -83,7 +83,7 @@ fn test_unpause_by_non_owner_fails() {
 }
 
 #[test]
-#[should_panic(expected = "HostError: Error(Contract, #6)")]
+#[should_panic(expected = "HostError: Error(Contract, #7)")]
 fn test_create_escrow_when_paused_fails() {
     let env = Env::default();
     let contract_id = env.register(crate::payroll::PayrollContract, ());


### PR DESCRIPTION
## Description

This PR fixes the incorrect error code expectation in the `test_create_escrow_when_paused_fails` test within `test_pause_and_unpause.rs`.

## Changes Made

### 🚨 Error Code Fix
- Updated `should_panic` attribute from `Error(Contract, #6)` to `Error(Contract, #7)`
- The contract correctly returns `ContractPaused` error (#7) when paused, not `InsufficientBalance` (#6)

### 📝 Code Changes
```rust
// Before
#[should_panic(expected = "HostError: Error(Contract, #6)")]

// After  
#[should_panic(expected = "HostError: Error(Contract, #7)")]
```

## Testing

- ✅ Test now passes with correct error code expectation
- ✅ Error code matches the contract's `ContractPaused` enum value
- ✅ No other error code mismatches found in the file

## Related Issues

Closes #38 

## Checklist

- [x] Error code expectation corrected
- [x] Test passes successfully
- [x] No other error code mismatches
- [x] Contract behavior properly tested