### PR TITLE
Add salary adjustment prevent retroactive edits without explicit authorization and add audit logging

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -148,6 +148,27 @@ The returned `log_id` is persisted in the expense record (`audit_log_id`) and em
 - Approval logs should include only operational metadata (`actor`, action, `subject`, amount).
 - Receipt material is not logged in plaintext by `audit_logger`; expense flows store only a domain-separated SHA-256 receipt commitment.
 
+### Salary Adjustment Audit Stream
+
+The `salary_adjustment` contract maintains a contract-local append-only audit stream in parallel with its lifecycle events. Each successful mutating action appends a `SalaryAdjustmentAuditEntry` and emits `("salary_adjustment_audit", audit_id)`.
+
+Logged actions include:
+
+- `adjustment_created`
+- `adjustment_approved`
+- `adjustment_rejected`
+- `adjustment_applied`
+- `adjustment_cancelled`
+- `salary_cap_set`
+
+Retroactive salary adjustments require the dedicated `create_retroactive_adjustment` path. The contract stores a domain-separated SHA-256 reason commitment rather than plaintext rationale:
+
+```text
+sha256("salary_adjustment:retroactive:v1" || actor and adjustment fields || caller_supplied_reason_hash)
+```
+
+This lets compliance teams prove that a reason existed and was bound to the immutable adjustment fields without exposing sensitive HR details on-chain.
+
 ---
 
 ### Testing
@@ -171,4 +192,3 @@ The test suite covers:
 - Log entries are immutable (tamper evidence)
 - Timestamps are monotonic
 - Multiple actors can append independently
-

--- a/docs/integration-examples.md
+++ b/docs/integration-examples.md
@@ -143,3 +143,26 @@ stellar contract invoke \
 
 These patterns can be wrapped in shell scripts, CI jobs, or higher‑level deployment tooling to provide reliable, repeatable interactions without writing additional application code.
 
+---
+
+### Payroll + Token Vesting Integration Assumptions
+
+The payroll and token vesting contracts are integrated by orchestration rather than by direct contract-to-contract calls. A hiring workflow should bind the same `employer`, `employee`, and `token` to:
+
+- a `stello_pay_contract` payroll agreement for recurring salary claims
+- a `token_vesting` schedule for grant, bonus, or equity-like vesting claims
+
+The integration tests in `onchain/integration_tests/tests/test_token_vesting_payroll_integration.rs` cover the expected lifecycle:
+
+- hire: employer creates and activates a payroll agreement, then creates a revocable vesting schedule for the same employee
+- claims: employee claims payroll periods and vested tokens at multiple ledger timestamps
+- termination: payroll cancellation starts the grace period, while vesting revocation refunds only unvested tokens and leaves vested-but-unclaimed tokens claimable
+- dispute/grace alignment: an admin early release may be used after a payroll dispute or grace-period decision, but only the vesting owner can approve it
+- security boundaries: mismatched employees cannot claim another employee's payroll or vesting, and mismatched employers cannot revoke a schedule
+
+Security notes:
+
+- Payroll escrow accounting remains independent from vesting escrow accounting; both contracts transfer the same SAC token but hold separate balances.
+- Revocation freezes vesting at `revoked_at`; later ledger movement must not increase `releasable_amount`.
+- Repeated same-ledger claims are rejected once no additional payroll period or vested amount is available.
+- Off-chain services should persist the payroll `agreement_id` to vesting `schedule_id` mapping and verify the employer, beneficiary, and token match before presenting combined lifecycle actions.

--- a/docs/salary-adjustment.md
+++ b/docs/salary-adjustment.md
@@ -7,7 +7,7 @@ This document covers the `salary_adjustment` contract implementing issue `#337`.
 
 ## Overview
 
-The `salary_adjustment` contract manages employer-driven salary change requests with structured approval workflows, effective date enforcement, salary cap controls, and payroll-visible salary tracking — with a full event log for auditors.
+The `salary_adjustment` contract manages employer-driven salary change requests with structured approval workflows, effective date enforcement, salary cap controls, payroll-visible salary tracking, and an append-only audit stream for compliance review.
 
 ## Workflow
 
@@ -31,10 +31,12 @@ Employer creates adjustment (Pending)
 |---------|-------------|
 | Only employer creates/applies/cancels | `employer.require_auth()` + identity check |
 | Only designated approver approves/rejects | `approver.require_auth()` + `adjustment.approver == approver` |
-| Retroactive abuse | `effective_date >= ledger.timestamp()` at creation |
+| Retroactive abuse | `create_adjustment` is forward-only; retroactive edits require owner + employer authorization and a reason hash |
 | Salary cap enforcement | `new_salary <= effective_salary_cap()` at creation |
 | One-time initialization | Persistent flag; second call panics |
 | Approved adjustments are immutable | Cancel blocked on `Approved`/`Applied` status |
+| Conflicting edits | Same employee + same effective timestamp can only have one stored adjustment |
+| Compliance auditability | Every mutating action appends a queryable audit record and emits an audit event |
 
 ## Constants
 
@@ -52,6 +54,9 @@ Employer creates adjustment (Pending)
 | `Adjustment(u128)` | `SalaryAdjustment` | Adjustment record by id |
 | `SalaryCap` | `i128` | Optional salary ceiling set by owner |
 | `EmployeeSalary(Address)` | `i128` | Last applied salary per employee |
+| `NextAuditLogId` | `u128` | Monotonic audit log counter |
+| `AuditLog(u128)` | `SalaryAdjustmentAuditEntry` | Append-only audit entry |
+| `EmployeeEffectiveAdjustment(Address, u64)` | `u128` | Conflict sentinel for employee/effective-date pairs |
 
 ## Data Model
 
@@ -67,8 +72,24 @@ pub struct SalaryAdjustment {
     pub new_salary: i128,
     pub effective_date: u64,        // Unix timestamp; must be >= created_at
     pub created_at: u64,
+    pub retroactive: bool,
+    pub retroactive_approved_by: Option<Address>,
+    pub reason_hash: Option<BytesN<32>>,
 }
 ```
+
+Retroactive records store a contract-computed reason commitment rather than the raw caller-provided hash. The stored value is:
+
+```text
+sha256(
+  "salary_adjustment:retroactive:v1" ||
+  owner || employer || employee ||
+  current_salary || new_salary || effective_date ||
+  caller_supplied_reason_hash
+)
+```
+
+This domain separates salary-adjustment reasons from hashes used by other contracts, binds the reason to the immutable adjustment parameters, and avoids storing plaintext HR rationale on-chain.
 
 ## Contract API
 
@@ -81,7 +102,7 @@ Owner-only. Sets a global ceiling enforced on all future `create_adjustment` cal
 **Panics**: `"Only owner can set salary cap"`, `"Salary cap must be positive"`
 
 ### `create_adjustment(employer, employee, approver, current_salary, new_salary, effective_date) -> u128`
-Creates a new adjustment in `Pending` state.
+Creates a new forward-only adjustment in `Pending` state. `effective_date` must be at or after the current ledger timestamp.
 
 **Panics**:
 - `"Current salary must be positive"`
@@ -89,6 +110,24 @@ Creates a new adjustment in `Pending` state.
 - `"New salary must differ from current salary"`
 - `"New salary exceeds salary cap"`
 - `"Effective date cannot be in the past"`
+- `"Conflicting adjustment exists"`
+
+### `create_retroactive_adjustment(owner, employer, employee, approver, current_salary, new_salary, effective_date, reason_hash) -> u128`
+Creates a retroactive adjustment in `Pending` state using the dedicated authorization path.
+
+Requirements:
+
+- `owner` must match the initialized contract owner and authenticate
+- `employer` must authenticate
+- `effective_date` must be before the current ledger timestamp
+- `reason_hash` must be non-zero
+- the stored reason hash is domain-separated and bound to the adjustment parameters
+
+**Panics**:
+- `"Only owner can authorize retroactive adjustment"`
+- `"Use create_adjustment for forward adjustments"`
+- `"Retroactive reason hash required"`
+- all standard `create_adjustment` validation panics except the forward-only date check
 
 ### `approve_adjustment(approver, adjustment_id)`
 Moves status `Pending → Approved`. Only the configured `approver` may call.
@@ -123,6 +162,12 @@ Returns configured cap or `DEFAULT_MAX_SALARY` if none set.
 ### `get_employee_salary(employee) -> Option<i128>`
 Returns the last applied salary for payroll claiming logic. `None` until first adjustment is applied.
 
+### `get_audit_log(audit_id) -> Option<SalaryAdjustmentAuditEntry>`
+Returns a stored append-only audit entry by id.
+
+### `get_audit_log_count() -> u128`
+Returns the number of audit entries written.
+
 ## Events
 
 | Topic | Payload |
@@ -133,36 +178,58 @@ Returns the last applied salary for payroll claiming logic. `None` until first a
 | `("adjustment_applied", id)` | `AdjustmentAppliedEvent` |
 | `("adjustment_cancelled", id)` | `AdjustmentCancelledEvent` |
 | `("salary_cap_set", cap)` | `SalaryCapSetEvent` |
+| `("salary_adjustment_audit", audit_id)` | `AdjustmentAuditEvent` |
+
+## Audit Stream
+
+Every successful mutating action appends a `SalaryAdjustmentAuditEntry` and emits a matching audit event:
+
+- `adjustment_created`
+- `adjustment_approved`
+- `adjustment_rejected`
+- `adjustment_applied`
+- `adjustment_cancelled`
+- `salary_cap_set`
+
+Audit records include the actor, action, optional adjustment id, optional employee, optional amount, optional reason hash, and ledger timestamp. There is no update or delete entrypoint for audit records.
 
 ## Test Coverage
 
-35 tests covering:
+49 tests covering:
 
 - Initialization (one-time guard, owner stored)
 - Double-init and pre-init panics
 - Create: increase, decrease, timestamps, id increment
-- Create validations: zero salary, same salary, retroactive date, cap exceeded
+- Create validations: zero salary, same salary, retroactive date, cap exceeded, conflicting effective dates
+- Retroactive authorization: default block, owner authorization, non-owner rejection, non-zero reason hash, domain-separated immutable reason storage
 - Cap: default, set, boundary (`new_salary == cap`), cap tightened
 - Approve: status change, wrong approver, double-approve, approve-after-reject
 - Reject: status change, wrong approver, reject-after-approve
 - Apply: happy path, exact effective date, before effective date, unapproved, wrong employer
 - Cancel: pending, rejected-then-cancel, approved blocked, applied blocked, wrong employer
 - Payroll visibility: `None` before apply, correct value after apply, tracks latest, independent per employee
+- Audit visibility: audit count, audit entry fields, audit reason linkage
 - Query: nonexistent adjustment, get_owner
 
 ## Invariants
 
 1. An adjustment id is never reused.
-2. `effective_date >= created_at` for all stored adjustments.
-3. `new_salary <= salary_cap` for all stored adjustments.
-4. `EmployeeSalary(employee)` reflects the `new_salary` of the most recently applied adjustment.
-5. Only `Pending` and `Rejected` adjustments can be cancelled.
-6. Only `Approved` adjustments can be applied.
-7. Status transitions are one-way and irreversible (no rollback).
+2. `effective_date >= created_at` for standard adjustments.
+3. Retroactive adjustments must store `retroactive = true`, owner approval, and a domain-separated `reason_hash`.
+4. `new_salary <= salary_cap` for all stored adjustments.
+5. `EmployeeSalary(employee)` reflects the `new_salary` of the most recently applied adjustment.
+6. Only `Pending` and `Rejected` adjustments can be cancelled.
+7. Only `Approved` adjustments can be applied.
+8. Status transitions are one-way and irreversible (no rollback).
+9. Audit log IDs are monotonic and records are append-only.
+10. One employee/effective-date pair cannot be reused for conflicting unresolved adjustments.
 
 ## Security Considerations
 
-- **Retroactive abuse**: `effective_date < now` is rejected at creation, preventing backdated salary increases that could exploit prior payroll periods.
+- **Retroactive abuse**: `create_adjustment` rejects `effective_date < now`, preventing accidental or unauthorized backdated salary changes. Retroactive changes must use `create_retroactive_adjustment`, which requires both owner and employer auth plus a non-zero reason hash.
+- **Reason privacy and integrity**: The raw HR reason is never stored. The contract stores a domain-separated SHA-256 commitment bound to the owner, employer, employee, salaries, and effective date, so the reason cannot be replayed across unrelated adjustments without changing the stored hash.
+- **Auditability**: All successful state changes write append-only audit entries that can be queried by id and correlated with events.
+- **Conflicts**: Duplicate adjustments for the same employee and effective timestamp are rejected to prevent ambiguous payroll interpretation.
 - **Cap bypass**: Cap is read fresh on each `create_adjustment` call, so lowering the cap immediately restricts new requests.
 - **Approver identity**: The approver is stored per-adjustment at creation. A global admin change does not affect outstanding adjustments.
 - **Auth checks**: All state-mutating methods call `require_auth()` on the acting address before any reads or writes.

--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -1177,6 +1177,8 @@ version = "0.0.0"
 dependencies = [
  "bonus_system",
  "dispute_escalation",
+ "employee_roles",
+ "governance",
  "payment_history",
  "payment_retry",
  "payment_scheduler",
@@ -1184,6 +1186,7 @@ dependencies = [
  "rbac",
  "soroban-sdk",
  "stello_pay_contract",
+ "token_vesting",
  "withdrawal_timelock",
 ]
 

--- a/onchain/contracts/payment_scheduler/src/lib.rs
+++ b/onchain/contracts/payment_scheduler/src/lib.rs
@@ -125,12 +125,12 @@ pub struct RetryConfig {
     pub retry_intervals: Vec<u64>,
 }
 
-pub struct RetryContractClient<'a> {
+pub struct RetryContractClient {
     pub env: Env,
     pub contract_id: Address,
 }
 
-impl<'a> RetryContractClient<'a> {
+impl RetryContractClient {
     pub fn new(env: &Env, contract_id: &Address) -> Self {
         Self {
             env: env.clone(),

--- a/onchain/contracts/salary_adjustment/src/lib.rs
+++ b/onchain/contracts/salary_adjustment/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol,
+};
 
 // ============================================================================
 // CONTRACT STRUCT
@@ -43,6 +45,22 @@ pub struct SalaryAdjustment {
     pub new_salary: i128,
     pub effective_date: u64,
     pub created_at: u64,
+    pub retroactive: bool,
+    pub retroactive_approved_by: Option<Address>,
+    pub reason_hash: Option<BytesN<32>>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SalaryAdjustmentAuditEntry {
+    pub id: u128,
+    pub adjustment_id: Option<u128>,
+    pub actor: Address,
+    pub action: Symbol,
+    pub employee: Option<Address>,
+    pub amount: Option<i128>,
+    pub reason_hash: Option<BytesN<32>>,
+    pub timestamp: u64,
 }
 
 // ============================================================================
@@ -60,6 +78,12 @@ enum StorageKey {
     SalaryCap,
     /// Tracks the last applied salary per employee for payroll visibility.
     EmployeeSalary(Address),
+    /// Monotonic audit id for append-only salary adjustment audit records.
+    NextAuditLogId,
+    /// Append-only audit record keyed by id.
+    AuditLog(u128),
+    /// Prevents conflicting unresolved adjustments for the same employee/effective timestamp.
+    EmployeeEffectiveAdjustment(Address, u64),
 }
 
 // ============================================================================
@@ -76,6 +100,8 @@ pub struct AdjustmentCreatedEvent {
     pub current_salary: i128,
     pub new_salary: i128,
     pub effective_date: u64,
+    pub retroactive: bool,
+    pub reason_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]
@@ -115,6 +141,18 @@ pub struct SalaryCapSetEvent {
     pub cap: i128,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdjustmentAuditEvent {
+    pub audit_id: u128,
+    pub adjustment_id: Option<u128>,
+    pub actor: Address,
+    pub action: Symbol,
+    pub employee: Option<Address>,
+    pub amount: Option<i128>,
+    pub reason_hash: Option<BytesN<32>>,
+}
+
 // ============================================================================
 // CONSTANTS
 // ============================================================================
@@ -122,6 +160,8 @@ pub struct SalaryCapSetEvent {
 /// Default maximum allowable salary (1 trillion stroops) used when no
 /// explicit cap has been configured by the owner.
 pub const DEFAULT_MAX_SALARY: i128 = 1_000_000_000_000;
+
+const RETRO_REASON_DOMAIN: &[u8] = b"salary_adjustment:retroactive:v1";
 
 // ============================================================================
 // INTERNAL HELPERS
@@ -162,12 +202,217 @@ fn next_adjustment_id(env: &Env) -> u128 {
     next
 }
 
+fn next_audit_id(env: &Env) -> u128 {
+    let current = env
+        .storage()
+        .persistent()
+        .get::<_, u128>(&StorageKey::NextAuditLogId)
+        .unwrap_or(0);
+    let next = current.checked_add(1).expect("Audit id overflow");
+    env.storage()
+        .persistent()
+        .set(&StorageKey::NextAuditLogId, &next);
+    next
+}
+
 /// Returns the configured salary cap, falling back to DEFAULT_MAX_SALARY.
 fn effective_salary_cap(env: &Env) -> i128 {
     env.storage()
         .persistent()
         .get::<_, i128>(&StorageKey::SalaryCap)
         .unwrap_or(DEFAULT_MAX_SALARY)
+}
+
+fn domain_separated_reason_hash(
+    env: &Env,
+    admin: &Address,
+    employer: &Address,
+    employee: &Address,
+    current_salary: i128,
+    new_salary: i128,
+    effective_date: u64,
+    reason_hash: &BytesN<32>,
+) -> BytesN<32> {
+    let mut bytes = Bytes::new(env);
+    for byte in RETRO_REASON_DOMAIN.iter() {
+        bytes.push_back(*byte);
+    }
+    bytes.append(&admin.clone().to_xdr(env));
+    bytes.append(&employer.clone().to_xdr(env));
+    bytes.append(&employee.clone().to_xdr(env));
+    for byte in current_salary.to_le_bytes().iter() {
+        bytes.push_back(*byte);
+    }
+    for byte in new_salary.to_le_bytes().iter() {
+        bytes.push_back(*byte);
+    }
+    for byte in effective_date.to_le_bytes().iter() {
+        bytes.push_back(*byte);
+    }
+    bytes.append(&reason_hash.clone().to_xdr(env));
+    env.crypto().sha256(&bytes).into()
+}
+
+fn assert_adjustment_inputs(
+    env: &Env,
+    current_salary: i128,
+    new_salary: i128,
+    effective_date: u64,
+    allow_retroactive: bool,
+) {
+    assert!(current_salary > 0, "Current salary must be positive");
+    assert!(new_salary > 0, "New salary must be positive");
+    assert!(
+        new_salary != current_salary,
+        "New salary must differ from current salary"
+    );
+
+    let cap = effective_salary_cap(env);
+    assert!(new_salary <= cap, "New salary exceeds salary cap");
+
+    let now = env.ledger().timestamp();
+    if !allow_retroactive {
+        assert!(
+            effective_date >= now,
+            "Effective date cannot be in the past"
+        );
+    }
+}
+
+fn assert_no_conflicting_adjustment(env: &Env, employee: &Address, effective_date: u64) {
+    let existing =
+        env.storage()
+            .persistent()
+            .get::<_, u128>(&StorageKey::EmployeeEffectiveAdjustment(
+                employee.clone(),
+                effective_date,
+            ));
+    assert!(existing.is_none(), "Conflicting adjustment exists");
+}
+
+fn reserve_adjustment_slot(
+    env: &Env,
+    employee: &Address,
+    effective_date: u64,
+    adjustment_id: u128,
+) {
+    env.storage().persistent().set(
+        &StorageKey::EmployeeEffectiveAdjustment(employee.clone(), effective_date),
+        &adjustment_id,
+    );
+}
+
+fn append_audit(
+    env: &Env,
+    actor: Address,
+    action: Symbol,
+    adjustment_id: Option<u128>,
+    employee: Option<Address>,
+    amount: Option<i128>,
+    reason_hash: Option<BytesN<32>>,
+) -> u128 {
+    let audit_id = next_audit_id(env);
+    let entry = SalaryAdjustmentAuditEntry {
+        id: audit_id,
+        adjustment_id,
+        actor: actor.clone(),
+        action: action.clone(),
+        employee: employee.clone(),
+        amount,
+        reason_hash: reason_hash.clone(),
+        timestamp: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&StorageKey::AuditLog(audit_id), &entry);
+    env.events().publish(
+        ("salary_adjustment_audit", audit_id),
+        AdjustmentAuditEvent {
+            audit_id,
+            adjustment_id,
+            actor,
+            action,
+            employee,
+            amount,
+            reason_hash,
+        },
+    );
+    audit_id
+}
+
+fn create_adjustment_internal(
+    env: &Env,
+    employer: Address,
+    employee: Address,
+    approver: Address,
+    current_salary: i128,
+    new_salary: i128,
+    effective_date: u64,
+    retroactive_approved_by: Option<Address>,
+    reason_hash: Option<BytesN<32>>,
+) -> u128 {
+    let retroactive = effective_date < env.ledger().timestamp();
+    assert_adjustment_inputs(
+        env,
+        current_salary,
+        new_salary,
+        effective_date,
+        retroactive_approved_by.is_some(),
+    );
+    assert_no_conflicting_adjustment(env, &employee, effective_date);
+
+    let kind = if new_salary > current_salary {
+        AdjustmentKind::Increase
+    } else {
+        AdjustmentKind::Decrease
+    };
+
+    let adjustment_id = next_adjustment_id(env);
+
+    let adjustment = SalaryAdjustment {
+        id: adjustment_id,
+        employer: employer.clone(),
+        employee: employee.clone(),
+        approver: approver.clone(),
+        kind: kind.clone(),
+        status: AdjustmentStatus::Pending,
+        current_salary,
+        new_salary,
+        effective_date,
+        created_at: env.ledger().timestamp(),
+        retroactive,
+        retroactive_approved_by,
+        reason_hash: reason_hash.clone(),
+    };
+
+    write_adjustment(env, &adjustment);
+    reserve_adjustment_slot(env, &employee, effective_date, adjustment_id);
+    env.events().publish(
+        ("adjustment_created", adjustment_id),
+        AdjustmentCreatedEvent {
+            adjustment_id,
+            employer: employer.clone(),
+            employee: employee.clone(),
+            kind,
+            current_salary,
+            new_salary,
+            effective_date,
+            retroactive,
+            reason_hash: reason_hash.clone(),
+        },
+    );
+    append_audit(
+        env,
+        employer,
+        Symbol::new(env, "adjustment_created"),
+        Some(adjustment_id),
+        Some(employee),
+        Some(new_salary),
+        reason_hash,
+    );
+
+    adjustment_id
 }
 
 // ============================================================================
@@ -217,12 +462,24 @@ impl SalaryAdjustmentContract {
         assert!(owner == stored_owner, "Only owner can set salary cap");
         assert!(cap > 0, "Salary cap must be positive");
 
-        env.storage()
-            .persistent()
-            .set(&StorageKey::SalaryCap, &cap);
+        env.storage().persistent().set(&StorageKey::SalaryCap, &cap);
 
-        env.events()
-            .publish(("salary_cap_set", cap), SalaryCapSetEvent { owner, cap });
+        env.events().publish(
+            ("salary_cap_set", cap),
+            SalaryCapSetEvent {
+                owner: owner.clone(),
+                cap,
+            },
+        );
+        append_audit(
+            &env,
+            owner,
+            Symbol::new(&env, "salary_cap_set"),
+            None,
+            None,
+            Some(cap),
+            None,
+        );
     }
 
     /// @notice Creates a salary adjustment request.
@@ -259,58 +516,81 @@ impl SalaryAdjustmentContract {
     ) -> u128 {
         require_initialized(&env);
         employer.require_auth();
-        assert!(current_salary > 0, "Current salary must be positive");
-        assert!(new_salary > 0, "New salary must be positive");
-        assert!(
-            new_salary != current_salary,
-            "New salary must differ from current salary"
-        );
-
-        let cap = effective_salary_cap(&env);
-        assert!(new_salary <= cap, "New salary exceeds salary cap");
-
-        let now = env.ledger().timestamp();
-        assert!(
-            effective_date >= now,
-            "Effective date cannot be in the past"
-        );
-
-        let kind = if new_salary > current_salary {
-            AdjustmentKind::Increase
-        } else {
-            AdjustmentKind::Decrease
-        };
-
-        let adjustment_id = next_adjustment_id(&env);
-
-        let adjustment = SalaryAdjustment {
-            id: adjustment_id,
-            employer: employer.clone(),
-            employee: employee.clone(),
-            approver: approver.clone(),
-            kind: kind.clone(),
-            status: AdjustmentStatus::Pending,
+        create_adjustment_internal(
+            &env,
+            employer,
+            employee,
+            approver,
             current_salary,
             new_salary,
             effective_date,
-            created_at: now,
-        };
+            None,
+            None,
+        )
+    }
 
-        write_adjustment(&env, &adjustment);
-        env.events().publish(
-            ("adjustment_created", adjustment_id),
-            AdjustmentCreatedEvent {
-                adjustment_id,
-                employer,
-                employee,
-                kind,
-                current_salary,
-                new_salary,
-                effective_date,
-            },
+    /// @notice Creates a retroactive salary adjustment with explicit owner approval.
+    /// @dev Requires both the employer and contract owner to authenticate. The provided
+    ///      reason hash is domain-separated with the adjustment details before storage.
+    ///
+    /// # Panics
+    /// * `"Only owner can authorize retroactive adjustment"`
+    /// * `"Retroactive reason hash required"`
+    /// * Standard create validation panics.
+    pub fn create_retroactive_adjustment(
+        env: Env,
+        owner: Address,
+        employer: Address,
+        employee: Address,
+        approver: Address,
+        current_salary: i128,
+        new_salary: i128,
+        effective_date: u64,
+        reason_hash: BytesN<32>,
+    ) -> u128 {
+        require_initialized(&env);
+        owner.require_auth();
+        employer.require_auth();
+
+        let stored_owner: Address = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::Owner)
+            .expect("Owner not set");
+        assert!(
+            owner == stored_owner,
+            "Only owner can authorize retroactive adjustment"
+        );
+        assert!(
+            effective_date < env.ledger().timestamp(),
+            "Use create_adjustment for forward adjustments"
         );
 
-        adjustment_id
+        let zero = BytesN::from_array(&env, &[0; 32]);
+        assert!(reason_hash != zero, "Retroactive reason hash required");
+
+        let stored_reason_hash = domain_separated_reason_hash(
+            &env,
+            &owner,
+            &employer,
+            &employee,
+            current_salary,
+            new_salary,
+            effective_date,
+            &reason_hash,
+        );
+
+        create_adjustment_internal(
+            &env,
+            employer,
+            employee,
+            approver,
+            current_salary,
+            new_salary,
+            effective_date,
+            Some(owner),
+            Some(stored_reason_hash),
+        )
     }
 
     /// @notice Approves a pending salary adjustment.
@@ -343,8 +623,17 @@ impl SalaryAdjustmentContract {
             ("adjustment_approved", adjustment_id),
             AdjustmentApprovedEvent {
                 adjustment_id,
-                approver,
+                approver: approver.clone(),
             },
+        );
+        append_audit(
+            &env,
+            approver,
+            Symbol::new(&env, "adjustment_approved"),
+            Some(adjustment_id),
+            Some(adjustment.employee),
+            Some(adjustment.new_salary),
+            adjustment.reason_hash,
         );
     }
 
@@ -378,8 +667,17 @@ impl SalaryAdjustmentContract {
             ("adjustment_rejected", adjustment_id),
             AdjustmentRejectedEvent {
                 adjustment_id,
-                approver,
+                approver: approver.clone(),
             },
+        );
+        append_audit(
+            &env,
+            approver,
+            Symbol::new(&env, "adjustment_rejected"),
+            Some(adjustment_id),
+            Some(adjustment.employee),
+            Some(adjustment.new_salary),
+            adjustment.reason_hash,
         );
     }
 
@@ -419,9 +717,10 @@ impl SalaryAdjustmentContract {
         write_adjustment(&env, &adjustment);
 
         // Update tracked salary so payroll claiming logic can read the latest effective salary.
-        env.storage()
-            .persistent()
-            .set(&StorageKey::EmployeeSalary(adjustment.employee.clone()), &adjustment.new_salary);
+        env.storage().persistent().set(
+            &StorageKey::EmployeeSalary(adjustment.employee.clone()),
+            &adjustment.new_salary,
+        );
 
         env.events().publish(
             ("adjustment_applied", adjustment_id),
@@ -430,6 +729,15 @@ impl SalaryAdjustmentContract {
                 employee: adjustment.employee.clone(),
                 new_salary: adjustment.new_salary,
             },
+        );
+        append_audit(
+            &env,
+            employer,
+            Symbol::new(&env, "adjustment_applied"),
+            Some(adjustment_id),
+            Some(adjustment.employee),
+            Some(adjustment.new_salary),
+            adjustment.reason_hash,
         );
     }
 
@@ -464,8 +772,17 @@ impl SalaryAdjustmentContract {
             ("adjustment_cancelled", adjustment_id),
             AdjustmentCancelledEvent {
                 adjustment_id,
-                employer,
+                employer: employer.clone(),
             },
+        );
+        append_audit(
+            &env,
+            employer,
+            Symbol::new(&env, "adjustment_cancelled"),
+            Some(adjustment_id),
+            Some(adjustment.employee),
+            Some(adjustment.new_salary),
+            adjustment.reason_hash,
         );
     }
 
@@ -501,5 +818,21 @@ impl SalaryAdjustmentContract {
         env.storage()
             .persistent()
             .get(&StorageKey::EmployeeSalary(employee))
+    }
+
+    /// @notice Returns an append-only audit record by id.
+    /// @param audit_id Audit record identifier.
+    pub fn get_audit_log(env: Env, audit_id: u128) -> Option<SalaryAdjustmentAuditEntry> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::AuditLog(audit_id))
+    }
+
+    /// @notice Returns the number of audit records written so far.
+    pub fn get_audit_log_count(env: Env) -> u128 {
+        env.storage()
+            .persistent()
+            .get::<_, u128>(&StorageKey::NextAuditLogId)
+            .unwrap_or(0)
     }
 }

--- a/onchain/contracts/salary_adjustment/tests/test_adjustment.rs
+++ b/onchain/contracts/salary_adjustment/tests/test_adjustment.rs
@@ -6,7 +6,7 @@ use salary_adjustment::{
     DEFAULT_MAX_SALARY,
 };
 use soroban_sdk::testutils::{Address as _, Ledger};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, BytesN, Env, Symbol};
 
 // ============================================================================
 // TEST HELPERS
@@ -27,6 +27,12 @@ fn set_time(env: &Env, timestamp: u64) {
     env.ledger().with_mut(|ledger| {
         ledger.timestamp = timestamp;
     });
+}
+
+fn reason_hash(env: &Env, marker: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = marker;
+    BytesN::from_array(env, &bytes)
 }
 
 // ============================================================================
@@ -234,6 +240,161 @@ fn test_effective_date_equals_current_time_allowed() {
     assert!(client.get_adjustment(&id).is_some());
 }
 
+#[test]
+fn test_retroactive_adjustment_blocked_by_default() {
+    let env = create_env();
+    set_time(&env, 1_000);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+
+    client.initialize(&owner);
+
+    let result =
+        client.try_create_adjustment(&employer, &employee, &approver, &5_000, &6_000, &999);
+    assert!(result.is_err());
+    assert_eq!(client.get_audit_log_count(), 0);
+}
+
+#[test]
+fn test_authorized_retroactive_adjustment_works_and_is_logged() {
+    let env = create_env();
+    set_time(&env, 1_000);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let raw_reason_hash = reason_hash(&env, 7);
+
+    client.initialize(&owner);
+
+    let id = client.create_retroactive_adjustment(
+        &owner,
+        &employer,
+        &employee,
+        &approver,
+        &5_000,
+        &6_000,
+        &500,
+        &raw_reason_hash,
+    );
+
+    let stored = client.get_adjustment(&id).unwrap();
+    assert!(stored.retroactive);
+    assert_eq!(stored.retroactive_approved_by, Some(owner.clone()));
+    assert!(stored.reason_hash.is_some());
+    assert_ne!(stored.reason_hash.clone().unwrap(), raw_reason_hash);
+    assert_eq!(stored.created_at, 1_000);
+    assert_eq!(stored.effective_date, 500);
+
+    assert_eq!(client.get_audit_log_count(), 1);
+    let audit = client.get_audit_log(&1).unwrap();
+    assert_eq!(audit.adjustment_id, Some(id));
+    assert_eq!(audit.actor, employer.clone());
+    assert_eq!(audit.action, Symbol::new(&env, "adjustment_created"));
+    assert_eq!(audit.employee, Some(employee.clone()));
+    assert_eq!(audit.amount, Some(6_000));
+    assert_eq!(audit.reason_hash, stored.reason_hash.clone());
+
+    client.approve_adjustment(&approver, &id);
+    client.apply_adjustment(&employer, &id);
+
+    let applied = client.get_adjustment(&id).unwrap();
+    assert_eq!(applied.status, AdjustmentStatus::Applied);
+    assert_eq!(applied.reason_hash, stored.reason_hash);
+    assert_eq!(client.get_employee_salary(&employee), Some(6_000));
+    assert_eq!(client.get_audit_log_count(), 3);
+}
+
+#[test]
+fn test_non_owner_cannot_authorize_retroactive_adjustment() {
+    let env = create_env();
+    set_time(&env, 1_000);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+
+    client.initialize(&owner);
+
+    let result = client.try_create_retroactive_adjustment(
+        &attacker,
+        &employer,
+        &employee,
+        &approver,
+        &5_000,
+        &6_000,
+        &500,
+        &reason_hash(&env, 8),
+    );
+    assert!(result.is_err());
+    assert_eq!(client.get_audit_log_count(), 0);
+}
+
+#[test]
+fn test_zero_retroactive_reason_hash_rejected() {
+    let env = create_env();
+    set_time(&env, 1_000);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let zero_hash = BytesN::from_array(&env, &[0; 32]);
+
+    client.initialize(&owner);
+
+    let result = client.try_create_retroactive_adjustment(
+        &owner, &employer, &employee, &approver, &5_000, &6_000, &500, &zero_hash,
+    );
+    assert!(result.is_err());
+    assert_eq!(client.get_audit_log_count(), 0);
+}
+
+#[test]
+fn test_conflicting_same_employee_effective_date_rejected() {
+    let env = create_env();
+    set_time(&env, 100);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+
+    client.initialize(&owner);
+
+    let first = client.create_adjustment(&employer, &employee, &approver, &5_000, &6_000, &200);
+    assert_eq!(first, 1);
+
+    let result =
+        client.try_create_adjustment(&employer, &employee, &approver, &6_000, &7_000, &200);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_same_employee_distinct_effective_dates_allowed() {
+    let env = create_env();
+    set_time(&env, 100);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+
+    client.initialize(&owner);
+
+    let first = client.create_adjustment(&employer, &employee, &approver, &5_000, &6_000, &200);
+    let second = client.create_adjustment(&employer, &employee, &approver, &6_000, &7_000, &201);
+
+    assert_eq!(second, first + 1);
+    assert_eq!(client.get_audit_log_count(), 2);
+}
+
 // ============================================================================
 // SALARY CAP TESTS
 // ============================================================================
@@ -352,7 +513,8 @@ fn test_updated_cap_is_respected() {
     client.set_salary_cap(&owner, &12_000);
 
     // 15_000 now exceeds new cap — must fail
-    let result = client.try_create_adjustment(&employer, &employee, &approver, &5_000, &15_000, &200);
+    let result =
+        client.try_create_adjustment(&employer, &employee, &approver, &5_000, &15_000, &200);
     assert!(result.is_err());
 }
 

--- a/onchain/integration_tests/Cargo.toml
+++ b/onchain/integration_tests/Cargo.toml
@@ -10,9 +10,12 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }
 stello_pay_contract = { path = "../contracts/stello_pay_contract" }
+token_vesting = { path = "../contracts/token_vesting" }
 payroll_escrow = { path = "../contracts/payroll_escrow" }
 bonus_system = { path = "../contracts/bonus_system" }
 payment_history = { path = "../contracts/payment_history" }
+payment_retry = { path = "../contracts/payment_retry" }
+payment_scheduler = { path = "../contracts/payment_scheduler" }
 dispute_escalation = { path = "../contracts/dispute_escalation" }
 employee_roles = { path = "../contracts/employee_roles" }
 rbac = { path = "../contracts/rbac" }

--- a/onchain/integration_tests/tests/test_retry_orchestration.rs
+++ b/onchain/integration_tests/tests/test_retry_orchestration.rs
@@ -3,11 +3,11 @@
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, BytesN, Env,
+    Address, Env,
 };
 
-use payment_scheduler::{PaymentSchedulerContract, PaymentSchedulerContractClient};
 use payment_retry::{PaymentRetryContract, PaymentRetryContractClient, RetryState};
+use payment_scheduler::{PaymentSchedulerContract, PaymentSchedulerContractClient};
 
 fn env() -> Env {
     let e = Env::default();
@@ -24,14 +24,18 @@ fn token(env: &Env) -> Address {
     env.register_stellar_asset_contract_v2(admin).address()
 }
 
-fn deploy_scheduler(env: &Env, owner: &Address, retry_addr: &Address) -> (Address, PaymentSchedulerContractClient<'_>) {
+fn deploy_scheduler<'a>(
+    env: &'a Env,
+    owner: &Address,
+    retry_addr: &Address,
+) -> (Address, PaymentSchedulerContractClient<'a>) {
     let id = env.register_contract(None, PaymentSchedulerContract);
     let client = PaymentSchedulerContractClient::new(env, &id);
     client.initialize(owner, retry_addr);
     (id, client)
 }
 
-fn deploy_retry(env: &Env, owner: &Address) -> (Address, PaymentRetryContractClient<'_>) {
+fn deploy_retry<'a>(env: &'a Env, owner: &Address) -> (Address, PaymentRetryContractClient<'a>) {
     let id = env.register_contract(None, PaymentRetryContract);
     let client = PaymentRetryContractClient::new(env, &id);
     client.initialize(owner);
@@ -59,7 +63,7 @@ fn test_retry_orchestration_e2e() {
 
     let amount = 1000i128;
     let start_time = env.ledger().timestamp();
-    
+
     // 1. Create Job
     let _job_id = sched_client.create_job(
         &employer,
@@ -79,12 +83,16 @@ fn test_retry_orchestration_e2e() {
     let payment_id = {
         use soroban_sdk::xdr::ToXdr;
         let mut buf = soroban_sdk::Bytes::new(&env);
-        buf.append(&employer.to_xdr(&env));
-        buf.append(&recipient.to_xdr(&env));
+        buf.append(&employer.clone().to_xdr(&env));
+        buf.append(&recipient.clone().to_xdr(&env));
         let amount_bytes = amount.to_le_bytes();
-        for b in amount_bytes.iter() { buf.push_back(*b); }
+        for b in amount_bytes.iter() {
+            buf.push_back(*b);
+        }
         let time_bytes = start_time.to_le_bytes();
-        for b in time_bytes.iter() { buf.push_back(*b); }
+        for b in time_bytes.iter() {
+            buf.push_back(*b);
+        }
         env.crypto().sha256(&buf).into()
     };
 
@@ -106,7 +114,7 @@ fn test_retry_orchestration_e2e() {
     retry_client.process_retry(&payment_id);
     let payment = retry_client.get_payment(&payment_id).unwrap();
     assert_eq!(payment.state, RetryState::Success);
-    
+
     // 7. Verify recipient balance
     let bal = TokenClient::new(&env, &tok_addr).balance(&recipient);
     assert_eq!(bal, amount);
@@ -130,29 +138,48 @@ fn test_retry_orchestration_max_retries() {
 
     let amount = 1000i128;
     let start_time = env.ledger().timestamp();
-    
-    sched_client.create_job(&employer, &recipient, &tok_addr, &amount, &3600, &start_time, &Some(1), &1); // max_retries = 1
+
+    sched_client.create_job(
+        &employer,
+        &recipient,
+        &tok_addr,
+        &amount,
+        &3600,
+        &start_time,
+        &Some(1),
+        &1,
+    ); // max_retries = 1
 
     sched_client.process_due_payments(&1);
 
     let payment_id = {
         use soroban_sdk::xdr::ToXdr;
         let mut buf = soroban_sdk::Bytes::new(&env);
-        buf.append(&employer.to_xdr(&env));
-        buf.append(&recipient.to_xdr(&env));
+        buf.append(&employer.clone().to_xdr(&env));
+        buf.append(&recipient.clone().to_xdr(&env));
         let amount_bytes = amount.to_le_bytes();
-        for b in amount_bytes.iter() { buf.push_back(*b); }
+        for b in amount_bytes.iter() {
+            buf.push_back(*b);
+        }
         let time_bytes = start_time.to_le_bytes();
-        for b in time_bytes.iter() { buf.push_back(*b); }
+        for b in time_bytes.iter() {
+            buf.push_back(*b);
+        }
         env.crypto().sha256(&buf).into()
     };
 
     // Attempt 1
     retry_client.process_retry(&payment_id);
-    assert_eq!(retry_client.get_payment(&payment_id).unwrap().state, RetryState::Retrying);
+    assert_eq!(
+        retry_client.get_payment(&payment_id).unwrap().state,
+        RetryState::Retrying
+    );
 
     // Attempt 2 -> Exceeds max_retries (1)
     advance(&env, 120);
     retry_client.process_retry(&payment_id);
-    assert_eq!(retry_client.get_payment(&payment_id).unwrap().state, RetryState::Failed);
+    assert_eq!(
+        retry_client.get_payment(&payment_id).unwrap().state,
+        RetryState::Failed
+    );
 }

--- a/onchain/integration_tests/tests/test_token_vesting_payroll_integration.rs
+++ b/onchain/integration_tests/tests/test_token_vesting_payroll_integration.rs
@@ -1,0 +1,317 @@
+//! Cross-contract integration coverage for payroll lifecycle orchestration and
+//! token vesting schedules.
+//!
+//! These tests intentionally use the generated clients for both contracts and a
+//! shared SAC token. The current contracts do not call each other directly, so
+//! the integration boundary is the off-chain workflow that binds one payroll
+//! agreement to one vesting schedule for the same employer/employee pair.
+
+#![cfg(test)]
+#![allow(deprecated)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+use stello_pay_contract::storage::{AgreementStatus, DataKey, DisputeStatus};
+use stello_pay_contract::{PayrollContract, PayrollContractClient};
+use token_vesting::{TokenVestingContract, TokenVestingContractClient, VestingStatus};
+
+const ONE_DAY: u64 = 86_400;
+const ONE_WEEK: u64 = 604_800;
+const SALARY_PER_DAY: i128 = 1_000;
+const PAYROLL_FUND: i128 = 20_000;
+const VESTING_GRANT: i128 = 12_000;
+const EMPLOYER_FLOAT: i128 = 100_000;
+
+struct PayrollDeployment<'a> {
+    id: Address,
+    client: PayrollContractClient<'a>,
+}
+
+struct VestingDeployment<'a> {
+    id: Address,
+    owner: Address,
+    client: TokenVestingContractClient<'a>,
+}
+
+fn env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn addr(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn set_time(env: &Env, timestamp: u64) {
+    env.ledger().with_mut(|li| li.timestamp = timestamp);
+}
+
+fn advance(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|li| li.timestamp += seconds);
+}
+
+fn token(env: &Env) -> Address {
+    let admin = addr(env);
+    env.register_stellar_asset_contract_v2(admin).address()
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn transfer(env: &Env, token: &Address, from: &Address, to: &Address, amount: i128) {
+    TokenClient::new(env, token).transfer(from, to, &amount);
+}
+
+fn balance(env: &Env, token: &Address, address: &Address) -> i128 {
+    TokenClient::new(env, token).balance(address)
+}
+
+fn deploy_payroll(env: &Env) -> PayrollDeployment<'_> {
+    let id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(env, &id);
+    let owner = addr(env);
+    client.initialize(&owner);
+    PayrollDeployment { id, client }
+}
+
+fn deploy_vesting(env: &Env) -> VestingDeployment<'_> {
+    let id = env.register_contract(None, TokenVestingContract);
+    let client = TokenVestingContractClient::new(env, &id);
+    let owner = addr(env);
+    client.initialize(&owner);
+    VestingDeployment { id, owner, client }
+}
+
+fn seed_payroll_funding(
+    env: &Env,
+    payroll_id: &Address,
+    agreement_id: u128,
+    token: &Address,
+    employee: &Address,
+    salary: i128,
+    total_fund: i128,
+) {
+    env.as_contract(payroll_id, || {
+        DataKey::set_agreement_escrow_balance(env, agreement_id, token, total_fund);
+        DataKey::set_agreement_activation_time(env, agreement_id, env.ledger().timestamp());
+        DataKey::set_agreement_period_duration(env, agreement_id, ONE_DAY);
+        DataKey::set_agreement_token(env, agreement_id, token);
+        DataKey::set_employee(env, agreement_id, 0, employee);
+        DataKey::set_employee_salary(env, agreement_id, 0, salary);
+        DataKey::set_employee_claimed_periods(env, agreement_id, 0, 0);
+        DataKey::set_employee_count(env, agreement_id, 1);
+    });
+}
+
+fn create_hired_employee_with_vesting(
+    env: &Env,
+    payroll: &PayrollDeployment<'_>,
+    vesting: &VestingDeployment<'_>,
+    employer: &Address,
+    employee: &Address,
+    token: &Address,
+) -> (u128, u128) {
+    let agreement_id = payroll
+        .client
+        .create_payroll_agreement(employer, token, &ONE_WEEK);
+    payroll
+        .client
+        .add_employee_to_agreement(&agreement_id, employee, &SALARY_PER_DAY);
+    payroll.client.activate_agreement(&agreement_id);
+
+    transfer(env, token, employer, &payroll.id, PAYROLL_FUND);
+    seed_payroll_funding(
+        env,
+        &payroll.id,
+        agreement_id,
+        token,
+        employee,
+        SALARY_PER_DAY,
+        PAYROLL_FUND,
+    );
+
+    let schedule_id = vesting.client.create_linear_schedule(
+        employer,
+        employee,
+        token,
+        &VESTING_GRANT,
+        &env.ledger().timestamp(),
+        &(env.ledger().timestamp() + (ONE_DAY * 12)),
+        &None,
+        &true,
+    );
+
+    (agreement_id, schedule_id)
+}
+
+#[test]
+fn employer_hires_employee_and_employee_claims_payroll_and_vesting_over_time() {
+    let env = env();
+    set_time(&env, 1_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    assert_eq!(balance(&env, &token, &payroll.id), PAYROLL_FUND);
+    assert_eq!(balance(&env, &token, &vesting.id), VESTING_GRANT);
+
+    advance(&env, ONE_DAY * 3);
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    let first_vesting_claim = vesting.client.claim(&employee, &schedule_id);
+
+    assert_eq!(
+        payroll
+            .client
+            .get_employee_claimed_periods(&agreement_id, &0),
+        3
+    );
+    assert_eq!(first_vesting_claim, 3_000);
+    assert_eq!(balance(&env, &token, &employee), 6_000);
+
+    let replay_payroll = payroll
+        .client
+        .try_claim_payroll(&employee, &agreement_id, &0);
+    let replay_vesting = vesting.client.try_claim(&employee, &schedule_id);
+    assert!(replay_payroll.is_err());
+    assert!(replay_vesting.is_err());
+
+    advance(&env, ONE_DAY * 2);
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    let second_vesting_claim = vesting.client.claim(&employee, &schedule_id);
+
+    assert_eq!(
+        payroll
+            .client
+            .get_employee_claimed_periods(&agreement_id, &0),
+        5
+    );
+    assert_eq!(second_vesting_claim, 2_000);
+    assert_eq!(balance(&env, &token, &employee), 10_000);
+}
+
+#[test]
+fn termination_revokes_unvested_tokens_and_freezes_later_vesting_claims() {
+    let env = env();
+    set_time(&env, 7_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    advance(&env, ONE_DAY * 3);
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    assert_eq!(vesting.client.claim(&employee, &schedule_id), 3_000);
+
+    advance(&env, ONE_DAY * 2);
+    payroll.client.cancel_agreement(&agreement_id);
+    let employer_before_revoke = balance(&env, &token, &employer);
+    let refunded = vesting.client.revoke(&employer, &schedule_id);
+
+    assert_eq!(refunded, 7_000);
+    assert_eq!(
+        balance(&env, &token, &employer) - employer_before_revoke,
+        7_000
+    );
+    assert_eq!(
+        payroll.client.get_agreement(&agreement_id).unwrap().status,
+        AgreementStatus::Cancelled
+    );
+    assert!(payroll.client.is_grace_period_active(&agreement_id));
+
+    let frozen_vested_remainder = vesting.client.claim(&employee, &schedule_id);
+    assert_eq!(frozen_vested_remainder, 2_000);
+    assert_eq!(
+        vesting.client.get_schedule(&schedule_id).unwrap().status,
+        VestingStatus::Revoked
+    );
+
+    advance(&env, ONE_DAY * 30);
+    assert_eq!(vesting.client.get_releasable_amount(&schedule_id), 0);
+    assert!(vesting.client.try_claim(&employee, &schedule_id).is_err());
+}
+
+#[test]
+fn admin_early_release_can_follow_payroll_dispute_or_grace_window_decision() {
+    let env = env();
+    set_time(&env, 20_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    let arbiter = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    advance(&env, ONE_DAY);
+    payroll.client.cancel_agreement(&agreement_id);
+    assert!(payroll.client.is_grace_period_active(&agreement_id));
+    payroll.client.raise_dispute(&employee, &agreement_id);
+    assert_eq!(
+        payroll.client.get_dispute_status(&agreement_id),
+        DisputeStatus::Raised
+    );
+    payroll.client.set_arbiter(&employer, &arbiter);
+    payroll
+        .client
+        .resolve_dispute(&arbiter, &agreement_id, &1_000, &0);
+
+    let employee_before = balance(&env, &token, &employee);
+    let early_release = vesting
+        .client
+        .approve_early_release(&vesting.owner, &schedule_id, &2_000);
+
+    assert_eq!(early_release, 2_000);
+    assert_eq!(balance(&env, &token, &employee) - employee_before, 2_000);
+    assert!(vesting
+        .client
+        .try_approve_early_release(&employee, &schedule_id, &1)
+        .is_err());
+}
+
+#[test]
+fn cannot_claim_or_revoke_with_mismatched_parties_across_payroll_and_vesting() {
+    let env = env();
+    set_time(&env, 30_000);
+    let payroll = deploy_payroll(&env);
+    let vesting = deploy_vesting(&env);
+    let token = token(&env);
+    let employer = addr(&env);
+    let employee = addr(&env);
+    let stranger = addr(&env);
+    mint(&env, &token, &employer, EMPLOYER_FLOAT);
+
+    let (agreement_id, schedule_id) =
+        create_hired_employee_with_vesting(&env, &payroll, &vesting, &employer, &employee, &token);
+
+    advance(&env, ONE_DAY * 4);
+
+    assert!(payroll
+        .client
+        .try_claim_payroll(&stranger, &agreement_id, &0)
+        .is_err());
+    assert!(vesting.client.try_claim(&stranger, &schedule_id).is_err());
+    assert!(vesting.client.try_revoke(&stranger, &schedule_id).is_err());
+
+    payroll.client.claim_payroll(&employee, &agreement_id, &0);
+    assert_eq!(vesting.client.claim(&employee, &schedule_id), 4_000);
+}


### PR DESCRIPTION
Closes #410 


This PR Adds explicit safeguards for retroactive salary adjustments and append-only audit logging to support compliance review.

Changes

Keeps standard salary adjustments forward-only by default.
Adds create_retroactive_adjustment requiring owner + employer authorization.
Requires a non-zero reason hash for retroactive edits.
Stores a domain-separated reason commitment bound to immutable adjustment fields.
Emits audit events and stores queryable audit records for all salary adjustment state changes.
Rejects conflicting adjustments for the same employee and effective timestamp.
Updates salary adjustment and audit logging docs.