### PR TITLE
Feature/oracle quorum

### DIFF
--- a/docs/price-oracle.md
+++ b/docs/price-oracle.md
@@ -236,7 +236,7 @@ This model keeps the implementation small and storage bounded while still reduci
 | `("oracle", "price")`     | `(base, quote, rate)`   | `push_price`         |
 | `("oracle", "owner")`     | `new_owner`             | `transfer_ownership` |
 
-## Test coverage (54 tests)
+## Test coverage (57 tests)
 
 - **Initialization** (2): owner set, double-init blocked
 - **Source management** (4): add/remove, non-owner blocked, removed source can't push
@@ -248,4 +248,5 @@ This model keeps the implementation small and storage bounded while still reduci
 - **Ownership transfer** (4): success, new owner works, old owner blocked, non-owner blocked
 - **Uninitialized guards** (5): all admin/source functions revert before init
 - **Security scenarios** (4): compromised source blast radius, pair isolation, reconfigure tightens bounds, pair direction matters
-- **Quorum-specific edge cases** (12): quorum success, dissent without quorum, duplicate-vote rejection, tolerance-boundary acceptance, bucket rollover reset, removed-source pending vote invalidation, and invalid zero-quorum configuration
+- **Quorum-specific edge cases** (15): quorum success, dissent without quorum, duplicate-vote rejection, tolerance-boundary acceptance, max-supporting-timestamp selection, older-bucket no-op after rollover, removed-source pending vote invalidation, FX forward failure handling, and invalid zero-quorum configuration
+- **Helper-path coverage** (3): non-positive tolerance input and arithmetic overflow guards in the tolerance matcher

--- a/docs/price-oracle.md
+++ b/docs/price-oracle.md
@@ -10,6 +10,7 @@ The `price_oracle` contract provides:
 - **Rate bounds** – Each `(base, quote)` pair has configurable `[min_rate, max_rate]` to limit oracle compromise blast radius.
 - **Staleness rejection** – Updates older than `max_staleness_seconds` are rejected; future timestamps are also rejected.
 - **Monotonic ordering** – Older-or-equal timestamps are silently ignored, preventing replay of stale rates.
+- **Optional quorum mode** – Pairs can require `N` distinct sources to submit matching or near-matching rates inside a time window before a rate is accepted.
 - **Payroll integration** – Accepted rates are automatically pushed to the core payroll contract via `set_exchange_rate`.
 - **Pair enable/disable** – Admin can pause and resume individual pairs without deleting configuration.
 - **Ownership transfer** – Single-step admin transfer for lightweight governance.
@@ -58,11 +59,19 @@ Where:
   - `min_rate` / `max_rate`: inclusive bounds for scaled rate.
   - `max_staleness_seconds`: maximum allowed age of an update.
   - `enabled`: allows pausing a pair without deleting configuration.
+  - `quorum_n`: number of distinct sources required. `1` preserves legacy single-source mode.
+  - `tolerance_bps`: maximum spread allowed between quorum-supporting rates, in basis points.
+  - `quorum_window_seconds`: time bucket size used to group pending quorum votes.
 
 - `PairState`:
   - `rate`: last accepted rate.
   - `last_updated_ts`: timestamp associated with the accepted update.
   - `last_source`: oracle source address that supplied the update.
+
+- Pending quorum state:
+  - A single active temporary bucket is kept per pair.
+  - Each bucket stores at most one vote per authorized source.
+  - The bucket is cleared when quorum is reached, when the pair is reconfigured, or when the pair is disabled.
 
 ---
 
@@ -86,7 +95,7 @@ Where:
 
 | Function                                                                  | Access | Description                               |
 |---------------------------------------------------------------------------|--------|-------------------------------------------|
-| `configure_pair(caller, base, quote, min_rate, max_rate, max_staleness)` | Owner  | Create or update a pair's configuration   |
+| `configure_pair(caller, base, quote, min_rate, max_rate, max_staleness, quorum_n, tolerance_bps, quorum_window_seconds)` | Owner  | Create or update a pair's configuration   |
 | `disable_pair(caller, base, quote)`                                       | Owner  | Pause updates for a pair                  |
 | `enable_pair(caller, base, quote)`                                        | Owner  | Resume updates for a pair                 |
 | `get_pair_config(base, quote)`                                            | Any    | Read pair configuration                   |
@@ -118,8 +127,11 @@ Each `push_price` call passes through these checks in order:
 5. **Bounds check** – `min_rate <= rate <= max_rate`.
 6. **No future timestamp** – `source_timestamp <= ledger.timestamp`.
 7. **Staleness check** – `ledger.timestamp - source_timestamp <= max_staleness_seconds`.
-8. **Monotonic ordering** – `source_timestamp > last_updated_ts` (or no prior state).
-9. **Persist & forward** – Save `PairState` and call `set_exchange_rate` on the payroll contract.
+8. **Single-source fast path** – If `quorum_n == 1`, the rate is accepted immediately.
+9. **Quorum path** – If `quorum_n > 1`, the vote is stored in the active `(pair, bucket)` window.
+10. **Duplicate rejection** – The same source cannot vote twice in the same active bucket.
+11. **Tolerance check** – Quorum is satisfied only when the completing vote finds `quorum_n` distinct source votes within `tolerance_bps`.
+12. **Persist & forward** – Save `PairState`, clear pending bucket state, and call `set_exchange_rate` on the payroll contract.
 
 On failure at any step, an `OracleError` is returned and no state in either
 contract is mutated.
@@ -144,7 +156,7 @@ Integration steps:
 3. **Configure sources and pairs**
    - Oracle owner calls:
      - `add_source(source_address)`
-     - `configure_pair(base, quote, min_rate, max_rate, max_staleness_seconds)`
+     - `configure_pair(base, quote, min_rate, max_rate, max_staleness_seconds, quorum_n, tolerance_bps, quorum_window_seconds)`
 4. **Feed prices**
    - Authorized sources call `push_price(source, base, quote, rate, source_ts)`.
    - On success, the payroll FX table is updated and any subsequent
@@ -167,18 +179,49 @@ Integration steps:
 | 8    | FxUpdateFailed    | Downstream payroll `set_exchange_rate` failed  |
 | 9    | ZeroRate          | Submitted rate is zero or negative             |
 | 10   | InvalidPairConfig | Invalid configuration parameters               |
+| 11   | DuplicateVote     | Source already voted in the active quorum bucket |
+
+## Quorum model
+
+Quorum mode is optional and configured per pair:
+
+- `quorum_n = 1` keeps the existing low-latency single-source behavior.
+- `quorum_n > 1` enables quorum for that pair only.
+- `tolerance_bps = 0` requires exact rate agreement.
+- `quorum_window_seconds` defines the time bucket. Votes in different buckets do not combine.
+
+Acceptance rules:
+
+- A vote is added to the pair's active bucket based on `source_timestamp / quorum_window_seconds`.
+- If a newer bucket starts, the contract drops the older pending bucket and starts collecting the new one.
+- The vote that arrives last is the anchor for the tolerance check.
+- Quorum is met when that anchor vote can find `quorum_n` distinct authorized-source submissions in the active bucket whose rates are all within `tolerance_bps` of the anchor.
+- The accepted rate is the anchor rate, and the accepted timestamp is the maximum timestamp among the supporting quorum votes.
+
+This model keeps the implementation small and storage bounded while still reducing single-key compromise risk.
 
 ## Threat model
 
 | Threat                          | Mitigation                                                                      |
 |---------------------------------|---------------------------------------------------------------------------------|
 | Compromised oracle source       | Rate bounds limit maximum damage; source cannot modify config or transfer admin |
+| Single source compromise in quorum mode | Attacker must compromise `quorum_n` distinct sources or collude within tolerance |
 | Stale rate injection            | `max_staleness_seconds` + future-timestamp rejection                            |
 | Replay of old rates             | Monotonic timestamp ordering (older updates are no-ops)                         |
+| Duplicate voting                | One vote per source in the active quorum bucket                                 |
+| Stale pending quorum state      | Pending bucket resets on rollover, reconfigure, disable, and successful acceptance |
 | Admin takeover                  | Only owner can add sources, configure pairs, transfer ownership                 |
 | Rate manipulation via wide bounds | Bounds are per-pair and admin-controlled; tighten as needed                   |
+| Quorum drift via wide tolerance | Admin should keep `tolerance_bps` tight; accepted rate is anchored to the completing vote |
 | Disabled pair bypass            | `push_price` checks `enabled` flag before accepting                             |
 | Pair direction confusion        | `(A, B)` and `(B, A)` are independent pairs in storage                         |
+
+## Trade-offs
+
+- **Security vs latency**: `quorum_n > 1` reduces single-key risk but adds at least one extra source round-trip.
+- **Tolerance vs precision**: larger `tolerance_bps` improves liveness during minor feed variance but widens the accepted spread.
+- **Bounded storage vs historical visibility**: the contract keeps only one active temporary bucket per pair instead of an unbounded per-pair submission log.
+- **Per-pair flexibility**: deployments can keep high-value pairs in quorum mode and leave low-latency pairs in single-source mode.
 
 ## Events
 
@@ -193,11 +236,11 @@ Integration steps:
 | `("oracle", "price")`     | `(base, quote, rate)`   | `push_price`         |
 | `("oracle", "owner")`     | `new_owner`             | `transfer_ownership` |
 
-## Test coverage (45 tests)
+## Test coverage (54 tests)
 
 - **Initialization** (2): owner set, double-init blocked
 - **Source management** (4): add/remove, non-owner blocked, removed source can't push
-- **Pair configuration** (7): read config, same-token rejected, min>max rejected, zero min, negative rate, zero staleness, non-owner blocked
+- **Pair configuration** (8): read config, same-token rejected, min>max rejected, zero min, negative rate, zero staleness, zero quorum window, non-owner blocked
 - **Disable/enable** (4): disable blocks updates, enable resumes, unconfigured pair error, non-owner blocked
 - **Push price happy path** (4): full integration, min boundary, max boundary, max staleness boundary
 - **Push price forbidden** (8): unregistered source, zero rate, negative rate, below min, above max, future timestamp, stale timestamp, unconfigured pair
@@ -205,3 +248,4 @@ Integration steps:
 - **Ownership transfer** (4): success, new owner works, old owner blocked, non-owner blocked
 - **Uninitialized guards** (5): all admin/source functions revert before init
 - **Security scenarios** (4): compromised source blast radius, pair isolation, reconfigure tightens bounds, pair direction matters
+- **Quorum-specific edge cases** (12): quorum success, dissent without quorum, duplicate-vote rejection, tolerance-boundary acceptance, bucket rollover reset, removed-source pending vote invalidation, and invalid zero-quorum configuration

--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Vec,
 };
 use stello_pay_contract::PayrollContractClient;
+
+const BPS_DENOMINATOR: i128 = 10_000;
 
 // ============================================================================
 // Errors
@@ -35,6 +37,8 @@ pub enum OracleError {
     ZeroRate = 9,
     /// Pair configuration parameters are invalid (e.g. min > max, zero staleness).
     InvalidPairConfig = 10,
+    /// The same source attempted to vote twice in the same active quorum bucket.
+    DuplicateVote = 11,
 }
 
 // ============================================================================
@@ -58,7 +62,11 @@ pub struct PairConfig {
     /// Whether the pair accepts new price updates.
     pub enabled: bool,
     /// Minimum number of unique authorized sources required to accept a price.
-    pub quorum: u32,
+    pub quorum_n: u32,
+    /// Maximum spread allowed between quorum-supporting rates, in basis points.
+    pub tolerance_bps: u32,
+    /// Time window used to group submissions into a single quorum bucket.
+    pub quorum_window_seconds: u64,
 }
 
 /// Last accepted rate for a `(base, quote)` pair.
@@ -71,6 +79,28 @@ pub struct PairState {
     pub last_updated_ts: u64,
     /// Address of the oracle source that submitted the accepted rate.
     pub last_source: Address,
+}
+
+/// A single source's pending vote within the active quorum bucket for a pair.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingSubmission {
+    /// Oracle source that submitted the vote.
+    pub source: Address,
+    /// Submitted scaled rate.
+    pub rate: i128,
+    /// Source timestamp carried with the vote.
+    pub source_timestamp: u64,
+}
+
+/// Pending quorum state for the current active bucket of a pair.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingBucketState {
+    /// Bucket identifier derived from `source_timestamp / quorum_window_seconds`.
+    pub timestamp_bucket: u64,
+    /// Distinct source votes recorded for the active bucket.
+    pub submissions: Vec<PendingSubmission>,
 }
 
 #[contracttype]
@@ -86,10 +116,8 @@ enum DataKey {
     PairConfig(Address, Address),
     /// Last accepted state for a `(base, quote)` pair.
     PairState(Address, Address),
-    /// Tracking individual source votes for quorum: (base, quote, timestamp, rate, source).
-    QuorumVote(Address, Address, u64, i128, Address),
-    /// Tracking aggregate vote counts for quorum: (base, quote, timestamp, rate).
-    QuorumCount(Address, Address, u64, i128),
+    /// Active pending quorum bucket for a `(base, quote)` pair.
+    PendingBucket(Address, Address),
 }
 
 #[contract]
@@ -142,6 +170,33 @@ fn require_admin(env: &Env, caller: &Address) -> Result<(), OracleError> {
     } else {
         Err(OracleError::NotAuthorized)
     }
+}
+
+fn bucket_for_timestamp(source_timestamp: u64, quorum_window_seconds: u64) -> u64 {
+    source_timestamp / quorum_window_seconds
+}
+
+fn within_tolerance(reference_rate: i128, candidate_rate: i128, tolerance_bps: u32) -> bool {
+    if reference_rate <= 0 || candidate_rate <= 0 {
+        return false;
+    }
+
+    let diff = if reference_rate >= candidate_rate {
+        reference_rate - candidate_rate
+    } else {
+        candidate_rate - reference_rate
+    };
+
+    let lhs = match diff.checked_mul(BPS_DENOMINATOR) {
+        Some(value) => value,
+        None => return false,
+    };
+    let rhs = match reference_rate.checked_mul(tolerance_bps as i128) {
+        Some(value) => value,
+        None => return false,
+    };
+
+    lhs <= rhs
 }
 
 // ============================================================================
@@ -244,6 +299,9 @@ impl PriceOracleContract {
     /// @param min_rate             Minimum allowed scaled rate (inclusive).
     /// @param max_rate             Maximum allowed scaled rate (inclusive).
     /// @param max_staleness_seconds Maximum allowed age of a rate update.
+    /// @param quorum_n             Minimum number of distinct sources required.
+    /// @param tolerance_bps        Maximum spread between quorum-supporting votes.
+    /// @param quorum_window_seconds Time window used to bucket pending votes.
     pub fn configure_pair(
         env: Env,
         caller: Address,
@@ -252,14 +310,16 @@ impl PriceOracleContract {
         min_rate: i128,
         max_rate: i128,
         max_staleness_seconds: u64,
-        quorum: u32,
+        quorum_n: u32,
+        tolerance_bps: u32,
+        quorum_window_seconds: u64,
     ) -> Result<(), OracleError> {
         require_admin(&env, &caller)?;
 
         if base == quote || min_rate <= 0 || max_rate <= 0 || min_rate > max_rate {
             return Err(OracleError::InvalidPairConfig);
         }
-        if max_staleness_seconds == 0 || quorum == 0 {
+        if max_staleness_seconds == 0 || quorum_n == 0 || quorum_window_seconds == 0 {
             return Err(OracleError::InvalidPairConfig);
         }
 
@@ -268,12 +328,17 @@ impl PriceOracleContract {
             max_rate,
             max_staleness_seconds,
             enabled: true,
-            quorum,
+            quorum_n,
+            tolerance_bps,
+            quorum_window_seconds,
         };
 
         env.storage()
             .instance()
             .set(&DataKey::PairConfig(base.clone(), quote.clone()), &cfg);
+        env.storage()
+            .temporary()
+            .remove(&DataKey::PendingBucket(base.clone(), quote.clone()));
 
         env.events().publish(
             (symbol_short!("oracle"), symbol_short!("cfgpair")),
@@ -307,6 +372,9 @@ impl PriceOracleContract {
         env.storage()
             .instance()
             .set(&DataKey::PairConfig(base.clone(), quote.clone()), &cfg);
+        env.storage()
+            .temporary()
+            .remove(&DataKey::PendingBucket(base.clone(), quote.clone()));
 
         env.events().publish(
             (symbol_short!("oracle"), symbol_short!("disable")),
@@ -362,8 +430,11 @@ impl PriceOracleContract {
     ///      6. Rejects stale timestamps (age > `max_staleness_seconds`).
     ///      7. Ignores updates older than or equal to the last accepted timestamp
     ///         (monotonic ordering).
-    ///      8. Persists the new `PairState`.
-    ///      9. Calls `set_exchange_rate` on the downstream payroll contract.
+    ///      8. In quorum mode, stores the vote in the active time bucket and
+    ///         only accepts once `quorum_n` distinct sources agree within
+    ///         `tolerance_bps`.
+    ///      9. Persists the new `PairState`.
+    ///      10. Calls `set_exchange_rate` on the downstream payroll contract.
     ///      Emits event `("oracle", "price")` with `(base, quote, rate)`.
     /// @param source           Oracle source address (must be pre-authorized).
     /// @param base             Base token address.
@@ -429,38 +500,68 @@ impl PriceOracleContract {
             }
         }
 
-        // Quorum check if enabled (> 1).
-        if cfg.quorum > 1 {
-            let vote_key = DataKey::QuorumVote(
-                base.clone(),
-                quote.clone(),
-                source_timestamp,
+        let accepted_timestamp = if cfg.quorum_n > 1 {
+            let bucket = bucket_for_timestamp(source_timestamp, cfg.quorum_window_seconds);
+            let pending_key = DataKey::PendingBucket(base.clone(), quote.clone());
+            let mut pending = match env
+                .storage()
+                .temporary()
+                .get::<_, PendingBucketState>(&pending_key)
+            {
+                Some(existing) if existing.timestamp_bucket > bucket => {
+                    // Ignore late votes from an older bucket once the pair has
+                    // moved on to a newer quorum window.
+                    return Ok(());
+                }
+                Some(existing) if existing.timestamp_bucket == bucket => existing,
+                _ => PendingBucketState {
+                    timestamp_bucket: bucket,
+                    submissions: Vec::new(&env),
+                },
+            };
+
+            for i in 0..pending.submissions.len() {
+                let existing = pending.submissions.get(i).unwrap();
+                if existing.source == source {
+                    return Err(OracleError::DuplicateVote);
+                }
+            }
+
+            pending.submissions.push_back(PendingSubmission {
+                source: source.clone(),
                 rate,
-                source.clone(),
-            );
-            if env.storage().temporary().has(&vote_key) {
-                // Source already submitted this exact rate/timestamp; ignore.
+                source_timestamp,
+            });
+
+            let mut matching_votes = 0u32;
+            let mut cluster_max_timestamp = source_timestamp;
+            for i in 0..pending.submissions.len() {
+                let existing = pending.submissions.get(i).unwrap();
+                if is_source(&env, &existing.source)
+                    && within_tolerance(rate, existing.rate, cfg.tolerance_bps)
+                {
+                    matching_votes += 1;
+                    if existing.source_timestamp > cluster_max_timestamp {
+                        cluster_max_timestamp = existing.source_timestamp;
+                    }
+                }
+            }
+
+            if matching_votes < cfg.quorum_n {
+                env.storage().temporary().set(&pending_key, &pending);
                 return Ok(());
             }
 
-            env.storage().temporary().set(&vote_key, &true);
-
-            let count_key =
-                DataKey::QuorumCount(base.clone(), quote.clone(), source_timestamp, rate);
-            let current_count: u32 = env.storage().temporary().get(&count_key).unwrap_or(0);
-            let new_count = current_count + 1;
-            env.storage().temporary().set(&count_key, &new_count);
-
-            if new_count < cfg.quorum {
-                // Quorum not yet reached.
-                return Ok(());
-            }
-        }
+            env.storage().temporary().remove(&pending_key);
+            cluster_max_timestamp
+        } else {
+            source_timestamp
+        };
 
         // Persist new state.
         let new_state = PairState {
             rate,
-            last_updated_ts: source_timestamp,
+            last_updated_ts: accepted_timestamp,
             last_source: source.clone(),
         };
         env.storage()

--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -199,6 +199,31 @@ fn within_tolerance(reference_rate: i128, candidate_rate: i128, tolerance_bps: u
     lhs <= rhs
 }
 
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_within_tolerance_rejects_non_positive_inputs() {
+        assert!(!within_tolerance(0, 1, 10));
+        assert!(!within_tolerance(1, 0, 10));
+    }
+
+    #[test]
+    fn test_within_tolerance_rejects_diff_overflow() {
+        assert!(!within_tolerance(i128::MAX, 1, 10));
+    }
+
+    #[test]
+    fn test_within_tolerance_rejects_rhs_overflow() {
+        assert!(!within_tolerance(
+            i128::MAX / 2 + 1,
+            i128::MAX / 2 + 1,
+            u32::MAX
+        ));
+    }
+}
+
 // ============================================================================
 // Contract implementation
 // ============================================================================

--- a/onchain/contracts/price_oracle/tests/test_oracle.rs
+++ b/onchain/contracts/price_oracle/tests/test_oracle.rs
@@ -1,14 +1,15 @@
 #![cfg(test)]
 #![allow(deprecated)]
 
-use price_oracle::{
-    OracleError, PriceOracleContract, PriceOracleContractClient,
-};
+use price_oracle::{OracleError, PriceOracleContract, PriceOracleContractClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, Env,
 };
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
+
+const DEFAULT_TOLERANCE_BPS: u32 = 0;
+const DEFAULT_QUORUM_WINDOW_SECONDS: u64 = 60;
 
 // ===========================================================================
 // Helpers
@@ -39,16 +40,41 @@ fn setup_oracle(
     (oracle_id, client, owner)
 }
 
+fn configure_pair_with_settings(
+    oracle_client: &PriceOracleContractClient<'static>,
+    oracle_owner: &Address,
+    base: &Address,
+    quote: &Address,
+    min_rate: i128,
+    max_rate: i128,
+    max_staleness_seconds: u64,
+    quorum_n: u32,
+    tolerance_bps: u32,
+    quorum_window_seconds: u64,
+) {
+    oracle_client.configure_pair(
+        oracle_owner,
+        base,
+        quote,
+        &min_rate,
+        &max_rate,
+        &max_staleness_seconds,
+        &quorum_n,
+        &tolerance_bps,
+        &quorum_window_seconds,
+    );
+}
+
 /// Full setup: payroll + oracle + FX admin registered + source + pair configured.
 fn full_setup(
     env: &Env,
 ) -> (
     PriceOracleContractClient<'static>,
     PayrollContractClient<'static>,
-    Address,       // oracle owner
-    Address,       // source
-    Address,       // base
-    Address,       // quote
+    Address, // oracle owner
+    Address, // source
+    Address, // base
+    Address, // quote
 ) {
     let (payroll_id, payroll_owner, payroll_client) = setup_payroll(env);
     let (oracle_id, oracle_client, oracle_owner) = setup_oracle(env, &payroll_id);
@@ -59,17 +85,27 @@ fn full_setup(
 
     let base = Address::generate(env);
     let quote = Address::generate(env);
-    oracle_client.configure_pair(
+    configure_pair_with_settings(
+        &oracle_client,
         &oracle_owner,
         &base,
         &quote,
-        &500_000i128,   // min 0.5
-        &5_000_000i128, // max 5.0
-        &600u64,        // 10 min staleness
-        &1u32,          // quorum
+        500_000i128,   // min 0.5
+        5_000_000i128, // max 5.0
+        600u64,        // 10 min staleness
+        1u32,          // quorum
+        DEFAULT_TOLERANCE_BPS,
+        DEFAULT_QUORUM_WINDOW_SECONDS,
     );
 
-    (oracle_client, payroll_client, oracle_owner, source, base, quote)
+    (
+        oracle_client,
+        payroll_client,
+        oracle_owner,
+        source,
+        base,
+        quote,
+    )
 }
 
 // ===========================================================================
@@ -173,6 +209,8 @@ fn test_configure_pair_and_read_config() {
         &3_000_000i128,
         &300u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
 
     let cfg = oracle_client.get_pair_config(&base2, &quote2).unwrap();
@@ -180,6 +218,9 @@ fn test_configure_pair_and_read_config() {
     assert_eq!(cfg.max_rate, 3_000_000);
     assert_eq!(cfg.max_staleness_seconds, 300);
     assert!(cfg.enabled);
+    assert_eq!(cfg.quorum_n, 1);
+    assert_eq!(cfg.tolerance_bps, DEFAULT_TOLERANCE_BPS);
+    assert_eq!(cfg.quorum_window_seconds, DEFAULT_QUORUM_WINDOW_SECONDS);
 }
 
 #[test]
@@ -196,6 +237,8 @@ fn test_configure_pair_same_base_quote_rejected() {
         &2_000_000i128,
         &300u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -215,6 +258,8 @@ fn test_configure_pair_min_greater_than_max_rejected() {
         &1_000_000i128,
         &300u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -234,6 +279,8 @@ fn test_configure_pair_zero_min_rate_rejected() {
         &2_000_000i128,
         &300u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -253,6 +300,8 @@ fn test_configure_pair_negative_rate_rejected() {
         &2_000_000i128,
         &300u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -272,6 +321,29 @@ fn test_configure_pair_zero_staleness_rejected() {
         &2_000_000i128,
         &0u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
+    );
+    assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
+}
+
+#[test]
+fn test_configure_pair_zero_quorum_window_rejected() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, _, _, _) = full_setup(&env);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    let res = oracle_client.try_configure_pair(
+        &oracle_owner,
+        &base,
+        &quote,
+        &1_000_000i128,
+        &2_000_000i128,
+        &300u64,
+        &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -292,6 +364,8 @@ fn test_non_owner_cannot_configure_pair() {
         &2_000_000i128,
         &300u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::NotAuthorized)));
 }
@@ -500,8 +574,13 @@ fn test_unconfigured_pair_rejected() {
     let unknown_quote = Address::generate(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
-    let res =
-        oracle_client.try_push_price(&source, &unknown_base, &unknown_quote, &2_000_000i128, &1_000u64);
+    let res = oracle_client.try_push_price(
+        &source,
+        &unknown_base,
+        &unknown_quote,
+        &2_000_000i128,
+        &1_000u64,
+    );
     assert_eq!(res, Err(Ok(OracleError::PairNotConfigured)));
 }
 
@@ -661,7 +740,17 @@ fn test_configure_pair_before_init_fails() {
     let b = Address::generate(&env);
     let c = Address::generate(&env);
 
-    let res = client.try_configure_pair(&a, &b, &c, &1i128, &2i128, &1u64, &1u32);
+    let res = client.try_configure_pair(
+        &a,
+        &b,
+        &c,
+        &1i128,
+        &2i128,
+        &1u64,
+        &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
+    );
     assert_eq!(res, Err(Ok(OracleError::NotInitialized)));
 }
 
@@ -700,7 +789,7 @@ fn test_transfer_ownership_before_init_fails() {
 #[test]
 fn test_compromised_source_blast_radius() {
     let env = create_env();
-    let (oracle_client, _, oracle_owner, source, base, quote) = full_setup(&env);
+    let (oracle_client, _, _oracle_owner, source, base, quote) = full_setup(&env);
 
     // Source cannot add another source.
     let evil_source = Address::generate(&env);
@@ -716,6 +805,8 @@ fn test_compromised_source_blast_radius() {
         &999_000_000i128,
         &86400u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::NotAuthorized)));
 
@@ -754,6 +845,8 @@ fn test_pair_isolation() {
         &9_000_000i128,
         &600u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -791,6 +884,8 @@ fn test_reconfigure_pair_tightens_bounds() {
         &3_000_000i128,
         &600u64,
         &1u32,
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
 
     // Same rate now rejected.
@@ -834,6 +929,8 @@ fn test_multi_source_quorum_success() {
         &5_000_000i128,
         &600u64,
         &2u32,
+        &50u32,
+        &60u64,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -874,6 +971,8 @@ fn test_multi_source_quorum_different_rates_do_not_count() {
         &5_000_000i128,
         &600u64,
         &2u32,
+        &50u32,
+        &60u64,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -885,6 +984,162 @@ fn test_multi_source_quorum_different_rates_do_not_count() {
     oracle_client.push_price(&source2, &base, &quote, &2_100_000i128, &1_000u64);
 
     // Neither reached quorum of 2.
+    assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+}
+
+#[test]
+fn test_multi_source_quorum_tolerance_boundary_accepts() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        50u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_005);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+    oracle_client.push_price(&source2, &base, &quote, &2_010_000i128, &1_005u64);
+
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_010_000);
+    assert_eq!(state.last_updated_ts, 1_005u64);
+    assert_eq!(state.last_source, source2);
+}
+
+#[test]
+fn test_multi_source_quorum_duplicate_vote_rejected() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        0u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+
+    let res = oracle_client.try_push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+    assert_eq!(res, Err(Ok(OracleError::DuplicateVote)));
+    assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+
+    oracle_client.push_price(&source2, &base, &quote, &2_000_000i128, &1_000u64);
+    assert_eq!(
+        oracle_client.get_pair_state(&base, &quote).unwrap().rate,
+        2_000_000
+    );
+}
+
+#[test]
+fn test_multi_source_quorum_dissenting_source_does_not_block_matching_cluster() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    let source3 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+    oracle_client.add_source(&oracle_owner, &source3);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        50u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+    oracle_client.push_price(&source2, &base, &quote, &2_100_000i128, &1_000u64);
+    assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+
+    oracle_client.push_price(&source3, &base, &quote, &2_000_000i128, &1_000u64);
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_000_000);
+    assert_eq!(state.last_source, source3);
+}
+
+#[test]
+fn test_multi_source_quorum_window_rollover_resets_pending_votes() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        0u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_060);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+    oracle_client.push_price(&source2, &base, &quote, &2_000_000i128, &1_060u64);
+    assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_060u64);
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_000_000);
+    assert_eq!(state.last_updated_ts, 1_060u64);
+}
+
+#[test]
+fn test_removed_source_pending_vote_no_longer_counts_toward_quorum() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        0u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+    oracle_client.remove_source(&oracle_owner, &source1);
+
+    oracle_client.push_price(&source2, &base, &quote, &2_000_000i128, &1_000u64);
     assert!(oracle_client.get_pair_state(&base, &quote).is_none());
 }
 
@@ -901,6 +1156,8 @@ fn test_quorum_rejection_on_zero_quorum() {
         &5_000_000i128,
         &600u64,
         &0u32, // Invalid
+        &DEFAULT_TOLERANCE_BPS,
+        &DEFAULT_QUORUM_WINDOW_SECONDS,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }

--- a/onchain/contracts/price_oracle/tests/test_oracle.rs
+++ b/onchain/contracts/price_oracle/tests/test_oracle.rs
@@ -1116,6 +1116,63 @@ fn test_multi_source_quorum_window_rollover_resets_pending_votes() {
 }
 
 #[test]
+fn test_multi_source_quorum_older_bucket_vote_is_ignored_after_rollover() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        0u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_060);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_060u64);
+
+    let res = oracle_client.try_push_price(&source2, &base, &quote, &2_000_000i128, &1_000u64);
+    assert!(res.is_ok());
+    assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+}
+
+#[test]
+fn test_multi_source_quorum_uses_max_supporting_timestamp() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        2u32,
+        100u32,
+        60u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_005);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_005u64);
+    oracle_client.push_price(&source2, &base, &quote, &2_000_500i128, &1_000u64);
+
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_000_500i128);
+    assert_eq!(state.last_updated_ts, 1_005u64);
+}
+
+#[test]
 fn test_removed_source_pending_vote_no_longer_counts_toward_quorum() {
     let env = create_env();
     let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
@@ -1141,6 +1198,34 @@ fn test_removed_source_pending_vote_no_longer_counts_toward_quorum() {
 
     oracle_client.push_price(&source2, &base, &quote, &2_000_000i128, &1_000u64);
     assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+}
+
+#[test]
+fn test_push_price_returns_fx_update_failed_when_payroll_rejects_update() {
+    let env = create_env();
+    let (payroll_id, _, _) = setup_payroll(&env);
+    let (_, oracle_client, oracle_owner) = setup_oracle(&env, &payroll_id);
+    let source = Address::generate(&env);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    oracle_client.add_source(&oracle_owner, &source);
+    configure_pair_with_settings(
+        &oracle_client,
+        &oracle_owner,
+        &base,
+        &quote,
+        500_000i128,
+        5_000_000i128,
+        600u64,
+        1u32,
+        DEFAULT_TOLERANCE_BPS,
+        DEFAULT_QUORUM_WINDOW_SECONDS,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    let res = oracle_client.try_push_price(&source, &base, &quote, &2_000_000i128, &1_000u64);
+    assert_eq!(res, Err(Ok(OracleError::FxUpdateFailed)));
 }
 
 #[test]


### PR DESCRIPTION
Closes #389 

Changes made:
- onchain/contracts/price_oracle/src/lib.rs: replaced simple quorum counting with bucketed pending votes, tolerance checks, duplicate-vote rejection, and new pair config fields (quorum_n, tolerance_bps, quorum_window_seconds).

- onchain/contracts/price_oracle/tests/test_oracle.rs: expanded tests for quorum tolerance, duplicate votes, bucket rollover, timestamp selection, source removal, config validation, and FX update failure.

- docs/price-oracle.md: updated API/docs to describe quorum mode, config params, acceptance flow, trade-offs, and test coverage.


Verification:

```
cargo test -p price_oracle -- --nocapture
running 3 tests
test result: ok. 3 passed; 0 failed

running 57 tests
test result: ok. 57 passed; 0 failed 
```


Coverage:

```
cargo tarpaulin -p price_oracle --include-files contracts/price_oracle/src/* --out Stdout --fail-under 95
contracts/price_oracle/src/lib.rs: 175/184
95.11% coverage
```