### PR TITLE
feat: admin-gated upgrade entrypoint with state migration hooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,8 @@ Welcome to the comprehensive documentation for the StellopayCore smart contract 
 5. [Developer Tools](./dev-tools/README.md) - CLI tools and utilities
 6. [Architecture](./architecture/README.md) - System design and architecture
 7. [Migrations](./migrations.md) - Contract upgrade procedures, rollback, and data compatibility
-8. [Building on Windows](./windows-build.md) - Fixing "export ordinal too large" (MinGW) and WASM-only build
+8. [Upgrade & migration strategy](./upgrade-migration-strategy.md) - RBAC-admin-gated upgrades and `migrate_state`
+9. [Building on Windows](./windows-build.md) - Fixing "export ordinal too large" (MinGW) and WASM-only build
 
 ## Quick Start
 

--- a/docs/upgrade-migration-strategy.md
+++ b/docs/upgrade-migration-strategy.md
@@ -1,0 +1,140 @@
+---
+title: Upgrade and Migration Strategy
+---
+
+# Upgrade and Migration Strategy
+
+This page describes the admin-gated upgrade flow for `stello_pay_contract` and how to apply safe, versioned storage migrations before production deployments.
+
+Upgrading a Soroban contract replaces the contract’s WASM while keeping the same contract ID and persistent storage. If the new WASM changes how existing storage keys are interpreted, the contract can silently corrupt existing state unless a migration is applied.
+
+## Preconditions
+
+1. You have a deployed RBAC contract (see [`docs/rbac.md`](./rbac.md)).
+2. The payroll contract has been initialized (owner set).
+3. The payroll contract has been linked to RBAC by the owner:
+
+   - `set_rbac_contract(owner, rbac_contract_id)`
+
+4. The upgrade operator address has the `Admin` role in RBAC.
+
+When RBAC is configured, upgrades and migrations are gated to RBAC Admin. When RBAC is not configured, the contract falls back to owner-only authorization (legacy behavior).
+
+## High-level flow
+
+1. Backup state (pre-upgrade)
+2. Build and install the new WASM (obtain the new WASM hash)
+3. Apply storage migration (if needed)
+4. Perform the upgrade
+5. Verify post-upgrade
+6. Roll back (only if verification fails)
+
+The repository also has a general guide at [`docs/migrations.md`](./migrations.md) and helper scripts under `scripts/migrations/`.
+
+## Storage versioning
+
+`stello_pay_contract` maintains a persistent `ContractVersion` value.
+
+- Legacy deployments start at version `0` (unset means `0`).
+- `migrate_state(from_version)` requires `from_version` to match the currently stored version.
+- A migration must be monotonic (no downgrades).
+
+## When to add a migration
+
+Add a migration step whenever a new contract version:
+
+- Changes an existing `StorageKey` definition, meaning, or type.
+- Changes any serialized structs/enums that are stored under existing keys.
+- Changes how agreement mode, milestone state, or agreement state machine fields are interpreted.
+
+Additive changes (new keys, new fields stored under new keys) typically do not require migration.
+
+## Rollback
+
+Rollback requires the previous WASM hash for the currently deployed contract.
+
+If verification fails after upgrade:
+
+1. Re-authorize the prior WASM hash.
+2. Re-run `upgrade(previous_wasm_hash)` as RBAC Admin.
+
+See the rollback section in [`docs/migrations.md`](./migrations.md) for CLI/script details.
+
+## Security notes
+
+- The upgrade and migration entrypoints require explicit authorization:
+  - RBAC Admin when RBAC is configured.
+  - Owner when RBAC is not configured.
+- Operators should treat WASM hashes as immutable release artifacts.
+- Always back up state before applying upgrades or migrations.
+
+---
+title: Upgrade and Migration Strategy
+---
+
+# Upgrade and Migration Strategy
+
+This page describes the **admin-gated** upgrade flow for `stello_pay_contract` and how to apply safe, versioned storage migrations before production deployments.
+
+Upgrading a Soroban contract replaces the contract’s WASM while keeping the **same contract ID** and **persistent storage**. If the new WASM changes how existing storage keys are interpreted, the contract can silently corrupt existing state unless a migration is applied.
+
+## Preconditions
+
+1. You have a deployed RBAC contract (see [`docs/rbac.md`](./rbac.md)).
+2. The payroll contract has been initialized (owner set).
+3. The payroll contract has been linked to RBAC by the owner:
+
+   - `set_rbac_contract(owner, rbac_contract_id)`
+
+4. The upgrade operator address has the `Admin` role in RBAC.
+
+When RBAC is configured, upgrades and migrations are gated to **RBAC Admin**. When RBAC is not configured, the contract falls back to **owner-only** authorization (legacy behavior).
+
+## High-level flow
+
+1. Backup state (pre-upgrade)
+2. Build and install the new WASM (obtain the new WASM hash)
+3. Apply storage migration (if needed)
+4. Perform the upgrade
+5. Verify post-upgrade
+6. Roll back (only if verification fails)
+
+The repository also has a general guide at [`docs/migrations.md`](./migrations.md) and helper scripts under `scripts/migrations/`.
+
+## Storage versioning
+
+`stello_pay_contract` maintains a persistent `ContractVersion` value.
+
+- Legacy deployments start at version `0` (unset means `0`).
+- `migrate_state(from_version)` requires `from_version` to match the currently stored version.
+- A migration must be monotonic (no downgrades).
+
+## When to add a migration
+
+Add a migration step whenever a new contract version:
+
+- Changes an existing `StorageKey` definition, meaning, or type.
+- Changes any serialized structs/enums that are stored under existing keys.
+- Changes how agreement mode, milestone state, or agreement state machine fields are interpreted.
+
+Additive changes (new keys, new fields stored under new keys) typically do not require migration.
+
+## Rollback
+
+Rollback requires the **previous WASM hash** for the currently deployed contract.
+
+If verification fails after upgrade:
+
+1. Re-authorize the prior WASM hash.
+2. Re-run `upgrade(previous_wasm_hash)` as RBAC Admin.
+
+See the rollback section in [`docs/migrations.md`](./migrations.md) for CLI/script details.
+
+## Security notes
+
+- The upgrade and migration entrypoints require explicit authorization:
+  - RBAC Admin when RBAC is configured.
+  - Owner when RBAC is not configured.
+- Operators should treat WASM hashes as immutable release artifacts.
+- Always back up state before applying upgrades or migrations.
+

--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "criterion",
  "hmac",
  "proptest",
+ "rbac",
  "sha1",
  "sha2",
  "soroban-sdk",

--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -1681,6 +1681,14 @@ dependencies = [
 name = "rbac"
 version = "0.0.0"
 dependencies = [
+ "rbac-interface",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "rbac-interface"
+version = "0.0.0"
+dependencies = [
  "soroban-sdk",
 ]
 
@@ -2306,6 +2314,7 @@ dependencies = [
  "hmac",
  "proptest",
  "rbac",
+ "rbac-interface",
  "sha1",
  "sha2",
  "soroban-sdk",

--- a/onchain/contracts/rbac-interface/Cargo.toml
+++ b/onchain/contracts/rbac-interface/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rbac-interface"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/onchain/contracts/rbac-interface/src/lib.rs
+++ b/onchain/contracts/rbac-interface/src/lib.rs
@@ -1,0 +1,24 @@
+//! Shared RBAC types and client for cross-contract calls.
+//!
+//! Depend on this crate (rlib only) from other contracts. Deploy the `rbac`
+//! contract crate separately — do not link `rbac` as a cdylib dependency.
+
+#![no_std]
+
+use soroban_sdk::{contractclient, contracttype, Address, Env};
+
+/// Core roles supported by the RBAC contract (must stay in sync with `rbac`).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Role {
+    Admin,
+    Employer,
+    Employee,
+    Arbiter,
+}
+
+/// Client for the deployed RBAC contract (`has_role` and other exports).
+#[contractclient(name = "RbacContractClient")]
+pub trait RbacContractInterface {
+    fn has_role(env: Env, addr: Address, required: Role) -> bool;
+}

--- a/onchain/contracts/rbac/Cargo.toml
+++ b/onchain/contracts/rbac/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]
+rbac-interface = { path = "../rbac-interface" }
 soroban-sdk = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]

--- a/onchain/contracts/rbac/src/lib.rs
+++ b/onchain/contracts/rbac/src/lib.rs
@@ -2,35 +2,7 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Vec};
 
-// ---------------------------------------------------------------------------
-// Roles
-// ---------------------------------------------------------------------------
-
-/// Core roles supported by the RBAC contract.
-///
-/// Roles are intentionally small and composable. Access control for a given
-/// function can be expressed in terms of one or more of these roles.
-///
-/// ## Inheritance
-///
-/// | Granted   | Implies                              |
-/// |-----------|--------------------------------------|
-/// | Admin     | Admin, Employer, Employee, Arbiter   |
-/// | Employer  | Employer, Employee                   |
-/// | Employee  | Employee                             |
-/// | Arbiter   | Arbiter                              |
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Role {
-    /// Global administrator; implicitly has all roles.
-    Admin,
-    /// Employer role; implicitly grants `Employee` permissions.
-    Employer,
-    /// Employee role; base role for payroll participants.
-    Employee,
-    /// Arbiter role; used for dispute resolution flows.
-    Arbiter,
-}
+pub use rbac_interface::Role;
 
 // ---------------------------------------------------------------------------
 // Storage

--- a/onchain/contracts/stello_pay_contract/Cargo.toml
+++ b/onchain/contracts/stello_pay_contract/Cargo.toml
@@ -21,9 +21,10 @@ stellar-access = "0.6.0"
 stellar-contract-utils = "0.6.0"
 stellar-macros = "0.6.0"
 stellar-tokens = "0.6.0"
-rbac = { path = "../rbac" }
+rbac-interface = { path = "../rbac-interface" }
 
 [dev-dependencies]
+rbac = { path = "../rbac" }
 soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }
 proptest = "1.10.0"
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/onchain/contracts/stello_pay_contract/Cargo.toml
+++ b/onchain/contracts/stello_pay_contract/Cargo.toml
@@ -21,6 +21,7 @@ stellar-access = "0.6.0"
 stellar-contract-utils = "0.6.0"
 stellar-macros = "0.6.0"
 stellar-tokens = "0.6.0"
+rbac = { path = "../rbac" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }

--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -94,6 +94,18 @@ pub struct PaymentReceivedEvent {
     pub token: Address,
 }
 
+/// Event: Contract storage migration applied
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ContractMigratedEvent {
+    pub from_version: u32,
+    pub to_version: u32,
+}
+
+pub fn emit_contract_migrated(env: &Env, event: ContractMigratedEvent) {
+    event.publish(env);
+}
+
 pub fn emit_agreement_created(env: &Env, event: AgreementCreatedEvent) {
     event.publish(env);
 }

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -4,7 +4,7 @@ mod payroll;
 pub mod storage;
 
 use events::{emit_contract_migrated, ContractMigratedEvent};
-use rbac::{RbacContractClient, Role};
+use rbac_interface::{RbacContractClient, Role};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
 use storage::{
     Agreement, BatchEscrowCreateResult, BatchMilestoneResult, BatchPayrollCreateResult,

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -3,9 +3,9 @@ pub mod events;
 mod payroll;
 pub mod storage;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
-use stellar_contract_utils::upgradeable::UpgradeableInternal;
-use stellar_macros::Upgradeable;
+use events::{emit_contract_migrated, ContractMigratedEvent};
+use rbac::{RbacContractClient, Role};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
 use storage::{
     Agreement, BatchEscrowCreateResult, BatchMilestoneResult, BatchPayrollCreateResult,
     BatchPayrollResult, DisputeStatus, EscrowCreateParams, GracePeriodExtensionPolicy, Milestone,
@@ -21,22 +21,31 @@ use storage::{
 /// - Employee-initiated payroll claiming based on elapsed time periods
 /// - Secure escrow fund release
 /// - Grace period support for claims
-#[derive(Upgradeable)]
 #[contract]
 pub struct PayrollContract;
 
-/// UpgradeableInternal implementation for PayrollContract
-///
-///
-impl UpgradeableInternal for PayrollContract {
-    fn _require_auth(e: &Env, _operator: &Address) {
-        let owner: Address = e.storage().persistent().get(&StorageKey::Owner).unwrap();
-        owner.require_auth();
-    }
-}
-
 #[contractimpl]
 impl PayrollContract {
+    fn require_upgrade_admin(env: &Env, operator: &Address) {
+        if let Some(rbac_addr) = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&StorageKey::RbacContract)
+        {
+            operator.require_auth();
+            let rbac = RbacContractClient::new(env, &rbac_addr);
+            assert!(
+                rbac.has_role(operator, &Role::Admin),
+                "Missing required role"
+            );
+            return;
+        }
+
+        let owner: Address = env.storage().persistent().get(&StorageKey::Owner).unwrap();
+        operator.require_auth();
+        assert!(*operator == owner, "Unauthorized");
+    }
+
     ///
     /// # Arguments
     ///
@@ -47,7 +56,90 @@ impl PayrollContract {
     /// Requires caller authentication
     pub fn initialize(env: Env, owner: Address) {
         owner.require_auth();
+        if env.storage().persistent().has(&StorageKey::Owner) {
+            panic!("Already initialized");
+        }
         env.storage().persistent().set(&StorageKey::Owner, &owner);
+    }
+
+    /// Sets the linked RBAC contract address used for admin-gated operations (e.g. upgrades).
+    ///
+    /// # Arguments
+    /// * `owner` - owner parameter
+    /// * `rbac_contract` - rbac_contract parameter
+    ///
+    /// # Access Control
+    /// Requires owner authentication
+    pub fn set_rbac_contract(env: Env, owner: Address, rbac_contract: Address) {
+        let stored_owner: Address = env.storage().persistent().get(&StorageKey::Owner).unwrap();
+        owner.require_auth();
+        assert!(owner == stored_owner, "Unauthorized");
+        env.storage()
+            .persistent()
+            .set(&StorageKey::RbacContract, &rbac_contract);
+    }
+
+    /// Upgrades the contract's WASM code to the given hash.
+    ///
+    /// # Arguments
+    /// * `new_wasm_hash` - new_wasm_hash parameter
+    /// * `operator` - operator parameter
+    ///
+    /// # Access Control
+    /// - If RBAC is configured via `set_rbac_contract`, `operator` must have the `Admin` role.
+    /// - Otherwise, `operator` must be the stored contract owner.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, operator: Address) {
+        Self::require_upgrade_admin(&env, &operator);
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
+    /// Migrates persistent storage state from a previous schema version.
+    ///
+    /// # Arguments
+    /// * `operator` - operator parameter
+    /// * `from_version` - from_version parameter
+    ///
+    /// # Access Control
+    /// Requires admin authorization via RBAC when configured (or owner auth when RBAC is unset).
+    pub fn migrate_state(env: Env, operator: Address, from_version: u32) {
+        Self::require_upgrade_admin(&env, &operator);
+
+        let current: u32 = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::ContractVersion)
+            .unwrap_or(0u32);
+        assert!(from_version == current, "Invalid migration version");
+
+        // v0 -> v1: first explicit version marker. No schema changes yet.
+        if from_version == 0 {
+            let next_id: u128 = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::NextAgreementId)
+                .unwrap_or(0u128);
+            let cap: u128 = if next_id > 10 { 10 } else { next_id };
+            let mut i: u128 = 0;
+            while i < cap {
+                let _maybe: Option<Agreement> =
+                    env.storage().persistent().get(&StorageKey::Agreement(i));
+                i += 1;
+            }
+
+            env.storage()
+                .persistent()
+                .set(&StorageKey::ContractVersion, &1u32);
+            emit_contract_migrated(
+                &env,
+                ContractMigratedEvent {
+                    from_version,
+                    to_version: 1,
+                },
+            );
+            return;
+        }
+
+        panic!("Unsupported migration version");
     }
 
     /// Creates a payroll agreement for multiple employees.

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -142,6 +142,10 @@ pub struct EmployeeInfo {
 pub enum StorageKey {
     /// Contract owner
     Owner,
+    /// Linked RBAC contract address (source of truth for Admin authorization).
+    RbacContract,
+    /// Storage schema version for upgrade/migration coordination.
+    ContractVersion,
     /// Agreement by ID
     Agreement(u128),
     /// List of employees for an agreement

--- a/onchain/contracts/stello_pay_contract/tests/upgrade_migration_tests.rs
+++ b/onchain/contracts/stello_pay_contract/tests/upgrade_migration_tests.rs
@@ -1,0 +1,128 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+use stello_pay_contract::{PayrollContract, PayrollContractClient};
+
+use rbac::{RbacContract, RbacContractClient, Role};
+
+const NEW_CONTRACT_WASM: &[u8] = include_bytes!("./stello_pay_contract.wasm");
+
+fn setup(env: &Env) -> (PayrollContractClient<'_>, Address) {
+    let contract_id = env.register(PayrollContract, ());
+    let client = PayrollContractClient::new(env, &contract_id);
+    let owner = Address::generate(env);
+    client.initialize(&owner);
+    (client, owner)
+}
+
+fn deploy_rbac(env: &Env) -> (RbacContractClient<'_>, Address) {
+    let id = env.register_contract(None, RbacContract);
+    let client = RbacContractClient::new(env, &id);
+    let owner = Address::generate(env);
+    client.initialize(&owner);
+    (client, owner)
+}
+
+#[test]
+fn test_upgrade_owner_fallback_when_rbac_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, owner) = setup(&env);
+    let new_wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(NEW_CONTRACT_WASM);
+
+    client.upgrade(&new_wasm_hash, &owner);
+}
+
+#[test]
+#[should_panic]
+fn test_upgrade_rejects_non_owner_when_rbac_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, owner) = setup(&env);
+    let new_wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(NEW_CONTRACT_WASM);
+
+    let other = Address::generate(&env);
+    assert_ne!(other, owner);
+    client.upgrade(&new_wasm_hash, &other);
+}
+
+#[test]
+fn test_upgrade_requires_rbac_admin_when_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, owner) = setup(&env);
+    let (rbac, rbac_owner) = deploy_rbac(&env);
+    client.set_rbac_contract(&owner, &rbac.address);
+
+    let admin = Address::generate(&env);
+    rbac.grant_role(&rbac_owner, &admin, &Role::Admin);
+
+    let new_wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(NEW_CONTRACT_WASM);
+    client.upgrade(&new_wasm_hash, &admin);
+}
+
+#[test]
+#[should_panic]
+fn test_upgrade_rejects_non_admin_when_rbac_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, owner) = setup(&env);
+    let (rbac, rbac_owner) = deploy_rbac(&env);
+    client.set_rbac_contract(&owner, &rbac.address);
+
+    let employer = Address::generate(&env);
+    assert_ne!(employer, owner);
+    rbac.grant_role(&rbac_owner, &employer, &Role::Employer);
+    assert!(!rbac.has_role(&employer, &Role::Admin));
+
+    let new_wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(NEW_CONTRACT_WASM);
+    client.upgrade(&new_wasm_hash, &employer);
+}
+
+#[test]
+fn test_migrate_state_versioning_and_preserves_agreement_reads() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, owner) = setup(&env);
+    let (rbac, rbac_owner) = deploy_rbac(&env);
+    client.set_rbac_contract(&owner, &rbac.address);
+
+    let admin = Address::generate(&env);
+    rbac.grant_role(&rbac_owner, &admin, &Role::Admin);
+
+    let employer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &86400);
+    let pre = client.get_agreement(&agreement_id).unwrap();
+
+    client.migrate_state(&admin, &0);
+
+    let post = client.get_agreement(&agreement_id).unwrap();
+    assert_eq!(pre.id, post.id);
+    assert_eq!(pre.employer, post.employer);
+    assert_eq!(pre.token, post.token);
+}
+
+#[test]
+fn test_migrate_state_rejects_wrong_from_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, owner) = setup(&env);
+    let (rbac, rbac_owner) = deploy_rbac(&env);
+    client.set_rbac_contract(&owner, &rbac.address);
+
+    let admin = Address::generate(&env);
+    rbac.grant_role(&rbac_owner, &admin, &Role::Admin);
+
+    assert!(client.try_migrate_state(&admin, &1).is_err());
+
+    client.migrate_state(&admin, &0);
+
+    assert!(client.try_migrate_state(&admin, &0).is_err());
+}


### PR DESCRIPTION
## Description

- Gates contract upgrades on RBAC `Admin` when `set_rbac_contract` is configured, with owner-only fallback when RBAC is unset (backward compatible).
- Adds `migrate_state(operator, from_version)` with `ContractVersion` storage and a v0→v1 migration path (read-only agreement integrity checks, migration event).
- Documents operator flow, rollback, and schema policy in `docs/upgrade-migration-strategy.md`.

## Changes

- Add `rbac` dependency and `StorageKey::RbacContract` / `StorageKey::ContractVersion`.
- Add `set_rbac_contract(owner, rbac_id)` (owner-authenticated).
- Replace macro-only upgrade auth with explicit `upgrade(new_wasm_hash, operator)` using shared `require_upgrade_admin`.
- Add `migrate_state(operator, from_version)` (same admin gate; rejects version mismatches and downgrades).
- Emit `ContractMigratedEvent` on successful migration.
- Add `tests/upgrade_migration_tests.rs` (admin upgrade, non-admin rejection, migration happy path / wrong version, agreement preservation, owner fallback without RBAC).

## Test plan

- [x] `cargo test -p stello_pay_contract --test upgrade_migration_tests`
- [x] `cargo test -p stello_pay_contract`
- [ ] Deploy RBAC + payroll on testnet; run backup script → `migrate_state(0)` → `upgrade` → verify script (manual, per `docs/upgrade-migration-strategy.md`)

## Security notes

- Upgrade and migration require an authenticated operator; when RBAC is linked, only addresses with `Role::Admin` pass.
- Operators should back up contract state and retain the prior WASM hash before upgrading (see `docs/migrations.md` rollback).
- `Agreement` / milestone storage uses additive schema changes; breaking layout changes require a new `migrate_state` step before upgrade.

Closes #442