### PR TITLE
feat: Badge Agreement Creation

### DIFF
--- a/docs/batch-creation.md
+++ b/docs/batch-creation.md
@@ -1,0 +1,59 @@
+Batch Agreement Creation
+
+- Adds batch creation entry points to the payroll contract
+- Supports payroll and escrow agreement creation in one transaction
+- Emits per-agreement events exactly as single-creation functions
+- Uses partial-success semantics: invalid inputs do not abort the batch
+
+Interfaces
+
+- batch_create_payroll_agreements(env, employer, items) -> Result<BatchPayrollCreateResult, PayrollError>
+- batch_create_escrow_agreements(env, employer, items) -> Result<BatchEscrowCreateResult, PayrollError>
+
+Parameters
+
+- PayrollCreateParams
+  - token: Address
+  - grace_period_seconds: u64
+- EscrowCreateParams
+  - contributor: Address
+  - token: Address
+  - amount_per_period: i128
+  - period_seconds: u64
+  - num_periods: u32
+
+Return Types
+
+- BatchPayrollCreateResult
+  - total_created: u32
+  - total_failed: u32
+  - agreement_ids: Vec<u128>
+  - results: Vec<PayrollCreateResult { agreement_id?, success, error_code }>
+- BatchEscrowCreateResult
+  - total_created: u32
+  - total_failed: u32
+  - agreement_ids: Vec<u128>
+  - results: Vec<EscrowCreateResult { agreement_id?, success, error_code }>
+
+Security
+
+- Requires employer authentication at the batch level
+- Individual agreement validation mirrors single-create functions
+- No external calls during creation; events emitted after state writes
+
+Semantics
+
+- Empty item list returns PayrollError::InvalidData
+- Escrow inputs validated per entry; failures recorded, batch continues
+- Payroll creation has no extra checks beyond auth; expected to succeed
+
+Gas and UX
+
+- Batch reduces repeated authorization and client roundtrips
+- Reuses internal single-create logic for readability and auditability
+- Emits per-agreement events; downstream indexing unchanged
+
+Examples
+
+- Creating 3 payroll agreements with distinct grace periods
+- Creating escrow entries with one invalid period to demonstrate partial success

--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -287,9 +287,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes-lit"
@@ -300,7 +306,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -311,9 +317,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -333,14 +339,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -386,13 +392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compliance_checker"
-version = "0.0.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +415,20 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "compliance_checker"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "compliance_reporting"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "const-oid"
@@ -586,7 +599,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -620,7 +633,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -634,7 +647,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -645,7 +658,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -656,7 +669,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -684,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -711,7 +724,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -868,6 +881,8 @@ version = "0.0.0"
 dependencies = [
  "soroban-sdk",
 ]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,9 +906,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -939,19 +954,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -989,10 +1004,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
+name = "hash32"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1017,6 +1041,16 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1050,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1086,12 +1120,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1159,9 +1193,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1181,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -1196,21 +1230,21 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1226,14 +1260,14 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "multisig"
@@ -1254,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -1266,7 +1300,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1365,8 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "payroll_escrow"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1442,7 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1502,6 +1537,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1615,7 +1656,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1668,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1695,6 +1736,13 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "salary_adjustment"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1731,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1787,7 +1835,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1805,18 +1853,18 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "indexmap 1.8.2",
+ "indexmap 1.9.3",
  "indexmap 2.13.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -1825,14 +1873,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1898,7 +1946,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1962,7 +2010,7 @@ dependencies = [
  "soroban-env-common",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
  "wasmparser 0.116.1",
 ]
 
@@ -1978,14 +2026,14 @@ dependencies = [
  "serde",
  "serde_json",
  "stellar-xdr",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "23.4.1"
+version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2424e0acf73a465a2a178ffbc70166fc65afdcd8318537ddd89c8d70e8e281"
+checksum = "8d23caecfbd1b83c687e725611618d2a54f551900edde324da42d0fb67d2adf5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1997,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "23.4.1"
+version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98b52fc08da8e0edf29233f8c195c5500404139ba68026d4e717931bd354987"
+checksum = "3a21e18cd688578bf7a8e664f6f16ba549e9a668573634fc3673fd707e26c374"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -2015,15 +2063,15 @@ dependencies = [
  "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
- "stellar-strkey",
+ "stellar-strkey 0.0.16",
  "visibility",
 ]
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "23.4.1"
+version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6534066bc1a4cac83e536456d66def2299594879dacc1b71f0133dde3fa742bf"
+checksum = "eb8f0e8d1ece50d4beae8d11a2c1c0ec43a1c539fbbbe4bcf6e07387e8a0f0a3"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -2036,14 +2084,14 @@ dependencies = [
  "soroban-spec",
  "soroban-spec-rust",
  "stellar-xdr",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "soroban-spec"
-version = "23.4.1"
+version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12864bda598c4941907cf24efe33c361e712a333749a4afd5b37b56fbf2e3a30"
+checksum = "2bc4fef2cad410563bbd56f9fa68731268f89e90a4d7e6c4d62adb45c0b4c571"
 dependencies = [
  "base64 0.22.1",
  "stellar-xdr",
@@ -2053,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "23.4.1"
+version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef78773373ade35a667ea1e36df634de674e97c0ec5f2cd7e94c3fc524ee0de"
+checksum = "6d106b87a159334f96995fd4441e947a15d845a43613c8a5a75c8f474f44a548"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2063,15 +2111,15 @@ dependencies = [
  "sha2",
  "soroban-spec",
  "stellar-xdr",
- "syn 2.0.114",
+ "syn 2.0.117",
  "thiserror",
 ]
 
 [[package]]
 name = "soroban-token-sdk"
-version = "23.4.1"
+version = "23.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39a6be52b50dca31a27ec55901b8024e943274dae50331817a0fa85c787ffb1"
+checksum = "52f8b9257001a8897ef07cd80799a4c2ac66040b549eb74b5b0416819f7d6046"
 dependencies = [
  "soroban-sdk",
 ]
@@ -2106,6 +2154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,7 +2191,7 @@ checksum = "8bb4b3dd8f599646dab3e949ba2febc3a060a194bc1a3711ddd5e7c275acfe5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2148,6 +2202,17 @@ checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
+]
+
+[[package]]
+name = "stellar-strkey"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084afcb0d458c3d5d5baa2d294b18f881e62cc258ef539d8fdf68be7dbe45520"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "heapless",
 ]
 
 [[package]]
@@ -2176,7 +2241,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "stellar-strkey",
+ "stellar-strkey 0.0.13",
 ]
 
 [[package]]
@@ -2223,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2239,13 +2304,16 @@ dependencies = [
  "soroban-sdk",
  "stellar-contract-utils",
  "stellar-macros",
+]
+
+[[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2268,14 +2336,14 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2288,15 +2356,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2333,9 +2401,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -2367,7 +2435,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2415,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2428,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2438,22 +2506,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2531,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2591,7 +2659,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2602,7 +2670,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2668,7 +2736,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2684,7 +2752,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2728,22 +2796,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2763,11 +2831,11 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/onchain/contracts/stello_pay_contract/benches/performance_benchmarks.rs
+++ b/onchain/contracts/stello_pay_contract/benches/performance_benchmarks.rs
@@ -5,11 +5,17 @@ use soroban_sdk::{
     Address, Env, Vec,
 };
 
+use stello_pay_contract::storage::{AgreementStatus, DataKey};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
-use stello_pay_contract::storage::{DataKey, AgreementStatus};
 
 /// Create a baseline environment + deployed payroll contract for benchmarks.
-fn setup_env() -> (Env, Address, Address, Address, PayrollContractClient<'static>) {
+fn setup_env() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    PayrollContractClient<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -43,6 +49,42 @@ fn bench_create_payroll_agreement(c: &mut Criterion) {
             |(env, employer, client, token)| {
                 let grace: u64 = 7 * 24 * 60 * 60;
                 let _id = client.create_payroll_agreement(&employer, &token, &grace);
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("batch_3_agreements", |b| {
+        b.iter_batched(
+            || {
+                let (env, _owner, employer, _arbiter, client) = setup_env();
+                let t1 = env
+                    .register_stellar_asset_contract_v2(Address::generate(&env))
+                    .address();
+                let t2 = env
+                    .register_stellar_asset_contract_v2(Address::generate(&env))
+                    .address();
+                let t3 = env
+                    .register_stellar_asset_contract_v2(Address::generate(&env))
+                    .address();
+                (env, employer, client, t1, t2, t3)
+            },
+            |(env, employer, client, t1, t2, t3)| {
+                let mut items: soroban_sdk::Vec<stello_pay_contract::storage::PayrollCreateParams> =
+                    soroban_sdk::Vec::new(&env);
+                items.push_back(stello_pay_contract::storage::PayrollCreateParams {
+                    token: t1,
+                    grace_period_seconds: 3600,
+                });
+                items.push_back(stello_pay_contract::storage::PayrollCreateParams {
+                    token: t2,
+                    grace_period_seconds: 7200,
+                });
+                items.push_back(stello_pay_contract::storage::PayrollCreateParams {
+                    token: t3,
+                    grace_period_seconds: 0,
+                });
+                let _ = client.batch_create_payroll_agreements(&employer, &items);
             },
             BatchSize::SmallInput,
         )
@@ -105,7 +147,7 @@ fn bench_claim_time_based(c: &mut Criterion) {
                 env.ledger().with_mut(|li| {
                     li.timestamp += 86_400;
                 });
-                let _ = client.claim_time_based(&agreement_id);
+                client.claim_time_based(&agreement_id);
             },
             BatchSize::SmallInput,
         )
@@ -118,7 +160,7 @@ fn setup_funded_milestone(
     env: &Env,
     client: &PayrollContractClient<'static>,
     employer: &Address,
-) -> (Address, u128, Vec<u32>) {
+) -> (Address, u128, soroban_sdk::Vec<u32>) {
     let contributor = Address::generate(env);
 
     let token_admin = Address::generate(env);
@@ -143,7 +185,7 @@ fn setup_funded_milestone(
     }
 
     // Build ID list
-    let mut ids = Vec::new(env);
+    let mut ids: soroban_sdk::Vec<u32> = soroban_sdk::Vec::new(env);
     for i in 1..=count {
         ids.push_back(i);
     }
@@ -188,9 +230,10 @@ fn bench_batch_claim_milestones(c: &mut Criterion) {
                         claimed_periods: None,
                     };
                     // Bump storage to keep host work comparable.
-                    env.storage()
-                        .persistent()
-                        .set(&stello_pay_contract::storage::StorageKey::Agreement(agreement_id), &agreement);
+                    env.storage().persistent().set(
+                        &stello_pay_contract::storage::StorageKey::Agreement(agreement_id),
+                        &agreement,
+                    );
                 });
             },
             BatchSize::SmallInput,
@@ -209,4 +252,3 @@ criterion_group!(
         bench_batch_claim_milestones
 );
 criterion_main!(benches);
-

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -7,8 +7,9 @@ use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
 use stellar_contract_utils::upgradeable::UpgradeableInternal;
 use stellar_macros::Upgradeable;
 use storage::{
-    Agreement, BatchMilestoneResult, BatchPayrollResult, DisputeStatus, Milestone, PayrollError,
-    StorageKey,
+    Agreement, BatchEscrowCreateResult, BatchMilestoneResult, BatchPayrollCreateResult,
+    BatchPayrollResult, DisputeStatus, EscrowCreateParams, Milestone, PayrollCreateParams,
+    PayrollError, StorageKey,
 };
 
 /// Payroll Contract for managing payroll agreements with employee claiming functionality.
@@ -67,6 +68,25 @@ impl PayrollContract {
         payroll::create_payroll_agreement(&env, employer, token, grace_period_seconds)
     }
 
+    /// Creates multiple payroll agreements in a single transaction.
+    ///
+    /// # Arguments
+    /// * `employer` - Address of the employer creating the agreements
+    /// * `items` - Vector of payroll creation parameters
+    ///
+    /// # Returns
+    /// `Ok(BatchPayrollCreateResult)` on success, or `Err(PayrollError)` if inputs invalid
+    ///
+    /// # Events
+    /// Emits `agreement_created_event` per created agreement
+    pub fn batch_create_payroll_agreements(
+        env: Env,
+        employer: Address,
+        items: Vec<PayrollCreateParams>,
+    ) -> Result<BatchPayrollCreateResult, PayrollError> {
+        payroll::batch_create_payroll_agreements(&env, employer, items)
+    }
+
     /// Creates an escrow agreement for a single contributor.
     ///
     /// # Arguments
@@ -101,6 +121,25 @@ impl PayrollContract {
             period_seconds,
             num_periods,
         )
+    }
+
+    /// Creates multiple escrow agreements in a single transaction.
+    ///
+    /// # Arguments
+    /// * `employer` - Address of the employer
+    /// * `items` - Vector of escrow creation parameters
+    ///
+    /// # Returns
+    /// `Ok(BatchEscrowCreateResult)` on success, or `Err(PayrollError)` if inputs invalid
+    ///
+    /// # Events
+    /// Emits `agreement_created_event` and `employee_added_event` per created agreement
+    pub fn batch_create_escrow_agreements(
+        env: Env,
+        employer: Address,
+        items: Vec<EscrowCreateParams>,
+    ) -> Result<BatchEscrowCreateResult, PayrollError> {
+        payroll::batch_create_escrow_agreements(&env, employer, items)
     }
 
     /// Creates a milestone-based payment agreement.

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -12,9 +12,11 @@ use crate::events::{
     MilestoneClaimed, PaymentReceivedEvent, PaymentSentEvent, PayrollClaimedEvent,
 };
 use crate::storage::{
-    Agreement, AgreementMode, AgreementStatus, BatchMilestoneResult, BatchPayrollResult, DataKey,
-    DisputeStatus, EmployeeInfo, Milestone, MilestoneClaimResult, MilestoneKey, PaymentType,
-    PayrollClaimResult, PayrollError, StorageKey,
+    Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,
+    BatchPayrollCreateResult, BatchPayrollResult, DataKey, DisputeStatus, EmployeeInfo,
+    EscrowCreateParams, EscrowCreateResult, Milestone, MilestoneClaimResult, MilestoneKey,
+    PaymentType, PayrollClaimResult, PayrollCreateParams, PayrollCreateResult, PayrollError,
+    StorageKey,
 };
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
@@ -417,13 +419,14 @@ pub fn batch_claim_milestones(
         successful_claims += 1;
 
         // Event — identical to claim_milestone
+        #[allow(clippy::needless_borrow)]
         MilestoneClaimed {
             agreement_id,
             milestone_id,
             amount,
             to: contributor.clone(),
         }
-        .publish(env);
+        .publish(&env);
 
         results.push_back(MilestoneClaimResult {
             milestone_id,
@@ -442,13 +445,14 @@ pub fn batch_claim_milestones(
         );
     }
 
+    #[allow(clippy::needless_borrow)]
     BatchMilestoneClaimedEvent {
         agreement_id,
         total_claimed,
         successful_claims,
         failed_claims,
     }
-    .publish(env);
+    .publish(&env);
 
     BatchMilestoneResult {
         agreement_id,
@@ -538,7 +542,15 @@ pub fn create_payroll_agreement(
     grace_period_seconds: u64,
 ) -> u128 {
     employer.require_auth();
+    create_payroll_agreement_internal(env, employer, token, grace_period_seconds)
+}
 
+fn create_payroll_agreement_internal(
+    env: &Env,
+    employer: Address,
+    token: Address,
+    grace_period_seconds: u64,
+) -> u128 {
     let agreement_id = get_next_agreement_id(env);
 
     let agreement = Agreement {
@@ -565,13 +577,11 @@ pub fn create_payroll_agreement(
         .persistent()
         .set(&StorageKey::Agreement(agreement_id), &agreement);
 
-    // Initialize empty employee list
     let employees: Vec<EmployeeInfo> = Vec::new(env);
     env.storage()
         .persistent()
         .set(&StorageKey::AgreementEmployees(agreement_id), &employees);
 
-    // Track employer's agreements
     add_to_employer_agreements(env, &employer, agreement_id);
 
     emit_agreement_created(
@@ -584,6 +594,56 @@ pub fn create_payroll_agreement(
     );
 
     agreement_id
+}
+
+/// Creates multiple payroll agreements in a single transaction.
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `employer` - Address of the employer creating the agreements
+/// * `items` - Vector of payroll creation parameters
+///
+/// # Returns
+/// `Ok(BatchPayrollCreateResult)` — always succeeds at the batch level
+/// unless `items` is empty; inspect per-item results for failures.
+pub fn batch_create_payroll_agreements(
+    env: &Env,
+    employer: Address,
+    items: Vec<PayrollCreateParams>,
+) -> Result<BatchPayrollCreateResult, PayrollError> {
+    employer.require_auth();
+
+    if items.is_empty() {
+        return Err(PayrollError::InvalidData);
+    }
+
+    let mut agreement_ids: Vec<u128> = Vec::new(env);
+    let mut results: Vec<PayrollCreateResult> = Vec::new(env);
+    let mut total_created: u32 = 0;
+    let total_failed: u32 = 0;
+
+    for params in items.iter() {
+        let id = create_payroll_agreement_internal(
+            env,
+            employer.clone(),
+            params.token.clone(),
+            params.grace_period_seconds,
+        );
+        agreement_ids.push_back(id);
+        results.push_back(PayrollCreateResult {
+            agreement_id: Some(id),
+            success: true,
+            error_code: 0,
+        });
+        total_created += 1;
+    }
+
+    Ok(BatchPayrollCreateResult {
+        total_created,
+        total_failed,
+        agreement_ids,
+        results,
+    })
 }
 
 /// Creates an escrow agreement for a single contributor
@@ -612,8 +672,26 @@ pub fn create_escrow_agreement(
     num_periods: u32,
 ) -> Result<u128, PayrollError> {
     employer.require_auth();
+    create_escrow_agreement_internal(
+        env,
+        employer,
+        contributor,
+        token,
+        amount_per_period,
+        period_seconds,
+        num_periods,
+    )
+}
 
-    // Validate inputs
+fn create_escrow_agreement_internal(
+    env: &Env,
+    employer: Address,
+    contributor: Address,
+    token: Address,
+    amount_per_period: i128,
+    period_seconds: u64,
+    num_periods: u32,
+) -> Result<u128, PayrollError> {
     if amount_per_period <= 0 {
         return Err(PayrollError::ZeroAmountPerPeriod);
     }
@@ -683,6 +761,70 @@ pub fn create_escrow_agreement(
     );
 
     Ok(agreement_id)
+}
+
+/// Creates multiple escrow agreements in a single transaction.
+///
+/// # Arguments
+/// * `env` - Contract environment
+/// * `employer` - Address of the employer
+/// * `items` - Vector of escrow creation parameters
+///
+/// # Returns
+/// `Ok(BatchEscrowCreateResult)` — always succeeds at the batch level
+/// unless `items` is empty; inspect per-item `results` for failures.
+pub fn batch_create_escrow_agreements(
+    env: &Env,
+    employer: Address,
+    items: Vec<EscrowCreateParams>,
+) -> Result<BatchEscrowCreateResult, PayrollError> {
+    employer.require_auth();
+
+    if items.is_empty() {
+        return Err(PayrollError::InvalidData);
+    }
+
+    let mut agreement_ids: Vec<u128> = Vec::new(env);
+    let mut results: Vec<EscrowCreateResult> = Vec::new(env);
+    let mut total_created: u32 = 0;
+    let mut total_failed: u32 = 0;
+
+    for params in items.iter() {
+        match create_escrow_agreement_internal(
+            env,
+            employer.clone(),
+            params.contributor.clone(),
+            params.token.clone(),
+            params.amount_per_period,
+            params.period_seconds,
+            params.num_periods,
+        ) {
+            Ok(id) => {
+                agreement_ids.push_back(id);
+                results.push_back(EscrowCreateResult {
+                    agreement_id: Some(id),
+                    success: true,
+                    error_code: 0,
+                });
+                total_created += 1;
+            }
+            Err(err) => {
+                results.push_back(EscrowCreateResult {
+                    agreement_id: None,
+                    success: false,
+                    error_code: err as u32,
+                });
+                total_failed += 1;
+            }
+        }
+    }
+
+    Ok(BatchEscrowCreateResult {
+        total_created,
+        total_failed,
+        agreement_ids,
+        results,
+    })
 }
 
 /// Adds an employee to a payroll agreement
@@ -1260,6 +1402,7 @@ pub fn claim_payroll(
         },
     );
 
+    #[allow(clippy::needless_borrow)]
     PaymentSentEvent {
         agreement_id,
         from: contract_address,
@@ -1267,15 +1410,16 @@ pub fn claim_payroll(
         amount,
         token: token.clone(),
     }
-    .publish(env);
+    .publish(&env);
 
+    #[allow(clippy::needless_borrow)]
     PaymentReceivedEvent {
         agreement_id,
         to: employee,
         amount,
         token: token.clone(),
     }
-    .publish(env);
+    .publish(&env);
 
     Ok(())
 }
@@ -1449,6 +1593,7 @@ pub fn claim_payroll_in_token(
         },
     );
 
+    #[allow(clippy::needless_borrow)]
     PaymentSentEvent {
         agreement_id,
         from: contract_address,
@@ -1458,6 +1603,7 @@ pub fn claim_payroll_in_token(
     }
     .publish(&env);
 
+    #[allow(clippy::needless_borrow)]
     PaymentReceivedEvent {
         agreement_id,
         to: employee,
@@ -1713,6 +1859,7 @@ pub fn batch_claim_payroll(
                 amount,
             },
         );
+        #[allow(clippy::needless_borrow)]
         PaymentSentEvent {
             agreement_id,
             from: contract_address.clone(),
@@ -1720,14 +1867,15 @@ pub fn batch_claim_payroll(
             amount,
             token: token.clone(),
         }
-        .publish(env);
+        .publish(&env);
+        #[allow(clippy::needless_borrow)]
         PaymentReceivedEvent {
             agreement_id,
             to: employee.clone(),
             amount,
             token: token.clone(),
         }
-        .publish(env);
+        .publish(&env);
 
         results.push_back(PayrollClaimResult {
             employee_index,
@@ -1741,13 +1889,14 @@ pub fn batch_claim_payroll(
 
     DataKey::set_agreement_escrow_balance(env, agreement_id, &token, escrow_balance);
 
+    #[allow(clippy::needless_borrow)]
     BatchPayrollClaimedEvent {
         agreement_id,
         total_claimed,
         successful_claims,
         failed_claims,
     }
-    .publish(env);
+    .publish(&env);
 
     Ok(BatchPayrollResult {
         agreement_id,

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -214,6 +214,59 @@ pub struct BatchMilestoneResult {
     pub results: Vec<MilestoneClaimResult>,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PayrollCreateParams {
+    pub token: Address,
+    pub grace_period_seconds: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct EscrowCreateParams {
+    pub contributor: Address,
+    pub token: Address,
+    pub amount_per_period: i128,
+    pub period_seconds: u64,
+    pub num_periods: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PayrollCreateResult {
+    pub agreement_id: Option<u128>,
+    pub success: bool,
+    /// Mirrors PayrollError discriminant where applicable; 0 = success
+    pub error_code: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct EscrowCreateResult {
+    pub agreement_id: Option<u128>,
+    pub success: bool,
+    /// Mirrors PayrollError discriminant where applicable; 0 = success
+    pub error_code: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BatchPayrollCreateResult {
+    pub total_created: u32,
+    pub total_failed: u32,
+    pub agreement_ids: Vec<u128>,
+    pub results: Vec<PayrollCreateResult>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BatchEscrowCreateResult {
+    pub total_created: u32,
+    pub total_failed: u32,
+    pub agreement_ids: Vec<u128>,
+    pub results: Vec<EscrowCreateResult>,
+}
+
 /// Error types for payroll operations
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -246,6 +299,12 @@ pub enum PayrollError {
     NotGuardian = 25,
     TimelockActive = 26,
     InvalidTimelock = 27,
+    /// Missing or unconfigured FX rate for a currency pair
+    ExchangeRateNotFound = 28,
+    /// Arithmetic overflow/underflow during FX conversion
+    ExchangeRateOverflow = 29,
+    /// Invalid FX rate (e.g. non-positive)
+    ExchangeRateInvalid = 30,
 }
 
 /// Emergency pause state
@@ -256,12 +315,6 @@ pub struct EmergencyPause {
     pub paused_at: Option<u64>,
     pub paused_by: Option<Address>,
     pub timelock_end: Option<u64>,
-    /// Missing or unconfigured FX rate for a currency pair
-    ExchangeRateNotFound = 24,
-    /// Arithmetic overflow/underflow during FX conversion
-    ExchangeRateOverflow = 25,
-    /// Invalid FX rate (e.g. non-positive)
-    ExchangeRateInvalid = 26,
 }
 
 /// Storage keys for the payroll claiming system.

--- a/onchain/contracts/stello_pay_contract/tests/stress/test_stress.rs
+++ b/onchain/contracts/stello_pay_contract/tests/stress/test_stress.rs
@@ -35,7 +35,9 @@ fn create_test_env() -> (Env, Address, Address, PayrollContractClient<'static>) 
 
     let employer = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
 
     (env, employer, token, client)
 }
@@ -90,7 +92,12 @@ fn setup_funded_milestone(
     for _ in 0..milestone_count {
         client.add_milestone(&agreement_id, &amount);
     }
-    mint(env, token, &client.address, amount * (milestone_count as i128));
+    mint(
+        env,
+        token,
+        &client.address,
+        amount * (milestone_count as i128),
+    );
     agreement_id
 }
 
@@ -139,16 +146,8 @@ fn stress_max_values_and_overflow_boundaries() {
 fn stress_rapid_transactions_single_window() {
     let (env, employer, token, client) = create_test_env();
     let contributor = Address::generate(&env);
-    let agreement_id = setup_funded_escrow(
-        &env,
-        &client,
-        &employer,
-        &contributor,
-        &token,
-        1000,
-        1,
-        10,
-    );
+    let agreement_id =
+        setup_funded_escrow(&env, &client, &employer, &contributor, &token, 1000, 1, 10);
 
     env.ledger().with_mut(|li| li.timestamp += 1);
     client.claim_time_based(&agreement_id);
@@ -190,15 +189,8 @@ fn stress_rapid_transactions_single_window() {
 fn stress_network_congestion_mixed_batch() {
     let (env, employer, token, client) = create_test_env();
     let contributor = Address::generate(&env);
-    let agreement_id = setup_funded_milestone(
-        &env,
-        &client,
-        &employer,
-        &contributor,
-        &token,
-        100,
-        100,
-    );
+    let agreement_id =
+        setup_funded_milestone(&env, &client, &employer, &contributor, &token, 100, 100);
 
     for id in 1..=60u32 {
         client.approve_milestone(&agreement_id, &id);

--- a/onchain/contracts/stello_pay_contract/tests/test_batch_creation.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_batch_creation.rs
@@ -1,0 +1,161 @@
+#![cfg(test)]
+#![allow(deprecated)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, Symbol, TryFromVal, Vec,
+};
+use stello_pay_contract::storage::{EscrowCreateParams, PayrollCreateParams, PayrollError};
+use stello_pay_contract::{PayrollContract, PayrollContractClient};
+
+fn create_test_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn addr(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn setup(env: &Env) -> (Address, PayrollContractClient<'static>) {
+    #[allow(deprecated)]
+    let id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(env, &id);
+    let owner = addr(env);
+    client.initialize(&owner);
+    (id, client)
+}
+
+#[test]
+fn batch_create_payroll_success() {
+    let env = create_test_env();
+    let (_id, client) = setup(&env);
+
+    let employer = addr(&env);
+    let token1 = addr(&env);
+    let token2 = addr(&env);
+    let token3 = addr(&env);
+
+    let mut items = soroban_sdk::Vec::<PayrollCreateParams>::new(&env);
+    items.push_back(PayrollCreateParams {
+        token: token1,
+        grace_period_seconds: 3600,
+    });
+    items.push_back(PayrollCreateParams {
+        token: token2,
+        grace_period_seconds: 7200,
+    });
+    items.push_back(PayrollCreateParams {
+        token: token3,
+        grace_period_seconds: 0,
+    });
+
+    let res = client.batch_create_payroll_agreements(&employer, &items);
+    assert_eq!(res.total_created, 3);
+    assert_eq!(res.total_failed, 0);
+    assert_eq!(res.results.len(), 3);
+    assert_eq!(res.agreement_ids.len(), 3);
+
+    // Each created agreement should emit agreement_created_event
+    let created_events = env
+        .events()
+        .all()
+        .iter()
+        .filter(|e| {
+            if e.1.len() > 0 {
+                let topic = e.1.get(0).unwrap();
+                if let Ok(sym) = Symbol::try_from_val(&env, &topic) {
+                    return sym.to_string() == "agreement_created_event";
+                }
+            }
+            false
+        })
+        .count();
+    assert!(created_events >= 3);
+}
+
+#[test]
+fn batch_create_payroll_empty_err() {
+    let env = create_test_env();
+    let (_id, client) = setup(&env);
+
+    let employer = addr(&env);
+    let items = soroban_sdk::Vec::<PayrollCreateParams>::new(&env);
+    let result = client.try_batch_create_payroll_agreements(&employer, &items);
+    assert_eq!(result, Err(Ok(PayrollError::InvalidData)));
+}
+
+#[test]
+fn batch_create_escrow_partial_success() {
+    let env = create_test_env();
+    let (_id, client) = setup(&env);
+
+    let employer = addr(&env);
+    let contributor_ok = addr(&env);
+    let contributor_bad = addr(&env);
+    let token = addr(&env);
+
+    let mut items = soroban_sdk::Vec::<EscrowCreateParams>::new(&env);
+    // Valid
+    items.push_back(EscrowCreateParams {
+        contributor: contributor_ok,
+        token: token.clone(),
+        amount_per_period: 1000,
+        period_seconds: 3600,
+        num_periods: 4,
+    });
+    // Invalid: zero period
+    items.push_back(EscrowCreateParams {
+        contributor: contributor_bad,
+        token,
+        amount_per_period: 1000,
+        period_seconds: 0,
+        num_periods: 4,
+    });
+
+    let res = client.batch_create_escrow_agreements(&employer, &items);
+    assert_eq!(res.total_created, 1);
+    assert_eq!(res.total_failed, 1);
+    assert_eq!(res.results.len(), 2);
+
+    let failure = res
+        .results
+        .iter()
+        .find(|r| !r.success)
+        .expect("one failure expected");
+    assert_eq!(failure.error_code, PayrollError::ZeroPeriodDuration as u32);
+
+    // Verify events: one agreement_created + one employee_added for success
+    let created_events = env
+        .events()
+        .all()
+        .iter()
+        .filter(|e| {
+            if e.1.len() > 0 {
+                let topic = e.1.get(0).unwrap();
+                if let Ok(sym) = Symbol::try_from_val(&env, &topic) {
+                    return sym.to_string() == "agreement_created_event";
+                }
+            }
+            false
+        })
+        .count();
+    assert!(created_events >= 1);
+
+    let employee_added_events = env
+        .events()
+        .all()
+        .iter()
+        .filter(|e| {
+            if e.1.len() > 0 {
+                let topic = e.1.get(0).unwrap();
+                if let Ok(sym) = Symbol::try_from_val(&env, &topic) {
+                    return sym.to_string() == "employee_added_event";
+                }
+            }
+            false
+        })
+        .count();
+    assert!(employee_added_events >= 1);
+}

--- a/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
@@ -68,9 +68,7 @@ fn test_claim_payroll_in_different_token_uses_fx_rate() {
     // Token setup
     // ---------------------------------------------------------------------
     let base_admin = Address::generate(&env);
-    let base_token = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base_token = env.register_stellar_asset_contract_v2(base_admin).address();
 
     let payout_admin = Address::generate(&env);
     let payout_token = env
@@ -140,12 +138,10 @@ fn test_claim_payroll_in_different_token_uses_fx_rate() {
 
     // Escrow balance and paid amount are updated correctly.
     env.as_contract(&contract_address, || {
-        let remaining =
-            DataKey::get_agreement_escrow_balance(&env, agreement_id, &payout_token);
+        let remaining = DataKey::get_agreement_escrow_balance(&env, agreement_id, &payout_token);
         assert_eq!(remaining, escrow_total - expected_payout);
 
         let paid = DataKey::get_agreement_paid_amount(&env, agreement_id);
         assert_eq!(paid, salary_per_period);
     });
 }
-

--- a/onchain/contracts/stello_pay_contract/tests/test_overflow_protection.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_overflow_protection.rs
@@ -106,4 +106,3 @@ fn test_claim_payroll_paid_amount_addition_overflow_guard() {
     let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
     assert_eq!(result, Err(Ok(PayrollError::InvalidData)));
 }
-

--- a/onchain/contracts/stello_pay_contract/tests/test_payment_failures.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_payment_failures.rs
@@ -339,12 +339,7 @@ fn test_time_based_claim_escrow_drains_across_periods() {
     // Fund only enough for 1 period.
     mint(&env, &token, &client.address, amount_per_period);
     env.as_contract(&client.address, || {
-        DataKey::set_agreement_escrow_balance(
-            &env,
-            agreement_id,
-            &token,
-            amount_per_period,
-        );
+        DataKey::set_agreement_escrow_balance(&env, agreement_id, &token, amount_per_period);
     });
 
     client.activate_agreement(&agreement_id);
@@ -405,20 +400,12 @@ fn test_batch_payroll_partial_escrow_failure() {
     advance_time(&env, ONE_DAY + 1);
 
     // e1 claims successfully, draining the escrow.
-    let batch_e1 = client.batch_claim_payroll(
-        &e1,
-        &agreement_id,
-        &Vec::from_array(&env, [0u32]),
-    );
+    let batch_e1 = client.batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32]));
     assert_eq!(batch_e1.successful_claims, 1);
     assert_eq!(batch_e1.total_claimed, salary);
 
     // e2 attempts to claim — escrow is empty.
-    let batch_e2 = client.batch_claim_payroll(
-        &e2,
-        &agreement_id,
-        &Vec::from_array(&env, [1u32]),
-    );
+    let batch_e2 = client.batch_claim_payroll(&e2, &agreement_id, &Vec::from_array(&env, [1u32]));
     assert_eq!(batch_e2.successful_claims, 0);
     assert_eq!(batch_e2.failed_claims, 1);
 
@@ -488,12 +475,7 @@ fn test_time_based_claim_panics_without_onchain_tokens() {
 
     // Set DataKey escrow balance but do NOT mint tokens.
     env.as_contract(&client.address, || {
-        DataKey::set_agreement_escrow_balance(
-            &env,
-            agreement_id,
-            &token,
-            STANDARD_SALARY * 4,
-        );
+        DataKey::set_agreement_escrow_balance(&env, agreement_id, &token, STANDARD_SALARY * 4);
     });
 
     client.activate_agreement(&agreement_id);
@@ -534,7 +516,14 @@ fn test_pause_blocks_claim_resume_allows_claim() {
     client.pause_agreement(&agreement_id);
 
     let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
-    assert!(result.is_err() || result.as_ref().ok().and_then(|r| r.as_ref().err()).is_some());
+    assert!(
+        result.is_err()
+            || result
+                .as_ref()
+                .ok()
+                .and_then(|r| r.as_ref().err())
+                .is_some()
+    );
 
     // Resume — claim should succeed.
     client.resume_agreement(&agreement_id);
@@ -688,12 +677,7 @@ fn test_fund_and_retry_after_insufficient_balance() {
     // Top up escrow.
     mint(&env, &token, &contract_id, STANDARD_SALARY * 5);
     env.as_contract(&contract_id, || {
-        DataKey::set_agreement_escrow_balance(
-            &env,
-            agreement_id,
-            &token,
-            STANDARD_SALARY * 5,
-        );
+        DataKey::set_agreement_escrow_balance(&env, agreement_id, &token, STANDARD_SALARY * 5);
     });
 
     // Retry — should succeed.
@@ -944,7 +928,14 @@ fn test_claimed_periods_unchanged_after_failed_claim() {
 
     // Fail on second claim.
     let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
-    assert!(result.is_err() || result.as_ref().ok().and_then(|r| r.as_ref().err()).is_some());
+    assert!(
+        result.is_err()
+            || result
+                .as_ref()
+                .ok()
+                .and_then(|r| r.as_ref().err())
+                .is_some()
+    );
 
     // Claimed periods still 1.
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
@@ -1053,7 +1044,14 @@ fn test_payroll_claim_on_non_activated_agreement() {
     advance_time(&env, ONE_DAY + 1);
 
     let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
-    assert!(result.is_err() || result.as_ref().ok().and_then(|r| r.as_ref().err()).is_some());
+    assert!(
+        result.is_err()
+            || result
+                .as_ref()
+                .ok()
+                .and_then(|r| r.as_ref().err())
+                .is_some()
+    );
 }
 
 /// Time-based claim on a non-activated escrow agreement must fail.
@@ -1428,28 +1426,16 @@ fn test_batch_payroll_mixed_state_consistency() {
     // Claims for all three as e1 (only index 0 matches caller).
     // e1 succeeds on index 0, fails on 1 (Unauthorized), fails on 2 (Unauthorized).
     // So use e1 for index 0, then separately use e2 for index 1.
-    let batch_e1 = client.batch_claim_payroll(
-        &e1,
-        &agreement_id,
-        &Vec::from_array(&env, [0u32]),
-    );
+    let batch_e1 = client.batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32]));
     assert_eq!(batch_e1.successful_claims, 1);
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
 
-    let batch_e2 = client.batch_claim_payroll(
-        &e2,
-        &agreement_id,
-        &Vec::from_array(&env, [1u32]),
-    );
+    let batch_e2 = client.batch_claim_payroll(&e2, &agreement_id, &Vec::from_array(&env, [1u32]));
     assert_eq!(batch_e2.successful_claims, 1);
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &1u32), 1);
 
     // e3 tries to claim — insufficient escrow.
-    let batch_e3 = client.batch_claim_payroll(
-        &e3,
-        &agreement_id,
-        &Vec::from_array(&env, [2u32]),
-    );
+    let batch_e3 = client.batch_claim_payroll(&e3, &agreement_id, &Vec::from_array(&env, [2u32]));
     assert_eq!(batch_e3.successful_claims, 0);
     assert_eq!(batch_e3.failed_claims, 1);
 

--- a/onchain/contracts/stello_pay_contract/tests/test_state_machine.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_state_machine.rs
@@ -51,9 +51,7 @@ use soroban_sdk::{
     token::StellarAssetClient,
     Address, Env,
 };
-use stello_pay_contract::storage::{
-    AgreementStatus, DataKey, DisputeStatus, MilestoneKey,
-};
+use stello_pay_contract::storage::{AgreementStatus, DataKey, DisputeStatus, MilestoneKey};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
 // ============================================================================
@@ -243,14 +241,8 @@ fn test_escrow_created_to_active() {
     let contributor = create_address(&env);
     let token = create_address(&env);
 
-    let id = client.create_escrow_agreement(
-        &employer,
-        &contributor,
-        &token,
-        &SALARY,
-        &ONE_DAY,
-        &4u32,
-    );
+    let id =
+        client.create_escrow_agreement(&employer, &contributor, &token, &SALARY, &ONE_DAY, &4u32);
     assert_eq!(
         client.get_agreement(&id).unwrap().status,
         AgreementStatus::Created


### PR DESCRIPTION
# Description
Implements batch agreement creation for both payroll and escrow agreements, allowing multiple agreements to be created in a single transaction. This reduces repeated authorization overhead and client roundtrips while preserving the exact same per-agreement validation, state writes, and event emissions as the existing single-create functions.

Payroll batch creation uses eager semantics (all inputs are expected to succeed since payroll creation has no extra validation beyond auth). Escrow batch creation uses partial-success semantics — invalid entries are recorded with an error code and the batch continues, so callers can inspect per-item results without the entire transaction reverting.

# Related Issue
Fixes #290

## Checklist
- [x] I have tested the changes locally
- [x] I have added/updated documentation as needed
- [x] I have reviewed the code and ensured it follows the project guidelines
- [x] I have added necessary tests (unit/integration)
- [x] My changes generate no new warnings/errors
- [x] I have checked for code formatting issues

## Key Changes

**`src/storage.rs`**
Added six new `#[contracttype]` structs: `PayrollCreateParams`, `EscrowCreateParams`, `PayrollCreateResult`, `EscrowCreateResult`, `BatchPayrollCreateResult`, and `BatchEscrowCreateResult`. Also resolved a duplicate `PayrollError` variant issue (FX-rate errors were defined twice at conflicting discriminant values; consolidated to correct positions 28–30).

**`src/payroll.rs`**
Extracted `create_payroll_agreement_internal` and `create_escrow_agreement_internal` private helpers so both single and batch entry points share identical logic. Implemented `batch_create_payroll_agreements` and `batch_create_escrow_agreements`. Fixed `#[allow(clippy::needless_borrow)]` and `.publish(env)` → `.publish(&env)` across all existing event emit sites.

**`src/lib.rs`**
Exposed `batch_create_payroll_agreements` and `batch_create_escrow_agreements` as public contract entry points with full NatSpec-style doc comments.

**`tests/test_batch_creation.rs`** *(new)*
Three test cases:
- `batch_create_payroll_success` — 3 agreements created, verifies counts, IDs, and `agreement_created_event` emissions.
- `batch_create_payroll_empty_err` — empty input returns `PayrollError::InvalidData`.
- `batch_create_escrow_partial_success` — one valid + one zero-period-duration entry; verifies `total_created=1`, `total_failed=1`, correct `error_code`, and that `agreement_created_event` / `employee_added_event` are emitted only for the successful entry.

**`benches/performance_benchmarks.rs`**
Added `batch_3_agreements` benchmark alongside the existing single-create benchmark for direct gas/instruction comparison.

**`docs/batch-creation.md`** *(new)*
Covers interfaces, parameter types, return types, security assumptions, partial-success semantics, gas/UX rationale, and usage examples.

## Screenshots/Recordings
N/A — onchain contract changes. Test output:
```
running 3 tests
test batch_create_payroll_success ... ok
test batch_create_payroll_empty_err ... ok
test batch_create_escrow_partial_success ... ok

test result: ok. 3 passed; 0 failed
```

## Additional Notes
- Empty item lists return `PayrollError::InvalidData` for both batch functions rather than silently succeeding with zero agreements.
- Escrow partial-success means a batch with N items will always return a `results` vec of length N; callers should check `success` per entry rather than relying solely on `total_created`.
- The internal helper refactor has no observable behaviour change for existing single-create callers — `employer.require_auth()` remains at the public entry point only.
- The duplicate FX-rate error variant fix (`ExchangeRateNotFound/Overflow/Invalid` previously appeared inside the `EmergencyPause` struct body due to a merge conflict artifact) is a correctness fix bundled here since it blocked compilation.