### PR TITLE
feat(splitter): formalize rounding+dust policy with exhaustive tests

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -94,3 +94,31 @@ Payroll claims (`claim_payroll`, `batch_claim_payroll`,
 `claim_payroll_in_token`) and pause/resume flows must preserve these invariants
 even in the presence of failures or partial successes.
 
+---
+
+### Payment Splitter Invariants
+
+For percentage-based payment splits:
+
+- **Positive input amounts only**
+  - `total_amount > 0`
+- **Share conservation**
+  - `sum(recipient_amounts) == total_amount`
+- **Valid percentage configuration**
+  - Every percentage share is `> 0`
+  - Total percentage shares sum to `10000`
+- **Deterministic dust handling**
+  - Each recipient first receives `floor((bps * total_amount) / 10000)`
+  - Remaining dust is distributed one unit at a time to the largest fractional remainders
+  - Exact remainder ties are broken by canonical recipient address order
+- **Order-independence for ties**
+  - Reordering the input recipients must not change the final allocation per address
+
+For fixed-amount payment splits:
+
+- **Positive input amounts only**
+  - `total_amount > 0`
+- **Exact-match requirement**
+  - `sum(fixed_amounts) == total_amount`
+- **No implicit absorber**
+  - No recipient receives a rounded or absorbed remainder

--- a/docs/payment-splitting.md
+++ b/docs/payment-splitting.md
@@ -1,13 +1,13 @@
 # Payment Splitting
 
-This document describes the hardened **Payment Splitter** contract, which allows splitting a single token payment across multiple recipients with high arithmetic precision and rounding discipline.
+This document describes the hardened **Payment Splitter** contract, which allows splitting a single token payment across multiple recipients with deterministic arithmetic and explicit dust handling.
 
 ## Overview
 
 The `payment_splitter` contract provides:
 
 - **Split definitions** – Multiple recipients with either percentage-based (basis points) or fixed-amount allocations.
-- **Rounding Discipline** – Implementation of the "remainder absorber" pattern to ensure zero dust loss.
+- **Rounding Discipline** – Percentage splits use a deterministic largest-remainder policy so dust is neither lost nor biased by caller-provided recipient ordering.
 - **Arithmetic Safety** – Checked math operations to prevent overflows and allocation underflows.
 - **Validation** – Strict checks for duplicate recipients, zero weights, and mutual exclusivity between split modes.
 
@@ -30,7 +30,10 @@ The `payment_splitter` contract provides:
 
 ### Computation and Validation
 - `compute_split(split_id, total_amount)` – Returns a list of `(recipient, amount)` for the given total.
-    - Uses the **Remainder Absorber** pattern: the final recipient receives the difference between `total_amount` and the sum of all previous slices. This ensures the total allocated always matches the input exactly.
+    - Rejects `total_amount <= 0`.
+    - For percentage splits, floors each exact share and then distributes any leftover dust to the recipients with the largest fractional remainders.
+    - Exact remainder ties are broken by canonical recipient address order, not input list order.
+    - For fixed splits, the call rejects totals that do not exactly match the sum of fixed shares.
 - `validate_split_for_amount(split_id, total_amount)` – Returns true if the split matches the intended amount.
     - For Fixed splits: `sum(fixed_amounts) == total_amount`.
     - For Percent splits: Always true (sum is validated at creation).
@@ -38,21 +41,37 @@ The `payment_splitter` contract provides:
 ## Implementation Details
 
 ### Rounding Discipline
-When calculating percentage-based splits, integer division typically loses "dust". The contract handles this by iterating through the recipients and tracking the `total_allocated`. The last recipient always receives `total_amount - total_allocated`, effectively absorbing any rounding remainder.
+When calculating percentage-based splits, integer division produces fractional dust. The contract applies the following deterministic policy:
+
+1. Compute each exact share as `(bps * total_amount) / 10000`.
+2. Allocate the floored integer portion to every recipient.
+3. Compute `dust = total_amount - sum(floored_shares)`.
+4. Give one extra unit to the `dust` recipients with the largest fractional remainders.
+5. If multiple recipients have the same fractional remainder, break the tie by canonical address order.
+
+This guarantees:
+
+- `sum(outputs) == total_amount` for every successful split.
+- No value is lost to truncation.
+- Caller-supplied recipient ordering cannot bias dust allocation.
 
 ### Example: Prime Number Split
 If splitting **107 units** between 2 recipients with a **60%/40%** ratio:
-1. Recipient A (60%): `(6000 * 107) / 10000 = 64.2` → **64**
-2. Recipient B (40% - Absorber): `107 - 64` → **43**
+1. Recipient A (60%): exact `64.2`, floor `64`, remainder `0.2`
+2. Recipient B (40%): exact `42.8`, floor `42`, remainder `0.8`
+3. Dust = `107 - (64 + 42) = 1`, so Recipient B receives the extra unit
 **Total: 107**
 
 ### Example: 1-Stroop Split
 If splitting **1 stroop** 50/50:
-1. Recipient A (50%): `(5000 * 1) / 10000 = 0.5` → **0**
-2. Recipient B (50% - Absorber): `1 - 0` → **1**
+1. Both recipients have an exact share of `0.5`, so both floor to `0`
+2. Dust = `1`
+3. Because the remainders are tied, the extra unit goes to the recipient with the lower canonical address encoding
 **Total: 1**
 
 ## Security Considerations
 - **Non-zero Weights**: The contract prevents creating splits with zero-weight percentages or zero-amount fixed shares.
 - **Duplicate Prevention**: Prevents unintentional double-allocation to the same address within one split.
+- **Ordering Resistance**: Dust assignment depends on remainders and canonical address order, not the caller-provided recipient list order.
+- **Fixed Split Integrity**: Fixed splits reject mismatched totals instead of silently shifting the difference onto the final recipient.
 - **Off-chain Integration**: This contract does not handle token movements directly. It provides the logic for other contracts or off-chain systems to perform safe token transfers.

--- a/onchain/contracts/payment_splitter/src/lib.rs
+++ b/onchain/contracts/payment_splitter/src/lib.rs
@@ -6,11 +6,11 @@
 //! percentage-based (basis points) or fixed-amount splits.
 //!
 //! Hardened with:
-//! - Rounding discipline (remainder absorber pattern)
+//! - Deterministic rounding discipline (largest-remainder dust distribution)
 //! - Arithmetic safety (checked operations)
 //! - Validation helpers (duplicate recipient checks, zero-weight prevention)
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, Env, Vec};
 
 #[contract]
 pub struct PaymentSplitterContract;
@@ -151,6 +151,8 @@ impl PaymentSplitterContract {
     /// For Percent splits: always true if sum is 100% (already checked at creation).
     /// For Fixed splits: sum of fixed amounts must equal total_amount.
     pub fn validate_split_for_amount(env: Env, split_id: u128, total_amount: i128) -> bool {
+        assert!(total_amount > 0, "Total amount must be > 0");
+
         let def: SplitDefinition = env
             .storage()
             .persistent()
@@ -172,46 +174,87 @@ impl PaymentSplitterContract {
     }
 
     /// Computes the amount for each recipient given a total amount.
-    /// Uses a "remainder absorber" approach to handle rounding errors.
+    ///
+    /// Percent splits use largest-remainder apportionment:
+    /// 1. Floor each exact percentage slice.
+    /// 2. Distribute the remaining dust one unit at a time to the recipients
+    ///    with the largest fractional remainder.
+    /// 3. Break exact remainder ties using canonical recipient address order.
     ///
     /// # Returns
     /// `Vec<(Address, i128)>` where each tuple is a recipient and their share.
     pub fn compute_split(env: Env, split_id: u128, total_amount: i128) -> Vec<(Address, i128)> {
+        assert!(total_amount > 0, "Total amount must be > 0");
+
         let def: SplitDefinition = env
             .storage()
             .persistent()
             .get(&StorageKey::Split(split_id))
             .expect("Split not found");
 
+        if !def.is_percent {
+            assert!(
+                Self::validate_split_for_amount(env.clone(), split_id, total_amount),
+                "Fixed split total must equal sum of fixed amounts"
+            );
+        }
+
         let mut out: Vec<(Address, i128)> = Vec::new(&env);
-        let mut total_allocated: i128 = 0;
         let recipient_count = def.recipients.len();
 
-        for i in 0..recipient_count {
-            let r = def.recipients.get_unchecked(i);
-            
-            let amt = if i == recipient_count - 1 {
-                // Remainder absorber: last recipient gets the rest of the bucket
-                total_amount.checked_sub(total_allocated).expect("Allocation underflow")
-            } else {
-                let slice = match r.kind {
-                    ShareKind::Percent(bps) => {
-                        // (bps * total_amount) / 10000
-                        let bps_u128 = i128::from(bps);
-                        bps_u128.checked_mul(total_amount)
-                            .expect("Mul overflow")
-                            .checked_div(10000)
-                            .expect("Div error")
-                    }
-                    ShareKind::Fixed(a) => a,
-                };
-                total_allocated = total_allocated.checked_add(slice).expect("Total allocated overflow");
-                slice
-            };
+        if def.is_percent {
+            let mut floored_amounts = Vec::<i128>::new(&env);
+            let mut remainders = Vec::<i128>::new(&env);
+            let mut awarded_dust = Vec::<u32>::new(&env);
+            let mut total_allocated: i128 = 0;
 
-            // Sanity check: ensure no negative allocations for the absorber
-            assert!(amt >= 0, "Negative allocation detected (check fixed sums)");
-            out.push_back((r.recipient.clone(), amt));
+            for i in 0..recipient_count {
+                let r = def.recipients.get_unchecked(i);
+                let bps = match r.kind {
+                    ShareKind::Percent(bps) => bps,
+                    ShareKind::Fixed(_) => unreachable!(),
+                };
+
+                let exact_numerator = i128::from(bps)
+                    .checked_mul(total_amount)
+                    .expect("Mul overflow");
+                let floored = exact_numerator.checked_div(10000).expect("Div error");
+                let remainder = exact_numerator.checked_rem(10000).expect("Rem error");
+
+                floored_amounts.push_back(floored);
+                remainders.push_back(remainder);
+                total_allocated = total_allocated
+                    .checked_add(floored)
+                    .expect("Total allocated overflow");
+            }
+
+            let dust = total_amount
+                .checked_sub(total_allocated)
+                .expect("Dust underflow");
+            assert!(dust >= 0, "Negative dust detected");
+
+            for _ in 0..dust {
+                let best = Self::select_next_dust_recipient(&env, &def.recipients, &remainders, &awarded_dust);
+                awarded_dust.push_back(best);
+            }
+
+            for i in 0..recipient_count {
+                let r = def.recipients.get_unchecked(i);
+                let mut amount = floored_amounts.get_unchecked(i);
+                if Self::contains_index(&awarded_dust, i) {
+                    amount = amount.checked_add(1).expect("Dust allocation overflow");
+                }
+                out.push_back((r.recipient.clone(), amount));
+            }
+        } else {
+            for i in 0..recipient_count {
+                let r = def.recipients.get_unchecked(i);
+                let amount = match r.kind {
+                    ShareKind::Fixed(amount) => amount,
+                    ShareKind::Percent(_) => unreachable!(),
+                };
+                out.push_back((r.recipient.clone(), amount));
+            }
         }
         out
     }
@@ -231,5 +274,74 @@ impl PaymentSplitterContract {
             .get(&StorageKey::Initialized)
             .unwrap_or(false);
         assert!(init, "Contract not initialized");
+    }
+
+    fn select_next_dust_recipient(
+        env: &Env,
+        recipients: &Vec<RecipientShare>,
+        remainders: &Vec<i128>,
+        awarded_dust: &Vec<u32>,
+    ) -> u32 {
+        let mut best_index = 0u32;
+        let mut best_remainder = -1i128;
+
+        for i in 0..recipients.len() {
+            if Self::contains_index(awarded_dust, i) {
+                continue;
+            }
+
+            let remainder = remainders.get_unchecked(i);
+            if remainder > best_remainder {
+                best_index = i;
+                best_remainder = remainder;
+                continue;
+            }
+
+            if remainder == best_remainder
+                && Self::compare_addresses(env, &recipients.get_unchecked(i).recipient, &recipients.get_unchecked(best_index).recipient) < 0
+            {
+                best_index = i;
+            }
+        }
+
+        best_index
+    }
+
+    fn contains_index(indexes: &Vec<u32>, needle: u32) -> bool {
+        for i in 0..indexes.len() {
+            if indexes.get_unchecked(i) == needle {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn compare_addresses(env: &Env, left: &Address, right: &Address) -> i32 {
+        let left_xdr: Bytes = left.clone().to_xdr(env);
+        let right_xdr: Bytes = right.clone().to_xdr(env);
+        let min_len = if left_xdr.len() < right_xdr.len() {
+            left_xdr.len()
+        } else {
+            right_xdr.len()
+        };
+
+        for i in 0..min_len {
+            let left_byte = left_xdr.get_unchecked(i);
+            let right_byte = right_xdr.get_unchecked(i);
+            if left_byte < right_byte {
+                return -1;
+            }
+            if left_byte > right_byte {
+                return 1;
+            }
+        }
+
+        if left_xdr.len() < right_xdr.len() {
+            -1
+        } else if left_xdr.len() > right_xdr.len() {
+            1
+        } else {
+            0
+        }
     }
 }

--- a/onchain/contracts/payment_splitter/tests/test_splitter.rs
+++ b/onchain/contracts/payment_splitter/tests/test_splitter.rs
@@ -4,7 +4,7 @@
 use payment_splitter::{
     PaymentSplitterContract, PaymentSplitterContractClient, RecipientShare, ShareKind,
 };
-use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+use soroban_sdk::{testutils::Address as _, xdr::ToXdr, Address, Bytes, Env, Vec};
 
 fn create_env() -> Env {
     let env = Env::default();
@@ -18,6 +18,35 @@ fn setup(env: &Env) -> (Address, PaymentSplitterContractClient<'_>) {
     let admin = Address::generate(env);
     client.initialize(&admin);
     (contract_id, client)
+}
+
+fn compare_addresses(env: &Env, left: &Address, right: &Address) -> i32 {
+    let left_xdr: Bytes = left.clone().to_xdr(env);
+    let right_xdr: Bytes = right.clone().to_xdr(env);
+    let min_len = if left_xdr.len() < right_xdr.len() {
+        left_xdr.len()
+    } else {
+        right_xdr.len()
+    };
+
+    for i in 0..min_len {
+        let left_byte = left_xdr.get_unchecked(i);
+        let right_byte = right_xdr.get_unchecked(i);
+        if left_byte < right_byte {
+            return -1;
+        }
+        if left_byte > right_byte {
+            return 1;
+        }
+    }
+
+    if left_xdr.len() < right_xdr.len() {
+        -1
+    } else if left_xdr.len() > right_xdr.len() {
+        1
+    } else {
+        0
+    }
 }
 
 #[test]
@@ -176,13 +205,20 @@ fn test_compute_split_one_stroop() {
     recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(5000) });
     
     let id = client.create_split(&creator, &recipients);
-    
-    // Total = 1
-    // A: (5000 * 1) / 10000 = 0
-    // B: 1 - 0 = 1
     let out = client.compute_split(&id, &1);
-    assert_eq!(out.get(0).unwrap().1, 0);
-    assert_eq!(out.get(1).unwrap().1, 1);
+
+    let a_amount = out.get(0).unwrap().1;
+    let b_amount = out.get(1).unwrap().1;
+    let a_wins_tie = compare_addresses(&env, &out.get(0).unwrap().0, &out.get(1).unwrap().0) < 0;
+
+    assert_eq!(a_amount + b_amount, 1);
+    if a_wins_tie {
+        assert_eq!(a_amount, 1);
+        assert_eq!(b_amount, 0);
+    } else {
+        assert_eq!(a_amount, 0);
+        assert_eq!(b_amount, 1);
+    }
 }
 
 #[test]
@@ -205,6 +241,156 @@ fn test_fixed_split_validation() {
     let out = client.compute_split(&id, &1000);
     assert_eq!(out.get(0).unwrap().1, 300);
     assert_eq!(out.get(1).unwrap().1, 700);
+}
+
+#[test]
+#[should_panic(expected = "Total amount must be > 0")]
+fn test_compute_split_zero_amount_rejected() {
+    let env = create_env();
+    let (_, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(5000) });
+    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(5000) });
+
+    let id = client.create_split(&creator, &recipients);
+    client.compute_split(&id, &0);
+}
+
+#[test]
+#[should_panic(expected = "Total amount must be > 0")]
+fn test_compute_split_negative_amount_rejected() {
+    let env = create_env();
+    let (_, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(5000) });
+    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(5000) });
+
+    let id = client.create_split(&creator, &recipients);
+    client.compute_split(&id, &-1);
+}
+
+#[test]
+#[should_panic(expected = "Fixed split total must equal sum of fixed amounts")]
+fn test_fixed_split_mismatched_total_rejected() {
+    let env = create_env();
+    let (_, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Fixed(300) });
+    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Fixed(700) });
+
+    let id = client.create_split(&creator, &recipients);
+    client.compute_split(&id, &999);
+}
+
+#[test]
+fn test_dust_tie_breaker_ignores_input_order() {
+    let env = create_env();
+    let (_, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let mut first_order = Vec::new(&env);
+    first_order.push_back(RecipientShare { recipient: a.clone(), kind: ShareKind::Percent(5000) });
+    first_order.push_back(RecipientShare { recipient: b.clone(), kind: ShareKind::Percent(5000) });
+
+    let mut reversed_order = Vec::new(&env);
+    reversed_order.push_back(RecipientShare { recipient: b.clone(), kind: ShareKind::Percent(5000) });
+    reversed_order.push_back(RecipientShare { recipient: a.clone(), kind: ShareKind::Percent(5000) });
+
+    let first_id = client.create_split(&creator, &first_order);
+    let second_id = client.create_split(&creator, &reversed_order);
+
+    let first_out = client.compute_split(&first_id, &1);
+    let second_out = client.compute_split(&second_id, &1);
+
+    let first_a = if first_out.get(0).unwrap().0 == a {
+        first_out.get(0).unwrap().1
+    } else {
+        first_out.get(1).unwrap().1
+    };
+    let second_a = if second_out.get(0).unwrap().0 == a {
+        second_out.get(0).unwrap().1
+    } else {
+        second_out.get(1).unwrap().1
+    };
+
+    assert_eq!(first_a, second_a);
+    assert_eq!(first_out.get(0).unwrap().1 + first_out.get(1).unwrap().1, 1);
+    assert_eq!(second_out.get(0).unwrap().1 + second_out.get(1).unwrap().1, 1);
+}
+
+#[test]
+fn test_repeated_percent_splits_do_not_lose_or_create_value() {
+    let env = create_env();
+    let (_, client) = setup(&env);
+    let creator = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    let mut recipients = Vec::new(&env);
+    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(3333) });
+    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(3333) });
+    recipients.push_back(RecipientShare { recipient: c, kind: ShareKind::Percent(3334) });
+
+    let id = client.create_split(&creator, &recipients);
+
+    let mut total_input = 0i128;
+    let mut total_output = 0i128;
+    for amount in 1..=257i128 {
+        let out = client.compute_split(&id, &amount);
+        let split_sum = out.iter().map(|entry| entry.1).sum::<i128>();
+        assert_eq!(split_sum, amount);
+        total_input += amount;
+        total_output += split_sum;
+    }
+
+    assert_eq!(total_output, total_input);
+}
+
+#[test]
+fn test_compute_split_extreme_recipient_count() {
+    let env = create_env();
+    let (_, client) = setup(&env);
+    let creator = Address::generate(&env);
+
+    let mut recipients = Vec::new(&env);
+    for _ in 0..100u32 {
+        recipients.push_back(RecipientShare {
+            recipient: Address::generate(&env),
+            kind: ShareKind::Percent(100),
+        });
+    }
+
+    let id = client.create_split(&creator, &recipients);
+    let out = client.compute_split(&id, &12_345);
+
+    let mut recipients_with_extra_unit = 0u32;
+    let mut total = 0i128;
+    for entry in out.iter() {
+        assert!(entry.1 == 123 || entry.1 == 124);
+        if entry.1 == 124 {
+            recipients_with_extra_unit += 1;
+        }
+        total += entry.1;
+    }
+
+    assert_eq!(out.len(), 100);
+    assert_eq!(recipients_with_extra_unit, 45);
+    assert_eq!(total, 12_345);
 }
 
 #[test]


### PR DESCRIPTION
# Description
Formalizes deterministic rounding and dust handling in `payment_splitter` so percentage splits always preserve the original total without caller-controlled rounding bias. This PR replaces the old last-recipient remainder absorption with a largest-remainder policy using canonical address tie-breaking, rejects invalid fixed split totals, adds coverage for dust/no-drift/edge cases, and updates the related docs and invariants.

# Related Issue

- Close #411

## Checklist
- [x] I have tested the changes locally
- [x] I have added/updated documentation as needed
- [x] I have reviewed the code and ensured it follows the project guidelines
- [x] I have added necessary tests (unit/integration)
- [x] My changes generate no new warnings/errors
- [ ] I have checked for code formatting issues

## Screenshots/Recordings

<img width="980" height="669" alt="Screenshot From 2026-04-23 07-08-20" src="https://github.com/user-attachments/assets/b75f048c-0bc9-4901-a2c8-d39bf38a2894" />


## Additional Notes
Local validation run:
`cd onchain && cargo test -p payment_splitter -- --nocapture`

The test suite passed with `15 passed; 0 failed`. There is still one existing deprecation warning in the test harness from `Env::register_contract`.