### PR TITLE
feat(expenses): add receipt hashing replay protection + audit linkage

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -126,6 +126,28 @@ Since `actor.require_auth()` is enforced, a malicious contract cannot impersonat
 - **Forensics**:
   - Use `get_latest_logs` for dashboards and `get_logs` for paginated history views.
 
+### Expense Reimbursement Approval Linkage
+
+The `expense_reimbursement` contract can be configured with an `audit_logger` address using:
+
+```rust
+set_audit_logger(owner, audit_logger_address)
+```
+
+When configured, each successful `approve_expense` call appends:
+
+- `actor = approver`
+- `action = "expense_approved"`
+- `subject = Some(submitter)`
+- `amount = Some(approved_amount)`
+
+The returned `log_id` is persisted in the expense record (`audit_log_id`) and emitted in the approval event payload, providing a stable on-chain linkage between the financial state transition and append-only audit history.
+
+#### Privacy Considerations for Expense Flows
+
+- Approval logs should include only operational metadata (`actor`, action, `subject`, amount).
+- Receipt material is not logged in plaintext by `audit_logger`; expense flows store only a domain-separated SHA-256 receipt commitment.
+
 ---
 
 ### Testing

--- a/docs/expense-reimbursement.md
+++ b/docs/expense-reimbursement.md
@@ -6,10 +6,10 @@ The Expense Reimbursement Contract provides a secure, auditable system for manag
 
 ## Features
 
-- **Expense Submission**: Employees submit expenses with receipt documentation (via off-chain hashes).
+- **Expense Submission**: Employees submit expenses with receipt payloads that are hashed on-chain.
 - **Escrowing**: Payer (Employer) locks the funds into the contract, maintaining strict guarantees over balances prior to approval.
 - **Approval Workflow**: Designated approvers review and approve/reject expenses. Includes support for partial approvals.
-- **Receipt Verification**: Hash-based receipt tracking for audit trails. NatSpec compliant hashes.
+- **Receipt Verification**: Domain-separated SHA-256 receipt hashing with replay protection across all requests.
 - **Role-Based Access**: Owner manages approvers, approvers handle approvals. Self-approval is explicitly disabled.
 - **Status Tracking**: Complete lifecycle management (Pending → Approved/Rejected/Cancelled → Paid).
 - **Refund Guarantees**: Escrowed funds dynamically return to the originator on rejection, cancellation, or partial approval surpluses.
@@ -39,11 +39,35 @@ The Expense Reimbursement Contract provides a secure, auditable system for manag
 3. **Employer funds expense** via `fund_expense`. Tokens are transferred to the contract's escrow.
 4. **Approver reviews** and validates `SHA256(retrieved_document) == stored_hash`.
 5. **Approver triggers approval** using `approve_expense`. (Can approve partially). Status enters `Approved`.
-6. **Payment released** via `pay_expense`. Employee gets their portion, Employer is refunded any unapproved surplus automatically. Status enters `Paid`.
+6. **Optional audit linkage**: if `audit_logger` is configured, approval writes `append_log(actor=approver, action="expense_approved", subject=submitter, amount=approved_amount)` and stores returned `audit_log_id`.
+7. **Payment released** via `pay_expense`. Employee gets their portion, Employer is refunded any unapproved surplus automatically. Status enters `Paid`.
+
+## Receipt Hashing Scheme
+
+- Hash function: `SHA-256`
+- Domain separation prefix: `stello.expense.receipt.v1`
+- Preimage format: `domain || 0x00 || XDR(receipt_payload_string)`
+- Stored value: `receipt_hash: BytesN<32>` per expense
+- Replay protection: each `receipt_hash` is unique globally in contract storage (`ReceiptHash(hash) -> expense_id`)
+
+This prevents reimbursing the same receipt payload twice, even when submitted by different users or in separate requests.
+
+## Privacy and Security Notes
+
+- Only the 32-byte commitment is stored on-chain; raw receipts should remain in off-chain systems.
+- Use high-entropy receipt payloads (e.g., canonical document digest or immutable URI+digest tuple) to reduce metadata leakage.
+- Collision resistance relies on SHA-256 security; practical second-preimage and collision attacks are infeasible for this use case.
+- Empty payloads are rejected.
+
+## Payload Size and Cost Limits
+
+- `MAX_RECEIPT_PAYLOAD_BYTES = 4096`
+- Oversized payloads are rejected to cap hashing cost and avoid unbounded compute usage.
+- Very short payloads are valid but can increase accidental replay collisions; use canonical, sufficiently specific receipt content.
 
 ## Gas Optimization and Edge Cases
 
-- **Duplicates**: Overlapping IDs are sidestepped by incremental counters. Same claim hashes are allowed uniquely scoped by IDs.
+- **Receipt Replay**: Duplicate receipt payloads now fail fast with `Receipt already reimbursed`.
 - **Zero Values**: Validations assert all fund operations involve strictly positive integers.
 
 ## Usage Commands (Integration Examples)

--- a/onchain/contracts/expense_reimbursement/src/lib.rs
+++ b/onchain/contracts/expense_reimbursement/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, token, xdr::ToXdr, Address, Bytes, BytesN, Env,
+    IntoVal, String, Symbol, Val, Vec,
+};
 
 /// ExpenseReimbursementContract manages expense submissions with approval workflows
 /// and receipt verification with escrow capabilities for organizational expense management.
@@ -39,9 +42,10 @@ pub struct Expense {
     pub approved_amount: Option<i128>,
     pub payer: Option<Address>,
     pub status: ExpenseStatus,
-    /// NatSpec: `receipt_hash` is a deterministic commitment (e.g., SHA-256) of the 
+    /// NatSpec: `receipt_hash` is a deterministic commitment (e.g., SHA-256) of the
     /// receipt document, allowing off-chain auditing of original receipts corresponding to on-chain payouts.
-    pub receipt_hash: String,
+    pub receipt_hash: BytesN<32>,
+    pub audit_log_id: Option<u64>,
     pub description: String,
     pub submitted_at: u64,
 }
@@ -53,6 +57,8 @@ enum StorageKey {
     Owner,
     NextExpenseId,
     Expense(u128),
+    ReceiptHash(BytesN<32>),
+    AuditLogger,
     ApproverRole(Address),
 }
 
@@ -63,7 +69,7 @@ pub struct ExpenseSubmittedEvent {
     pub submitter: Address,
     pub approver: Address,
     pub amount: i128,
-    pub receipt_hash: String,
+    pub receipt_hash: BytesN<32>,
 }
 
 #[contracttype]
@@ -80,6 +86,8 @@ pub struct ExpenseApprovedEvent {
     pub expense_id: u128,
     pub approver: Address,
     pub approved_amount: i128,
+    pub receipt_hash: BytesN<32>,
+    pub audit_log_id: Option<u64>,
 }
 
 #[contracttype]
@@ -129,6 +137,46 @@ fn is_approver(env: &Env, addr: &Address) -> bool {
         .persistent()
         .get(&StorageKey::ApproverRole(addr.clone()))
         .unwrap_or(false)
+}
+
+const RECEIPT_HASH_DOMAIN: &[u8] = b"stello.expense.receipt.v1";
+const MAX_RECEIPT_PAYLOAD_BYTES: u32 = 4096;
+
+fn compute_receipt_hash(env: &Env, receipt_payload: &String) -> BytesN<32> {
+    let payload_len = receipt_payload.len();
+    assert!(payload_len > 0, "Receipt payload cannot be empty");
+    assert!(
+        payload_len <= MAX_RECEIPT_PAYLOAD_BYTES,
+        "Receipt payload too large"
+    );
+
+    let mut preimage = Bytes::new(env);
+    preimage.append(&Bytes::from_slice(env, RECEIPT_HASH_DOMAIN));
+    preimage.push_back(0u8);
+    preimage.append(&receipt_payload.clone().to_xdr(env));
+    env.crypto().sha256(&preimage).into()
+}
+
+fn append_approval_audit_log(
+    env: &Env,
+    approver: &Address,
+    subject: &Address,
+    approved_amount: i128,
+) -> Option<u64> {
+    let maybe_audit_logger: Option<Address> = env.storage().persistent().get(&StorageKey::AuditLogger);
+    maybe_audit_logger.map(|audit_logger| {
+        let mut args = Vec::<Val>::new(env);
+        args.push_back(approver.clone().into_val(env));
+        args.push_back(Symbol::new(env, "expense_approved").into_val(env));
+        args.push_back(Some(subject.clone()).into_val(env));
+        args.push_back(Some(approved_amount).into_val(env));
+
+        env.invoke_contract::<u64>(
+            &audit_logger,
+            &Symbol::new(env, "append_log"),
+            args,
+        )
+    })
 }
 
 #[contractimpl]
@@ -190,7 +238,7 @@ impl ExpenseReimbursementContract {
         approver: Address,
         token: Address,
         amount: i128,
-        receipt_hash: String,
+        receipt_payload: String,
         description: String,
     ) -> u128 {
         require_initialized(&env);
@@ -199,6 +247,14 @@ impl ExpenseReimbursementContract {
         assert!(amount > 0, "Amount must be positive");
         assert!(is_approver(&env, &approver), "Invalid approver");
         assert!(submitter != approver, "Approver cannot be submitter");
+
+        let receipt_hash = compute_receipt_hash(&env, &receipt_payload);
+        assert!(
+            !env.storage()
+                .persistent()
+                .has(&StorageKey::ReceiptHash(receipt_hash.clone())),
+            "Receipt already reimbursed"
+        );
 
         let expense_id: u128 = env
             .storage()
@@ -217,6 +273,7 @@ impl ExpenseReimbursementContract {
             payer: None,
             status: ExpenseStatus::Pending,
             receipt_hash: receipt_hash.clone(),
+            audit_log_id: None,
             description,
             submitted_at: env.ledger().timestamp(),
         };
@@ -224,6 +281,9 @@ impl ExpenseReimbursementContract {
         env.storage()
             .persistent()
             .set(&StorageKey::Expense(expense_id), &expense);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::ReceiptHash(receipt_hash.clone()), &expense_id);
         env.storage()
             .persistent()
             .set(&StorageKey::NextExpenseId, &(expense_id + 1));
@@ -302,6 +362,13 @@ impl ExpenseReimbursementContract {
 
         expense.approved_amount = Some(approved_amount);
         expense.status = ExpenseStatus::Approved;
+        let audit_log_id = append_approval_audit_log(
+            &env,
+            &approver,
+            &expense.submitter,
+            approved_amount,
+        );
+        expense.audit_log_id = audit_log_id;
         env.storage()
             .persistent()
             .set(&StorageKey::Expense(expense_id), &expense);
@@ -312,6 +379,8 @@ impl ExpenseReimbursementContract {
                 expense_id,
                 approver,
                 approved_amount,
+                receipt_hash: expense.receipt_hash,
+                audit_log_id,
             },
         );
     }
@@ -453,5 +522,20 @@ impl ExpenseReimbursementContract {
     pub fn is_approver(env: Env, address: Address) -> bool {
         require_initialized(&env);
         is_approver(&env, &address)
+    }
+
+    /// Configure the optional external audit logger contract for approval traceability.
+    pub fn set_audit_logger(env: Env, owner: Address, audit_logger: Address) {
+        require_initialized(&env);
+        require_owner(&env, &owner);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::AuditLogger, &audit_logger);
+    }
+
+    /// Return currently configured audit logger contract address.
+    pub fn get_audit_logger(env: Env) -> Option<Address> {
+        require_initialized(&env);
+        env.storage().persistent().get(&StorageKey::AuditLogger)
     }
 }

--- a/onchain/contracts/expense_reimbursement/tests/test_expense.rs
+++ b/onchain/contracts/expense_reimbursement/tests/test_expense.rs
@@ -4,7 +4,40 @@ use expense_reimbursement::{
     ExpenseReimbursementContract, ExpenseReimbursementContractClient, ExpenseStatus,
 };
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{token, Address, Env, String};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, token, Address, Env, String, Symbol,
+};
+
+#[contracttype]
+#[derive(Clone)]
+enum MockAuditStorageKey {
+    NextId,
+}
+
+#[contract]
+pub struct MockAuditLoggerContract;
+
+#[contractimpl]
+impl MockAuditLoggerContract {
+    pub fn append_log(
+        env: Env,
+        actor: Address,
+        _action: Symbol,
+        _subject: Option<Address>,
+        _amount: Option<i128>,
+    ) -> u64 {
+        actor.require_auth();
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&MockAuditStorageKey::NextId)
+            .unwrap_or(1u64);
+        env.storage()
+            .persistent()
+            .set(&MockAuditStorageKey::NextId, &(id + 1));
+        id
+    }
+}
 
 fn create_token<'a>(env: &Env, admin: &Address) -> token::Client<'a> {
     let token_address = env.register_stellar_asset_contract(admin.clone());
@@ -14,6 +47,10 @@ fn create_token<'a>(env: &Env, admin: &Address) -> token::Client<'a> {
 fn create_contract<'a>(env: &Env) -> ExpenseReimbursementContractClient<'a> {
     let contract_id = env.register_contract(None, ExpenseReimbursementContract);
     ExpenseReimbursementContractClient::new(env, &contract_id)
+}
+
+fn create_mock_audit_logger(env: &Env) -> Address {
+    env.register_contract(None, MockAuditLoggerContract)
 }
 
 #[test]
@@ -115,10 +152,137 @@ fn test_submit_expense() {
     assert_eq!(expense.amount, 500);
     assert_eq!(expense.escrow_amount, 0);
     assert_eq!(expense.status, ExpenseStatus::Pending);
-    assert_eq!(
-        expense.receipt_hash,
-        String::from_str(&env, "receipt_hash_123")
+    assert_eq!(expense.audit_log_id, None);
+}
+
+#[test]
+#[should_panic(expected = "Receipt payload cannot be empty")]
+fn test_submit_expense_empty_receipt_payload_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+
+    client.submit_expense(
+        &submitter,
+        &approver,
+        &token_client.address,
+        &500,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "Invalid"),
     );
+}
+
+#[test]
+#[should_panic(expected = "Receipt payload too large")]
+fn test_submit_expense_oversized_receipt_payload_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+
+    let oversized = "x".repeat(4097);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+
+    client.submit_expense(
+        &submitter,
+        &approver,
+        &token_client.address,
+        &500,
+        &String::from_str(&env, &oversized),
+        &String::from_str(&env, "Too big"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Receipt already reimbursed")]
+fn test_same_receipt_payload_rejected_on_second_submission() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter_a = Address::generate(&env);
+    let submitter_b = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+
+    let payload = String::from_str(&env, "same-receipt-payload");
+
+    client.submit_expense(
+        &submitter_a,
+        &approver,
+        &token_client.address,
+        &300,
+        &payload,
+        &String::from_str(&env, "Expense A"),
+    );
+
+    client.submit_expense(
+        &submitter_b,
+        &approver,
+        &token_client.address,
+        &300,
+        &payload,
+        &String::from_str(&env, "Expense B"),
+    );
+}
+
+#[test]
+fn test_different_receipt_payloads_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter_a = Address::generate(&env);
+    let submitter_b = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+
+    let id1 = client.submit_expense(
+        &submitter_a,
+        &approver,
+        &token_client.address,
+        &300,
+        &String::from_str(&env, "receipt-payload-1"),
+        &String::from_str(&env, "Expense 1"),
+    );
+
+    let id2 = client.submit_expense(
+        &submitter_b,
+        &approver,
+        &token_client.address,
+        &300,
+        &String::from_str(&env, "receipt-payload-2"),
+        &String::from_str(&env, "Expense 2"),
+    );
+
+    assert_eq!(id1, 0);
+    assert_eq!(id2, 1);
 }
 
 #[test]
@@ -278,6 +442,94 @@ fn test_approve_expense_partial() {
     let expense = client.get_expense(&expense_id).unwrap();
     assert_eq!(expense.status, ExpenseStatus::Approved);
     assert_eq!(expense.approved_amount, Some(300));
+}
+
+#[test]
+fn test_approve_expense_requires_designated_approver() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let unauthorized_approver = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+    client.add_approver(&unauthorized_approver);
+
+    let expense_id = client.submit_expense(
+        &submitter,
+        &approver,
+        &token_client.address,
+        &500,
+        &String::from_str(&env, "receipt_hash"),
+        &String::from_str(&env, "Travel"),
+    );
+
+    client.fund_expense(&payer, &expense_id, &500);
+
+    let result = client.try_approve_expense(&unauthorized_approver, &expense_id, &500);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_approval_links_to_audit_logger_when_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+    let audit_logger = create_mock_audit_logger(&env);
+
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+    client.set_audit_logger(&owner, &audit_logger);
+    assert_eq!(client.get_audit_logger(), Some(audit_logger));
+
+    let expense_id = client.submit_expense(
+        &submitter,
+        &approver,
+        &token_client.address,
+        &500,
+        &String::from_str(&env, "receipt_hash"),
+        &String::from_str(&env, "Travel"),
+    );
+
+    client.fund_expense(&payer, &expense_id, &500);
+    client.approve_expense(&approver, &expense_id, &500);
+
+    let expense = client.get_expense(&expense_id).unwrap();
+    assert_eq!(expense.audit_log_id, Some(1));
+}
+
+#[test]
+fn test_set_audit_logger_requires_owner_auth() {
+    let env = Env::default();
+
+    let owner = Address::generate(&env);
+    let non_owner = Address::generate(&env);
+    let audit_logger = create_mock_audit_logger(&env);
+    let client = create_contract(&env);
+
+    env.mock_all_auths();
+    client.initialize(&owner);
+
+    let result = client.try_set_audit_logger(&non_owner, &audit_logger);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -502,7 +754,7 @@ fn test_cancel_expense_refunds() {
 }
 
 #[test]
-fn test_multiple_expenses_and_duplicate_handling_implicitly_resolved_by_incrementing_ids() {
+fn test_multiple_expenses_with_unique_receipts_work_end_to_end() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -528,13 +780,12 @@ fn test_multiple_expenses_and_duplicate_handling_implicitly_resolved_by_incremen
         &String::from_str(&env, "receipt1"),
         &String::from_str(&env, "Expense 1"),
     );
-    // Duplicate submission should result in a different ID thus avoiding ID collisions
     let expense_id2 = client.submit_expense(
         &submitter1,
         &approver,
         &token_client.address,
         &300,
-        &String::from_str(&env, "receipt1"),
+        &String::from_str(&env, "receipt1b"),
         &String::from_str(&env, "Expense 1_duplicate"),
     );
     let expense_id3 = client.submit_expense(
@@ -555,7 +806,6 @@ fn test_multiple_expenses_and_duplicate_handling_implicitly_resolved_by_incremen
     let expense3 = client.get_expense(&expense_id3).unwrap();
 
     assert_eq!(expense1.amount, 300);
-    // Submitter duplicate works seamlessly
     assert_eq!(expense2.amount, 300);
     assert_eq!(expense3.amount, 700);
     assert_eq!(expense1.submitter, submitter1);


### PR DESCRIPTION
closes #405 
Title:
Add receipt replay protection and audit traceability for expense reimbursements

Description:
This change prevents the same receipt from being reimbursed more than once. It also connects approved reimbursements to audit log records so reviewers can trace each approval.

What was changed:
receipt handling now uses a SHA-256 hash with a domain prefix. The contract stores each receipt hash and rejects any duplicate with a clear error. The contract also validates receipt payload size and rejects empty or oversized payloads.

The expense data now stores a 32-byte receipt hash and an optional audit log id. The contract can be configured with an audit logger address. When an expense is approved, it writes an audit log entry and stores the returned log id in the expense record.

new tests were added for duplicate receipt rejection, different receipt acceptance, authorization boundaries, audit logger linkage, empty payload rejection, and oversized payload rejection.


The docs now explain the hashing scheme, replay protection behavior, privacy expectations, collision resistance assumptions, and payload size limits.

Test run:
Command used:
cd onchain
cargo test -p expense_reimbursement -- --nocapture

Result:
All tests passed.
25 passed, 0 failed.

Security notes:
Only a hash commitment is stored on chain, not full receipt content.
SHA-256 is used for collision resistance.
Domain separation reduces cross-context hash confusion.
Duplicate receipts are blocked at submission time.
Approval actions can be traced through stored audit log ids.