### PR TITLE
Add cross contract integration tests between token vesting and core payroll flows

### DIFF
--- a/docs/integration-examples.md
+++ b/docs/integration-examples.md
@@ -143,3 +143,26 @@ stellar contract invoke \
 
 These patterns can be wrapped in shell scripts, CI jobs, or higher‑level deployment tooling to provide reliable, repeatable interactions without writing additional application code.
 
+---
+
+### Payroll + Token Vesting Integration Assumptions
+
+The payroll and token vesting contracts are integrated by orchestration rather than by direct contract-to-contract calls. A hiring workflow should bind the same `employer`, `employee`, and `token` to:
+
+- a `stello_pay_contract` payroll agreement for recurring salary claims
+- a `token_vesting` schedule for grant, bonus, or equity-like vesting claims
+
+The integration tests in `onchain/integration_tests/tests/test_token_vesting_payroll_integration.rs` cover the expected lifecycle:
+
+- hire: employer creates and activates a payroll agreement, then creates a revocable vesting schedule for the same employee
+- claims: employee claims payroll periods and vested tokens at multiple ledger timestamps
+- termination: payroll cancellation starts the grace period, while vesting revocation refunds only unvested tokens and leaves vested-but-unclaimed tokens claimable
+- dispute/grace alignment: an admin early release may be used after a payroll dispute or grace-period decision, but only the vesting owner can approve it
+- security boundaries: mismatched employees cannot claim another employee's payroll or vesting, and mismatched employers cannot revoke a schedule
+
+Security notes:
+
+- Payroll escrow accounting remains independent from vesting escrow accounting; both contracts transfer the same SAC token but hold separate balances.
+- Revocation freezes vesting at `revoked_at`; later ledger movement must not increase `releasable_amount`.
+- Repeated same-ledger claims are rejected once no additional payroll period or vested amount is available.
+- Off-chain services should persist the payroll `agreement_id` to vesting `schedule_id` mapping and verify the employer, beneficiary, and token match before presenting combined lifecycle actions.

--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -1177,6 +1177,8 @@ version = "0.0.0"
 dependencies = [
  "bonus_system",
  "dispute_escalation",
+ "employee_roles",
+ "governance",
  "payment_history",
  "payment_retry",
  "payment_scheduler",
@@ -1184,6 +1186,7 @@ dependencies = [
  "rbac",
  "soroban-sdk",
  "stello_pay_contract",
+ "token_vesting",
  "withdrawal_timelock",
 ]
 

--- a/onchain/contracts/payment_scheduler/src/lib.rs
+++ b/onchain/contracts/payment_scheduler/src/lib.rs
@@ -125,12 +125,12 @@ pub struct RetryConfig {
     pub retry_intervals: Vec<u64>,
 }
 
-pub struct RetryContractClient<'a> {
+pub struct RetryContractClient {
     pub env: Env,
     pub contract_id: Address,
 }
 
-impl<'a> RetryContractClient<'a> {
+impl RetryContractClient {
     pub fn new(env: &Env, contract_id: &Address) -> Self {
         Self {
             env: env.clone(),

--- a/onchain/integration_tests/Cargo.toml
+++ b/onchain/integration_tests/Cargo.toml
@@ -10,9 +10,12 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }
 stello_pay_contract = { path = "../contracts/stello_pay_contract" }
+token_vesting = { path = "../contracts/token_vesting" }
 payroll_escrow = { path = "../contracts/payroll_escrow" }
 bonus_system = { path = "../contracts/bonus_system" }
 payment_history = { path = "../contracts/payment_history" }
+payment_retry = { path = "../contracts/payment_retry" }
+payment_scheduler = { path = "../contracts/payment_scheduler" }
 dispute_escalation = { path = "../contracts/dispute_escalation" }
 employee_roles = { path = "../contracts/employee_roles" }
 rbac = { path = "../contracts/rbac" }

--- a/onchain/integration_tests/tests/test_retry_orchestration.rs
+++ b/onchain/integration_tests/tests/test_retry_orchestration.rs
@@ -3,11 +3,11 @@
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, BytesN, Env,
+    Address, Env,
 };
 
-use payment_scheduler::{PaymentSchedulerContract, PaymentSchedulerContractClient};
 use payment_retry::{PaymentRetryContract, PaymentRetryContractClient, RetryState};
+use payment_scheduler::{PaymentSchedulerContract, PaymentSchedulerContractClient};
 
 fn env() -> Env {
     let e = Env::default();
@@ -24,14 +24,18 @@ fn token(env: &Env) -> Address {
     env.register_stellar_asset_contract_v2(admin).address()
 }
 
-fn deploy_scheduler(env: &Env, owner: &Address, retry_addr: &Address) -> (Address, PaymentSchedulerContractClient<'_>) {
+fn deploy_scheduler<'a>(
+    env: &'a Env,
+    owner: &Address,
+    retry_addr: &Address,
+) -> (Address, PaymentSchedulerContractClient<'a>) {
     let id = env.register_contract(None, PaymentSchedulerContract);
     let client = PaymentSchedulerContractClient::new(env, &id);
     client.initialize(owner, retry_addr);
     (id, client)
 }
 
-fn deploy_retry(env: &Env, owner: &Address) -> (Address, PaymentRetryContractClient<'_>) {
+fn deploy_retry<'a>(env: &'a Env, owner: &Address) -> (Address, PaymentRetryContractClient<'a>) {
     let id = env.register_contract(None, PaymentRetryContract);
     let client = PaymentRetryContractClient::new(env, &id);
     client.initialize(owner);
@@ -59,7 +63,7 @@ fn test_retry_orchestration_e2e() {
 
     let amount = 1000i128;
     let start_time = env.ledger().timestamp();
-    
+
     // 1. Create Job
     let _job_id = sched_client.create_job(
         &employer,
@@ -79,12 +83,16 @@ fn test_retry_orchestration_e2e() {
     let payment_id = {
         use soroban_sdk::xdr::ToXdr;
         let mut buf = soroban_sdk::Bytes::new(&env);
-        buf.append(&employer.to_xdr(&env));
-        buf.append(&recipient.to_xdr(&env));
+        buf.append(&employer.clone().to_xdr(&env));
+        buf.append(&recipient.clone().to_xdr(&env));
         let amount_bytes = amount.to_le_bytes();
-        for b in amount_bytes.iter() { buf.push_back(*b); }
+        for b in amount_bytes.iter() {
+            buf.push_back(*b);
+        }
         let time_bytes = start_time.to_le_bytes();
-        for b in time_bytes.iter() { buf.push_back(*b); }
+        for b in time_bytes.iter() {
+            buf.push_back(*b);
+        }
         env.crypto().sha256(&buf).into()
     };
 
@@ -106,7 +114,7 @@ fn test_retry_orchestration_e2e() {
     retry_client.process_retry(&payment_id);
     let payment = retry_client.get_payment(&payment_id).unwrap();
     assert_eq!(payment.state, RetryState::Success);
-    
+
     // 7. Verify recipient balance
     let bal = TokenClient::new(&env, &tok_addr).balance(&recipient);
     assert_eq!(bal, amount);
@@ -130,29 +138,48 @@ fn test_retry_orchestration_max_retries() {
 
     let amount = 1000i128;
     let start_time = env.ledger().timestamp();
-    
-    sched_client.create_job(&employer, &recipient, &tok_addr, &amount, &3600, &start_time, &Some(1), &1); // max_retries = 1
+
+    sched_client.create_job(
+        &employer,
+        &recipient,
+        &tok_addr,
+        &amount,
+        &3600,
+        &start_time,
+        &Some(1),
+        &1,
+    ); // max_retries = 1
 
     sched_client.process_due_payments(&1);
 
     let payment_id = {
         use soroban_sdk::xdr::ToXdr;
         let mut buf = soroban_sdk::Bytes::new(&env);
-        buf.append(&employer.to_xdr(&env));
-        buf.append(&recipient.to_xdr(&env));
+        buf.append(&employer.clone().to_xdr(&env));
+        buf.append(&recipient.clone().to_xdr(&env));
         let amount_bytes = amount.to_le_bytes();
-        for b in amount_bytes.iter() { buf.push_back(*b); }
+        for b in amount_bytes.iter() {
+            buf.push_back(*b);
+        }
         let time_bytes = start_time.to_le_bytes();
-        for b in time_bytes.iter() { buf.push_back(*b); }
+        for b in time_bytes.iter() {
+            buf.push_back(*b);
+        }
         env.crypto().sha256(&buf).into()
     };
 
     // Attempt 1
     retry_client.process_retry(&payment_id);
-    assert_eq!(retry_client.get_payment(&payment_id).unwrap().state, RetryState::Retrying);
+    assert_eq!(
+        retry_client.get_payment(&payment_id).unwrap().state,
+        RetryState::Retrying
+    );
 
     // Attempt 2 -> Exceeds max_retries (1)
     advance(&env, 120);
     retry_client.process_retry(&payment_id);
-    assert_eq!(retry_client.get_payment(&payment_id).unwrap().state, RetryState::Failed);
+    assert_eq!(
+        retry_client.get_payment(&payment_id).unwrap().state,
+        RetryState::Failed
+    );
 }

--- a/onchain/integration_tests/tests/test_token_vesting_payroll_integration.rs
+++ b/onchain/integration_tests/tests/test_token_vesting_payroll_integration.rs
@@ -1,0 +1,317 @@
+//! Cross-contract integration coverage for payroll lifecycle orchestration and
+//! token vesting schedules.
+//!
+//! These tests intentionally use the generated clients for both contracts and a
+//! shared SAC token. The current contracts do not call each other directly, so
+//! the integration boundary is the off-chain workflow that binds one payroll
+//! agreement to one vesting schedule for the same employer/employee pair.
+
+#![cfg(test)]
+#![allow(deprecated)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+use stello_pay_contract::storage::{AgreementStatus, DataKey, DisputeStatus};
+use stello_pay_contract::{PayrollContract, PayrollContractClient};
+use token_vesting::{TokenVestingContract, TokenVestingContractClient, VestingStatus};
+
+const ONE_DAY: u64 = 86_400;
+const ONE_WEEK: u64 = 604_800;
+const SALARY_PER_DAY: i128 = 1_000;
+const PAYROLL_FUND: i128 = 20_000;
+const VESTING_GRANT: i128 = 12_000;
+const EMPLOYER_FLOAT: i128 = 100_000;
+
+struct PayrollDeployment<'a> {
+    id: Address,
+    client: PayrollContractClient<'a>,
+}
+
+struct VestingDeployment<'a> {
+    id: Address,
+    owner: Address,
+    client: TokenVestingContractClient<'a>,
+}
+
+fn env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn addr(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn set_time(env: &Env, timestamp: u64) {
+    env.ledger().with_mut(|li| li.timestamp = timestamp);
+}
+
+fn advance(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|li| li.timestamp += seconds);
+}
+
+fn token(env: &Env) -> Address {
+    let admin = addr(env);
+    env.register_stellar_asset_contract_v2(admin).address()
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn transfer(env: &Env, token: &Address, from: &Address, to: &Address, amount: i128) {
+    TokenClient::new(env, token).transfer(from, to, &amount);
+}
+
+fn balance(env: &Env, token: &Address, address: &Address) -> i128 {
+    TokenClient::new(env, token).balance(address)
+}
+
+fn deploy_payroll(env: &Env) -> PayrollDeployment<'_> {
+    let id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(env, &id);
+    let owner = addr(env);
+    client.initialize(&owner);
+    PayrollDeployment { id, client }
+}
+
+fn deploy_vesting(env: &Env) -> VestingDeployment<'_> {
+    let id = env.register_contract(None, TokenVestingContract);
+    let client = TokenVestingContractClient::new(env, &id);
+    let owner = addr(env);
+    client.initialize(&owner);
+    VestingDeployment { id, owner, client }
+}
+
+fn seed_payroll_funding(
+    env: &Env,
+    payroll_id: &Address,
+    agreement_id: u128,
+    token: &Address,
+    employee: &Address,
+    salary: i128,
+    total_fund: i128,
+) {
+    env.as_contract(payroll_id, || {
+        DataKey::set_agreement_escrow_balance(env, agreement_id, token, total_fund);
+        DataKey::set_agreement_activation_time(env, agreement_id, env.ledger().timestamp());
+        DataKey::set_agreement_period_duration(env, agreement_id, ONE_DAY);
+        DataKey::set_agreement_token(env, agreement_id, token);
+        DataKey::set_employee(env, agreement_id, 0, employee);
+        DataKey::set_employee_salary(env, agreement_id, 0, salary);
+        DataKey::set_employee_claimed_periods(env, agreement_id, 0, 0);
+        DataKey::set_employee_count(env, agreement_id, 1);
+    });
+}
+
+fn create_hired_employee_with_vesting(
+    env: &Env,
+    payroll: &PayrollDeployment<'_>,
+    vesting: &VestingDeployment<'_>,
+    employer: &Address,
+    employee: &Address,
+    token: &Address,
+) -> (u128, u128) {
+    let agreement_id = payroll
+        .client
+        .create_payroll_agreement(employer, token, &ONE_WEEK);
+    payroll
+        .client
+        .add_employee_to_agreement(&agreement_id, employee, &SALARY_PER_DAY);
+    payroll.client.activate_agreement(&agreement_id);
+
+    transfer(env, token, employer, &payroll.id, PAYROLL_FUND);
+    seed_payroll_funding(
+        env,
+        &payroll.id,
+        agreement_id,
+        token,
+        employee,
+        SALARY_PER_DAY,
+        PAYROLL_FUND,
+    );
+
+    let schedule_id = vesting.client.create_linear_schedule(
+        employer,
+        employee,
+        token,
+        &VESTING_GRANT,
+        &env.ledger().timestamp(),
+        &(env.ledger().timestamp() + (ONE_DAY * 12)),
+        &None,
+        &true,
+    );
+
+    (agreement_id, schedule_id)
+}
+
+#[test]
+fn employer_hires_employee_and_employee_claims_payroll_and_vesting_over_time() {
+    let env = env();
+    set_time(&env, 1_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    assert_eq!(balance(&env, &token, &payroll.id), PAYROLL_FUND);
+    assert_eq!(balance(&env, &token, &vesting.id), VESTING_GRANT);
+
+    advance(&env, ONE_DAY * 3);
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    let first_vesting_claim = vesting.client.claim(&employee, &schedule_id);
+
+    assert_eq!(
+        payroll
+            .client
+            .get_employee_claimed_periods(&agreement_id, &0),
+        3
+    );
+    assert_eq!(first_vesting_claim, 3_000);
+    assert_eq!(balance(&env, &token, &employee), 6_000);
+
+    let replay_payroll = payroll
+        .client
+        .try_claim_payroll(&employee, &agreement_id, &0);
+    let replay_vesting = vesting.client.try_claim(&employee, &schedule_id);
+    assert!(replay_payroll.is_err());
+    assert!(replay_vesting.is_err());
+
+    advance(&env, ONE_DAY * 2);
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    let second_vesting_claim = vesting.client.claim(&employee, &schedule_id);
+
+    assert_eq!(
+        payroll
+            .client
+            .get_employee_claimed_periods(&agreement_id, &0),
+        5
+    );
+    assert_eq!(second_vesting_claim, 2_000);
+    assert_eq!(balance(&env, &token, &employee), 10_000);
+}
+
+#[test]
+fn termination_revokes_unvested_tokens_and_freezes_later_vesting_claims() {
+    let env = env();
+    set_time(&env, 7_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    advance(&env, ONE_DAY * 3);
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    assert_eq!(vesting.client.claim(&employee, &schedule_id), 3_000);
+
+    advance(&env, ONE_DAY * 2);
+    payroll.client.cancel_agreement(&agreement_id);
+    let employer_before_revoke = balance(&env, &token, &employer);
+    let refunded = vesting.client.revoke(&employer, &schedule_id);
+
+    assert_eq!(refunded, 7_000);
+    assert_eq!(
+        balance(&env, &token, &employer) - employer_before_revoke,
+        7_000
+    );
+    assert_eq!(
+        payroll.client.get_agreement(&agreement_id).unwrap().status,
+        AgreementStatus::Cancelled
+    );
+    assert!(payroll.client.is_grace_period_active(&agreement_id));
+
+    let frozen_vested_remainder = vesting.client.claim(&employee, &schedule_id);
+    assert_eq!(frozen_vested_remainder, 2_000);
+    assert_eq!(
+        vesting.client.get_schedule(&schedule_id).unwrap().status,
+        VestingStatus::Revoked
+    );
+
+    advance(&env, ONE_DAY * 30);
+    assert_eq!(vesting.client.get_releasable_amount(&schedule_id), 0);
+    assert!(vesting.client.try_claim(&employee, &schedule_id).is_err());
+}
+
+#[test]
+fn admin_early_release_can_follow_payroll_dispute_or_grace_window_decision() {
+    let env = env();
+    set_time(&env, 20_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    let arbiter = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    advance(&env, ONE_DAY);
+    payroll.client.cancel_agreement(&agreement_id);
+    assert!(payroll.client.is_grace_period_active(&agreement_id));
+    payroll.client.raise_dispute(&employee, &agreement_id);
+    assert_eq!(
+        payroll.client.get_dispute_status(&agreement_id),
+        DisputeStatus::Raised
+    );
+    payroll.client.set_arbiter(&employer, &arbiter);
+    payroll
+        .client
+        .resolve_dispute(&arbiter, &agreement_id, &1_000, &0);
+
+    let employee_before = balance(&env, &token, &employee);
+    let early_release = vesting
+        .client
+        .approve_early_release(&vesting.owner, &schedule_id, &2_000);
+
+    assert_eq!(early_release, 2_000);
+    assert_eq!(balance(&env, &token, &employee) - employee_before, 2_000);
+    assert!(vesting
+        .client
+        .try_approve_early_release(&employee, &schedule_id, &1)
+        .is_err());
+}
+
+#[test]
+fn cannot_claim_or_revoke_with_mismatched_parties_across_payroll_and_vesting() {
+    let env = env();
+    set_time(&env, 30_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    let stranger = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    advance(&env, ONE_DAY * 4);
+
+    assert!(payroll
+        .client
+        .try_claim_payroll(&stranger, &agreement_id, &0)
+        .is_err());
+    assert!(vesting.client.try_claim(&stranger, &schedule_id).is_err());
+    assert!(vesting.client.try_revoke(&stranger, &schedule_id).is_err());
+
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    assert_eq!(vesting.client.claim(&employee, &schedule_id), 4_000);
+}


### PR DESCRIPTION
closes #385

This PR Adds cross-contract integration coverage between token_vesting and stello_pay_contract payroll flows. The new tests model hire, payroll activation, vesting schedule creation, multi-timestamp claims, termination, vesting revocation, refund behavior, early release approval, and mismatched party protections.

Changes

Added Token Vesting dependency to the integration_tests crate.
Added payroll + vesting integration tests under onchain/integration_tests/tests/.
Documented integration assumptions and security notes in docs/integration-examples.md.
Fixed existing integration test harness compile issues for retry/scheduler tests so the full package test runs.