### PR TITLE
feat(badge): add revocation/expiry and enforce metadata immutability …

### DIFF
--- a/onchain/contracts/nft_payroll_badge/src/lib.rs
+++ b/onchain/contracts/nft_payroll_badge/src/lib.rs
@@ -15,6 +15,10 @@ pub enum BadgeError {
     BadgeNotFound = 5,
     TransferNotAllowed = 6,
     MetadataTooLong = 7,
+    BadgeRevoked = 8,
+    BadgeExpired = 9,
+    MetadataFrozen = 10,
+    AlreadyRevoked = 11,
 }
 
 /// Types of payroll badges issued by the contract.
@@ -27,6 +31,15 @@ pub enum BadgeKind {
     Employee,
     /// Custom badge for integrations or UI labels.
     Custom(u32),
+}
+
+/// Lifecycle states for a badge.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BadgeState {
+    Active,
+    Revoked,
+    Expired,
 }
 
 /// Events emitted by the NFT payroll badge contract.
@@ -54,6 +67,30 @@ pub struct BadgeTransferred {
     pub to: Address,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BadgeMetadataUpdated {
+    pub id: u128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BadgeMetadataFrozen {
+    pub id: u128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BadgeRevokedEvent {
+    pub id: u128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BadgeExpiredEvent {
+    pub id: u128,
+}
+
 /// Represents a single NFT-style payroll badge.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -67,6 +104,12 @@ pub struct Badge {
     /// Whether this badge can be transferred by the holder.
     pub transferable: bool,
     pub created_at: u64,
+    /// Timestamp when the badge organically expires. 0 means never.
+    pub expires_at: u64,
+    /// Whether the badge has been permanently revoked.
+    pub revoked: bool,
+    /// Whether the metadata is permanently locked from updates.
+    pub metadata_frozen: bool,
 }
 
 /// Storage keys for the badge contract.
@@ -217,6 +260,7 @@ impl NftPayrollBadge {
     /// @param kind Badge kind (Employer, Employee, or Custom).
     /// @param metadata Arbitrary metadata bytes (e.g. URI, IPFS hash).
     /// @param transferable Whether the badge may be transferred by the holder.
+    /// @param expires_at Timestamp when the badge expires (0 for never).
     /// @return badge_id Newly minted badge identifier.
     pub fn mint(
         env: Env,
@@ -225,6 +269,7 @@ impl NftPayrollBadge {
         kind: BadgeKind,
         metadata: Bytes,
         transferable: bool,
+        expires_at: u64,
     ) -> Result<u128, BadgeError> {
         require_initialized(&env)?;
         require_admin(&env, &caller)?;
@@ -241,6 +286,9 @@ impl NftPayrollBadge {
             metadata,
             transferable,
             created_at: env.ledger().timestamp(),
+            expires_at,
+            revoked: false,
+            metadata_frozen: false,
         };
 
         write_badge(&env, &badge);
@@ -255,6 +303,88 @@ impl NftPayrollBadge {
         .publish(&env);
 
         Ok(id)
+    }
+
+    /// @notice Updates the metadata of an existing badge if it hasn't been frozen.
+    pub fn update_metadata(
+        env: Env,
+        caller: Address,
+        badge_id: u128,
+        metadata: Bytes,
+    ) -> Result<(), BadgeError> {
+        require_initialized(&env)?;
+        require_admin(&env, &caller)?;
+
+        let mut badge = read_badge(&env, badge_id)?;
+        if badge.metadata_frozen {
+            return Err(BadgeError::MetadataFrozen);
+        }
+        if metadata.len() > 1024 {
+            return Err(BadgeError::MetadataTooLong);
+        }
+
+        badge.metadata = metadata;
+        write_badge(&env, &badge);
+
+        BadgeMetadataUpdated { id: badge_id }.publish(&env);
+
+        Ok(())
+    }
+
+    /// @notice Permanently freezes the metadata of a given badge.
+    pub fn freeze_metadata(env: Env, caller: Address, badge_id: u128) -> Result<(), BadgeError> {
+        require_initialized(&env)?;
+        require_admin(&env, &caller)?;
+
+        let mut badge = read_badge(&env, badge_id)?;
+        if badge.metadata_frozen {
+            return Err(BadgeError::MetadataFrozen);
+        }
+
+        badge.metadata_frozen = true;
+        write_badge(&env, &badge);
+
+        BadgeMetadataFrozen { id: badge_id }.publish(&env);
+
+        Ok(())
+    }
+
+    /// @notice Revokes a badge permanently (e.g. employee termination).
+    pub fn revoke(env: Env, caller: Address, badge_id: u128) -> Result<(), BadgeError> {
+        require_initialized(&env)?;
+        require_admin(&env, &caller)?;
+
+        let mut badge = read_badge(&env, badge_id)?;
+        if badge.revoked {
+            return Err(BadgeError::AlreadyRevoked);
+        }
+
+        badge.revoked = true;
+        write_badge(&env, &badge);
+
+        BadgeRevokedEvent { id: badge_id }.publish(&env);
+
+        Ok(())
+    }
+
+    /// @notice Manually marks a badge as expired right now.
+    pub fn expire(env: Env, caller: Address, badge_id: u128) -> Result<(), BadgeError> {
+        require_initialized(&env)?;
+        require_admin(&env, &caller)?;
+
+        let mut badge = read_badge(&env, badge_id)?;
+        let current_time = env.ledger().timestamp();
+        
+        if badge.expires_at != 0 && current_time >= badge.expires_at {
+            return Err(BadgeError::BadgeExpired);
+        }
+
+        badge.expires_at = current_time;
+        write_badge(&env, &badge);
+
+        BadgeExpiredEvent { id: badge_id }.publish(&env);
+
+        Ok(())
     }
 
     /// @notice Burns an existing badge, removing it from circulation.
@@ -286,7 +416,7 @@ impl NftPayrollBadge {
     }
 
     /// @notice Transfers a badge to a new owner if it is marked transferable.
-    /// @dev Caller must be current owner; non-transferable badges cannot be moved.
+    /// @dev Caller must be current owner; non-transferable or inactive badges cannot be moved.
     /// @param caller Current owner; must authenticate.
     /// @param badge_id Identifier of the badge to transfer.
     /// @param to New owner address.
@@ -309,6 +439,14 @@ impl NftPayrollBadge {
             return Err(BadgeError::NotOwnerOrAdmin);
         }
 
+        // Check lifecycle state before allowing transfer
+        if badge.revoked {
+            return Err(BadgeError::BadgeRevoked);
+        }
+        if badge.expires_at != 0 && env.ledger().timestamp() >= badge.expires_at {
+            return Err(BadgeError::BadgeExpired);
+        }
+
         // Remove from current owner and add to new owner.
         remove_badge(&env, badge_id);
         badge.owner = to.clone();
@@ -327,14 +465,24 @@ impl NftPayrollBadge {
 
     /// @notice Returns the badge data for a given id.
     /// @param badge_id badge_id parameter
-    /// @dev Requires caller authentication
     pub fn get_badge(env: Env, badge_id: u128) -> Option<Badge> {
         env.storage().persistent().get(&StorageKey::Badge(badge_id))
     }
 
+    /// @notice Computes the current lifecycle state of a badge.
+    pub fn get_state(env: Env, badge_id: u128) -> Result<BadgeState, BadgeError> {
+        let badge = read_badge(&env, badge_id)?;
+        if badge.revoked {
+            return Ok(BadgeState::Revoked);
+        }
+        if badge.expires_at != 0 && env.ledger().timestamp() >= badge.expires_at {
+            return Ok(BadgeState::Expired);
+        }
+        Ok(BadgeState::Active)
+    }
+
     /// @notice Returns the owner of a badge, if it exists.
     /// @param badge_id badge_id parameter
-    /// @dev Requires caller authentication
     pub fn owner_of(env: Env, badge_id: u128) -> Option<Address> {
         env.storage()
             .persistent()
@@ -343,7 +491,6 @@ impl NftPayrollBadge {
 
     /// @notice Returns all badge ids currently owned by an address.
     /// @param owner owner parameter
-    /// @dev Requires caller authentication
     pub fn badges_of(env: Env, owner: Address) -> Vec<u128> {
         env.storage()
             .persistent()
@@ -352,7 +499,6 @@ impl NftPayrollBadge {
     }
 
     /// @notice Returns the configured admin address.
-    /// @dev Requires caller authentication
     pub fn get_admin(env: Env) -> Option<Address> {
         env.storage().persistent().get(&StorageKey::Admin)
     }

--- a/onchain/contracts/nft_payroll_badge/tests/test_badge.rs
+++ b/onchain/contracts/nft_payroll_badge/tests/test_badge.rs
@@ -1,12 +1,23 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Bytes, Env,
+};
 
-use nft_payroll_badge::{Badge, BadgeError, BadgeKind, NftPayrollBadge, NftPayrollBadgeClient};
+use nft_payroll_badge::{Badge, BadgeError, BadgeKind, BadgeState, NftPayrollBadge, NftPayrollBadgeClient};
 
 fn create_env() -> Env {
     let env = Env::default();
     env.mock_all_auths();
+    
+    // Set a non-zero timestamp. In Soroban tests, the default timestamp is 0.
+    // Because our contract treats `expires_at == 0` as "never expires",
+    // calling `expire()` when the ledger time is 0 creates a logical conflict.
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_000_000;
+    });
+
     env
 }
 
@@ -48,6 +59,7 @@ fn mint_employer_and_employee_badges() {
         &BadgeKind::Employer,
         &bytes_from_str(&env, "employer-meta"),
         &false,
+        &0,
     );
 
     let employee_badge_id = client.mint(
@@ -56,6 +68,7 @@ fn mint_employer_and_employee_badges() {
         &BadgeKind::Employee,
         &bytes_from_str(&env, "employee-meta"),
         &true,
+        &0,
     );
 
     assert!(employer_badge_id != employee_badge_id);
@@ -64,6 +77,7 @@ fn mint_employer_and_employee_badges() {
     assert_eq!(employer_badge.owner, employer);
     assert_eq!(employer_badge.kind, BadgeKind::Employer);
     assert!(!employer_badge.transferable);
+    assert!(!employer_badge.metadata_frozen);
 
     let employee_badge: Badge = client.get_badge(&employee_badge_id).unwrap();
     assert_eq!(employee_badge.owner, employee);
@@ -90,6 +104,7 @@ fn custom_badge_and_transferable_flag() {
         &BadgeKind::Custom(42),
         &bytes_from_str(&env, "custom"),
         &true,
+        &0,
     );
 
     let badge = client.get_badge(&badge_id).unwrap();
@@ -108,6 +123,7 @@ fn transfer_only_allowed_for_transferable_badges() {
         &BadgeKind::Employer,
         &bytes_from_str(&env, "nt"),
         &false,
+        &0,
     );
 
     let transferable_id = client.mint(
@@ -116,6 +132,7 @@ fn transfer_only_allowed_for_transferable_badges() {
         &BadgeKind::Employee,
         &bytes_from_str(&env, "t"),
         &true,
+        &0,
     );
 
     // Non-transferable: transfer should fail.
@@ -140,6 +157,7 @@ fn burn_by_admin_or_owner() {
         &BadgeKind::Employer,
         &bytes_from_str(&env, "admin-minted"),
         &false,
+        &0,
     );
 
     let owner_minted_id = client.mint(
@@ -148,6 +166,7 @@ fn burn_by_admin_or_owner() {
         &BadgeKind::Employee,
         &bytes_from_str(&env, "owner-minted"),
         &false,
+        &0,
     );
 
     // Admin can burn employer badge.
@@ -165,13 +184,13 @@ fn non_admin_cannot_mint_or_burn_others() {
     let (client, admin, employer, employee) = setup_initialized(&env);
 
     // Non-admin mint must fail.
-    // Non-admin mint panics with NotAdmin.
     let res = client.try_mint(
         &employer,
         &employee,
         &BadgeKind::Employee,
         &bytes_from_str(&env, "x"),
         &true,
+        &0,
     );
     assert!(res.is_err());
 
@@ -182,6 +201,7 @@ fn non_admin_cannot_mint_or_burn_others() {
         &BadgeKind::Employee,
         &bytes_from_str(&env, "y"),
         &true,
+        &0,
     );
 
     // Employer (not admin, not owner) cannot burn.
@@ -207,6 +227,7 @@ fn metadata_too_long() {
         &BadgeKind::Employee,
         &metadata,
         &true,
+        &0,
     );
     assert_eq!(res, Err(Ok(BadgeError::MetadataTooLong)));
 
@@ -222,6 +243,148 @@ fn metadata_too_long() {
         &BadgeKind::Employee,
         &metadata2,
         &true,
+        &0,
     );
     assert!(res2.is_ok());
+}
+
+#[test]
+fn metadata_update_and_freeze() {
+    let env = create_env();
+    let (client, admin, employer, _) = setup_initialized(&env);
+
+    let badge_id = client.mint(
+        &admin,
+        &employer,
+        &BadgeKind::Employer,
+        &bytes_from_str(&env, "meta1"),
+        &true,
+        &0,
+    );
+
+    // Update metadata
+    client.update_metadata(&admin, &badge_id, &bytes_from_str(&env, "meta2"));
+    let badge = client.get_badge(&badge_id).unwrap();
+    assert_eq!(badge.metadata, bytes_from_str(&env, "meta2"));
+
+    // Freeze
+    client.freeze_metadata(&admin, &badge_id);
+    let frozen_badge = client.get_badge(&badge_id).unwrap();
+    assert!(frozen_badge.metadata_frozen);
+
+    // Try update again -> error
+    let res = client.try_update_metadata(&admin, &badge_id, &bytes_from_str(&env, "meta3"));
+    assert_eq!(res, Err(Ok(BadgeError::MetadataFrozen)));
+    
+    // Try freeze again -> error
+    let res2 = client.try_freeze_metadata(&admin, &badge_id);
+    assert_eq!(res2, Err(Ok(BadgeError::MetadataFrozen)));
+}
+
+#[test]
+fn revocation_and_expiry_flows() {
+    let env = create_env();
+    let (client, admin, _, employee) = setup_initialized(&env);
+
+    let badge_id = client.mint(
+        &admin,
+        &employee,
+        &BadgeKind::Employee,
+        &bytes_from_str(&env, "employee"),
+        &true,
+        &0,
+    );
+
+    assert_eq!(client.get_state(&badge_id), BadgeState::Active);
+
+    // Revoke
+    client.revoke(&admin, &badge_id);
+    assert_eq!(client.get_state(&badge_id), BadgeState::Revoked);
+
+    // Repeated revoke -> error
+    let res = client.try_revoke(&admin, &badge_id);
+    assert_eq!(res, Err(Ok(BadgeError::AlreadyRevoked)));
+
+    // Try transfer revoked badge -> error
+    let res_transfer = client.try_transfer(&employee, &badge_id, &admin);
+    assert_eq!(res_transfer, Err(Ok(BadgeError::BadgeRevoked)));
+}
+
+#[test]
+fn explicit_expiry() {
+    let env = create_env();
+    let (client, admin, _, employee) = setup_initialized(&env);
+
+    let badge_id = client.mint(
+        &admin,
+        &employee,
+        &BadgeKind::Employee,
+        &bytes_from_str(&env, "employee"),
+        &true,
+        &0,
+    );
+
+    // Expire
+    client.expire(&admin, &badge_id);
+    assert_eq!(client.get_state(&badge_id), BadgeState::Expired);
+    
+    // Repeated expire -> error
+    let res = client.try_expire(&admin, &badge_id);
+    assert_eq!(res, Err(Ok(BadgeError::BadgeExpired)));
+    
+    // Transfer expired -> error
+    let res_transfer = client.try_transfer(&employee, &badge_id, &admin);
+    assert_eq!(res_transfer, Err(Ok(BadgeError::BadgeExpired)));
+}
+
+#[test]
+fn metadata_too_long_on_update() {
+    let env = create_env();
+    let (client, admin, employee, _) = setup_initialized(&env);
+
+    let badge_id = client.mint(
+        &admin,
+        &employee,
+        &BadgeKind::Employee,
+        &bytes_from_str(&env, "short"),
+        &false,
+        &0,
+    );
+
+    let mut data = [0u8; 1025];
+    for i in 0..1025 {
+        data[i] = (i % 256) as u8;
+    }
+    let metadata = Bytes::from_slice(&env, &data);
+
+    let res = client.try_update_metadata(&admin, &badge_id, &metadata);
+    assert_eq!(res, Err(Ok(BadgeError::MetadataTooLong)));
+}
+
+#[test]
+fn non_admin_update_revoke_fails() {
+    let env = create_env();
+    let (client, admin, employer, employee) = setup_initialized(&env);
+
+    let badge_id = client.mint(
+        &admin,
+        &employee,
+        &BadgeKind::Employee,
+        &bytes_from_str(&env, "emp"),
+        &true,
+        &0,
+    );
+
+    // Employer is not admin, should fail to update/revoke/expire
+    let res1 = client.try_update_metadata(&employer, &badge_id, &bytes_from_str(&env, "new"));
+    assert!(res1.is_err());
+    
+    let res2 = client.try_revoke(&employer, &badge_id);
+    assert!(res2.is_err());
+    
+    let res3 = client.try_expire(&employer, &badge_id);
+    assert!(res3.is_err());
+    
+    let res4 = client.try_freeze_metadata(&employer, &badge_id);
+    assert!(res4.is_err());
 }


### PR DESCRIPTION
# Description
This PR defines and enforces clear metadata immutability rules for the `nft_payroll_badge` contract and introduces lifecycle management (revocation and expiry flows) to represent employment termination or badge expiry.

**Key Changes:**
- Added a `BadgeState` enum (`Active`, `Revoked`, `Expired`) and a `get_state` function.
- Added `update_metadata` and `freeze_metadata` functions to strictly control metadata mutability.
- Added `revoke` and `expire` admin functions for lifecycle management.
- Updated the `transfer` logic to enforce that revoked or expired badges cannot be transferred.
- Added new events (`BadgeMetadataUpdated`, `BadgeMetadataFrozen`, `BadgeRevokedEvent`, `BadgeExpiredEvent`).
- Added comprehensive test coverage for all new flows, including edge cases (e.g., repeating revokes, updating after a freeze, and testing non-admin access controls).

# Related Issue
Fixes #407

## Checklist
- [x] I have tested the changes locally
- [x] I have added/updated documentation as needed
- [x] I have reviewed the code and ensured it follows the project guidelines
- [x] I have added necessary tests (unit/integration)
- [x] My changes generate no new warnings/errors
- [x] I have checked for code formatting issues

## Screenshots/Recordings
<img width="1078" height="348" alt="drips" src="https://github.com/user-attachments/assets/a92b608b-18ab-48c1-b5eb-c7ddefe7ed33" />

