### PR TITLE
feat: implement agreement pause and resume functionality

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -59,6 +59,20 @@ pub struct PayrollClaimedEvent {
     pub amount: i128,
 }
 
+/// Event: Agreement paused
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AgreementPausedEvent {
+    pub agreement_id: u128,
+}
+
+/// Event: Agreement resumed
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AgreementResumedEvent {
+    pub agreement_id: u128,
+}
+
 pub fn emit_agreement_created(env: &Env, event: AgreementCreatedEvent) {
     let topics = (symbol_short!("agr_new"), event.agreement_id);
     env.events().publish(topics, event);
@@ -76,5 +90,15 @@ pub fn emit_employee_added(env: &Env, event: EmployeeAddedEvent) {
 
 pub fn emit_payroll_claimed(env: &Env, event: PayrollClaimedEvent) {
     let topics = (symbol_short!("pay_clm"), event.agreement_id);
+    env.events().publish(topics, event);
+}
+
+pub fn emit_agreement_paused(env: &Env, event: AgreementPausedEvent) {
+    let topics = (symbol_short!("agr_pau"), event.agreement_id);
+    env.events().publish(topics, event);
+}
+
+pub fn emit_agreement_resumed(env: &Env, event: AgreementResumedEvent) {
+    let topics = (symbol_short!("agr_res"), event.agreement_id);
     env.events().publish(topics, event);
 }

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -226,4 +226,58 @@ impl PayrollContract {
     pub fn claim_payroll(env: Env, agreement_id: u128, employee: Address) {
         payroll::claim_payroll(&env, agreement_id, employee);
     }
+
+    /// Pauses an active agreement, preventing claims.
+    ///
+    /// # Arguments
+    /// * `agreement_id` - ID of the agreement to pause
+    ///
+    /// # State Transition
+    /// Active -> Paused
+    ///
+    /// # Requirements
+    /// - Agreement must be in Active status
+    /// - Caller must be the employer
+    ///
+    /// # Behavior
+    /// - Paused agreements cannot have claims processed
+    /// - Agreement state is preserved
+    /// - Can be resumed later or cancelled
+    pub fn pause_agreement(env: Env, agreement_id: u128) {
+        // Try new-style agreement first (payroll/escrow)
+        if payroll::get_agreement(&env, agreement_id).is_some() {
+            payroll::pause_agreement(&env, agreement_id);
+            return;
+        }
+
+        // Fall back to milestone-based agreement
+        payroll::pause_milestone_agreement(env, agreement_id);
+    }
+
+    /// Resumes a paused agreement, allowing claims again.
+    ///
+    /// # Arguments
+    /// * `agreement_id` - ID of the agreement to resume
+    ///
+    /// # State Transition
+    /// Paused -> Active
+    ///
+    /// # Requirements
+    /// - Agreement must be in Paused status
+    /// - Caller must be the employer
+    ///
+    /// # Behavior
+    /// - Agreement returns to Active status
+    /// - Claims can be processed again
+    /// - All agreement data is preserved
+    pub fn resume_agreement(env: Env, agreement_id: u128) {
+        // Try new-style agreement first (payroll/escrow)
+        if payroll::get_agreement(&env, agreement_id).is_some() {
+            payroll::resume_agreement(&env, agreement_id);
+            return;
+        }
+
+        // Fall back to milestone-based agreement
+        payroll::resume_milestone_agreement(env, agreement_id);
+    }
 }


### PR DESCRIPTION
## Summary
Implements pause and resume functionality for individual agreements, allowing employers to temporarily halt payments without cancelling agreements.

## Changes

### Core Functionality
- **`pause_agreement()`** - Pauses active agreements (payroll/escrow/milestone)
- **`resume_agreement()`** - Resumes paused agreements back to active state
- Unified interface that handles both new-style (payroll/escrow) and milestone-based agreements

### Claim Blocking
- Updated `claim_payroll()` to check for Paused status and block claims
- Updated `claim_milestone()` to check for Paused status and block claims
- Claims fail with clear error message: "Cannot claim when agreement is paused"

### Events
- Added `AgreementPausedEvent` - emitted when agreement is paused
- Added `AgreementResumedEvent` - emitted when agreement is resumed
- Event helpers: `emit_agreement_paused()` and `emit_agreement_resumed()`

### Security & Validation
- Only employer can pause/resume (enforced via `require_auth()`)
- State transition validation:
  - Can only pause Active agreements (or Created for milestone agreements)
  - Can only resume Paused agreements
- Agreement state is fully preserved during pause/resume cycles

## State Transitions
- **Pause**: `Active` → `Paused`
- **Resume**: `Paused` → `Active`

## Files Modified
- `src/payroll.rs` - Added pause/resume functions and updated claim functions
- `src/events.rs` - Added pause/resume events
- `src/lib.rs` - Exposed pause/resume functions in public interface

## Testing
- ✅ `cargo build` - Successful
- ✅ `cargo test` - All existing tests pass
- Core functionality verified and ready for integration testing

## Documentation
- Comprehensive Rust doc comments on all functions
- State transition documentation
- Security and access control notes
- Behavior documentation

## Notes
- Paused agreements maintain all state (amounts, employees, etc.)
- Paused agreements can still be cancelled
- Multiple pause/resume cycles are supported
- Works with payroll, escrow, and milestone-based agreements

Closes #171 