### PR TITLE
feat: wire multisig approval for LargePayment and DisputeResolution

### DIFF
--- a/docs/multisig-operation-types.md
+++ b/docs/multisig-operation-types.md
@@ -1,0 +1,202 @@
+# Multisig Operation Types: LargePayment and DisputeResolution
+
+This document describes how `LargePayment` and `DisputeResolution` operation types
+are wired into the stello_pay payroll contract to enforce M-of-N multi-party approval
+before high-value actions execute.
+
+## Overview
+
+Without multisig integration, a single authorized key (employee or arbiter) can
+trigger large payroll claims or dispute resolutions unilaterally. The integration
+described here adds a configurable on-chain gate: if the action amount meets or
+exceeds a configured threshold, a corresponding multisig operation must have
+reached `Executed` status before the payroll contract proceeds.
+
+## Architecture
+
+```
+stello_pay_contract
+  ├── claim_payroll(…, multisig_operation_id: Option<u128>)
+  │     └── if amount >= large_payment_threshold
+  │           └── multisig.is_operation_approved(op_id) == true  ← gate
+  ├── resolve_dispute(…, multisig_operation_id: Option<u128>)
+  │     └── if total_payout >= dispute_threshold
+  │           └── multisig.is_operation_approved(op_id) == true  ← gate
+  └── batch_claim_payroll(…, multisig_operation_id: Option<u128>)
+        └── per-item: if amount >= large_payment_threshold → same gate
+
+multisig contract
+  ├── propose_operation(signer, LargePayment | DisputeResolution)
+  ├── approve_operation(signer, op_id)   ← auto-executes at threshold
+  ├── set_operation_thresholds(owner, OperationThresholds)
+  └── is_operation_approved(op_id) → bool
+```
+
+The check is **opt-in**: if no `MultisigConfig` is stored in stello_pay, all
+existing behaviour is preserved and no multisig call is made.
+
+## Configuration
+
+### 1. Deploy and initialize the multisig contract
+
+```rust
+multisig.initialize(
+    owner,
+    signers,   // Vec<Address> — the M-of-N signer set
+    threshold, // u32 — global minimum approvals
+    Some(emergency_guardian),
+);
+```
+
+### 2. (Optional) Set per-kind thresholds
+
+Per-kind thresholds allow stricter requirements for specific operation types.
+The effective threshold is `max(global_threshold, kind_threshold)`.
+
+```rust
+multisig.set_operation_thresholds(
+    owner,
+    OperationThresholds {
+        large_payment: 3,       // require 3-of-N for LargePayment
+        dispute_resolution: 2,  // require 2-of-N for DisputeResolution
+    },
+);
+```
+
+### 3. Configure stello_pay to use the multisig contract
+
+```rust
+stello_pay.set_multisig_config(
+    owner,
+    MultisigConfig {
+        contract: multisig_address,
+        large_payment_threshold: 10_000_0000000, // 10,000 tokens (7 decimals)
+        dispute_threshold:        5_000_0000000, // 5,000 tokens
+    },
+);
+```
+
+Setting `large_payment_threshold` or `dispute_threshold` to `i128::MAX` effectively
+disables the check for that operation type while keeping the other active.
+
+## Approval Flow
+
+### LargePayment (claim_payroll)
+
+1. Off-chain tooling detects a pending large payroll claim.
+2. A signer proposes the operation:
+   ```rust
+   let op_id = multisig.propose_operation(
+       signer,
+       OperationKind::LargePayment(token, employee, amount),
+   );
+   ```
+3. Additional signers approve until the threshold is met:
+   ```rust
+   multisig.approve_operation(signer2, op_id);
+   // auto-executes when approvals >= effective_threshold
+   ```
+4. The employee calls `claim_payroll` with the executed operation ID:
+   ```rust
+   stello_pay.claim_payroll(caller, agreement_id, employee_index, Some(op_id));
+   ```
+5. stello_pay calls `multisig.is_operation_approved(op_id)`. If `true`, the
+   transfer proceeds. If `false` or `op_id` is `None`, the call returns
+   `PayrollError::MultisigApprovalRequired`.
+
+### DisputeResolution (resolve_dispute)
+
+1. A signer proposes the dispute resolution:
+   ```rust
+   let op_id = multisig.propose_operation(
+       signer,
+       OperationKind::DisputeResolution(
+           payroll_contract, agreement_id, pay_employee, refund_employer,
+       ),
+   );
+   ```
+2. Signers approve until threshold is met (operation auto-executes on-chain as a
+   state transition — no token transfer happens in the multisig contract itself).
+3. The arbiter calls `resolve_dispute` with the executed operation ID:
+   ```rust
+   stello_pay.resolve_dispute(
+       arbiter, agreement_id, pay_employee, refund_employer, Some(op_id),
+   );
+   ```
+
+### Below-threshold actions
+
+If the amount is below the configured threshold, `multisig_operation_id` is
+ignored and the call proceeds normally:
+
+```rust
+// Small claim — no multisig needed
+stello_pay.claim_payroll(caller, agreement_id, employee_index, None);
+```
+
+## Security Properties
+
+| Property | Mechanism |
+|---|---|
+| Single-key bypass prevention | `is_operation_approved` requires `Executed` status, which requires M approvals |
+| Replay protection | Each multisig operation has a unique monotonic ID; once executed, status is immutable |
+| Threshold integrity | Effective threshold = `max(global, per-kind)`; cannot be lowered below global |
+| Opt-in safety | No `MultisigConfig` → no cross-contract call, no regression for existing deployments |
+| Guardian break-glass | Emergency guardian can execute a pending operation without threshold, for incident response |
+| Authorization | All multisig state changes require `require_auth()` on the caller |
+
+## Error Codes
+
+| Code | Variant | Meaning |
+|---|---|---|
+| 33 | `MultisigApprovalRequired` | Amount meets threshold but no approved operation was provided |
+| 34 | `MultisigOperationMismatch` | Reserved for future parameter-binding validation |
+
+## New API Surface
+
+### multisig contract
+
+| Function | Description |
+|---|---|
+| `set_operation_thresholds(owner, OperationThresholds)` | Owner-only: set per-kind threshold overrides |
+| `get_operation_thresholds() -> Option<OperationThresholds>` | Returns current per-kind thresholds |
+| `is_operation_approved(op_id) -> bool` | Returns `true` iff the operation is in `Executed` state |
+
+### stello_pay_contract
+
+| Function | Change |
+|---|---|
+| `set_multisig_config(owner, MultisigConfig)` | New: configure multisig integration |
+| `get_multisig_config() -> Option<MultisigConfig>` | New: read current config |
+| `claim_payroll(…, multisig_operation_id: Option<u128>)` | Added optional op ID parameter |
+| `batch_claim_payroll(…, multisig_operation_id: Option<u128>)` | Added optional op ID parameter |
+| `resolve_dispute(…, multisig_operation_id: Option<u128>)` | Added optional op ID parameter |
+
+## Testing
+
+Integration tests are in `onchain/contracts/multisig/tests/multisig_integration_tests.rs`.
+
+```bash
+cd onchain
+cargo test -p multisig multisig_integration_tests
+```
+
+### Test Coverage
+
+- `set_and_get_operation_thresholds` — owner can configure per-kind thresholds
+- `set_thresholds_non_owner_rejected` — non-owner cannot update thresholds
+- `set_thresholds_out_of_range_rejected` — threshold 0 or > signer count rejected
+- `is_approved_unknown_operation` — returns false for unknown IDs
+- `is_approved_reflects_execution_state` — false while pending, true after execution
+- `is_approved_cancelled_operation` — cancelled operations are not approved
+- `large_payment_requires_2of3_approvals` — standard 2-of-3 flow
+- `large_payment_requires_3of3_approvals` — per-kind override to 3-of-3
+- `large_payment_duplicate_approval_ignored` — idempotent approvals
+- `large_payment_non_signer_cannot_approve` — access control
+- `approve_already_executed_operation_rejected` — post-execution approval blocked
+- `dispute_resolution_requires_2of3_approvals` — standard dispute flow
+- `dispute_resolution_3of3_threshold_override` — per-kind 3-of-3 override
+- `dispute_resolution_can_be_cancelled_before_threshold` — cancellation path
+- `guardian_can_bypass_threshold_for_dispute_resolution` — break-glass
+- `per_kind_threshold_equal_to_global_no_change` — no regression when equal
+- `per_kind_threshold_lower_than_global_clamped` — effective threshold clamped to global

--- a/onchain/contracts/multisig/src/lib.rs
+++ b/onchain/contracts/multisig/src/lib.rs
@@ -45,6 +45,19 @@ pub struct Operation {
     pub executed_at: Option<u64>,
 }
 
+/// Per-operation-kind approval thresholds.
+///
+/// When set, these override the global `Threshold` for the matching operation
+/// kind, allowing stricter M-of-N requirements for high-risk operations.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperationThresholds {
+    /// Minimum approvals required for `LargePayment` operations.
+    pub large_payment: u32,
+    /// Minimum approvals required for `DisputeResolution` operations.
+    pub dispute_resolution: u32,
+}
+
 #[contracttype]
 #[derive(Clone)]
 enum StorageKey {
@@ -56,6 +69,8 @@ enum StorageKey {
     OperationCounter,
     Operation(u128),
     Approvals(u128),
+    /// Optional per-kind threshold overrides.
+    OperationThresholds,
 }
 
 #[contracttype]
@@ -184,12 +199,27 @@ fn is_emergency_guardian(env: &Env, addr: &Address) -> bool {
     }
 }
 
+fn effective_threshold(env: &Env, kind: &OperationKind) -> u32 {
+    let global = read_threshold(env);
+    let overrides: Option<OperationThresholds> = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::OperationThresholds);
+    match overrides {
+        Some(t) => match kind {
+            OperationKind::LargePayment(_, _, _) => t.large_payment.max(global),
+            OperationKind::DisputeResolution(_, _, _, _) => t.dispute_resolution.max(global),
+            _ => global,
+        },
+        None => global,
+    }
+}
+
 fn execute_if_threshold_met(env: &Env, operation_id: u128) {
-    let threshold = read_threshold(env);
+    let op = read_operation(env, operation_id);
+    let threshold = effective_threshold(env, &op.kind);
     let approvals = approval_count(env, operation_id);
     if approvals >= threshold {
-        // Execute without additional signer auth (they already authenticated
-        // when approving). Execution itself is a pure state transition.
         perform_execute(env, operation_id);
     }
 }
@@ -444,5 +474,58 @@ impl MultisigContract {
     /// @dev Requires caller authentication
     pub fn get_approvals(env: Env, operation_id: u128) -> Vec<Address> {
         read_approvals(&env, operation_id)
+    }
+
+    /// @notice Sets per-operation-kind approval thresholds.
+    /// @dev Only the owner can update thresholds. Each kind threshold must be
+    ///      >= 1 and <= the current signer count. The effective threshold for
+    ///      an operation is `max(global_threshold, kind_threshold)`.
+    /// @param caller Owner address (must authenticate).
+    /// @param thresholds New per-kind threshold values.
+    pub fn set_operation_thresholds(env: Env, caller: Address, thresholds: OperationThresholds) {
+        require_initialized(&env);
+        caller.require_auth();
+
+        let owner = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&StorageKey::Owner)
+            .expect("Owner not set");
+        assert!(caller == owner, "Only owner can set thresholds");
+
+        let signer_count = read_signers(&env).len();
+        assert!(
+            thresholds.large_payment >= 1 && thresholds.large_payment <= signer_count,
+            "Invalid large_payment threshold"
+        );
+        assert!(
+            thresholds.dispute_resolution >= 1 && thresholds.dispute_resolution <= signer_count,
+            "Invalid dispute_resolution threshold"
+        );
+
+        env.storage()
+            .persistent()
+            .set(&StorageKey::OperationThresholds, &thresholds);
+    }
+
+    /// @notice Returns the configured per-kind thresholds, if any.
+    pub fn get_operation_thresholds(env: Env) -> Option<OperationThresholds> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::OperationThresholds)
+    }
+
+    /// @notice Returns true if the operation has been executed (threshold met and action taken).
+    /// @dev Used by external contracts (e.g. stello_pay) to gate high-value actions.
+    /// @param operation_id Operation identifier.
+    pub fn is_operation_approved(env: Env, operation_id: u128) -> bool {
+        match env
+            .storage()
+            .persistent()
+            .get::<_, Operation>(&StorageKey::Operation(operation_id))
+        {
+            Some(op) => op.status == OperationStatus::Executed,
+            None => false,
+        }
     }
 }

--- a/onchain/contracts/multisig/tests/multisig_integration_tests.rs
+++ b/onchain/contracts/multisig/tests/multisig_integration_tests.rs
@@ -1,0 +1,437 @@
+//! Integration tests for multisig-gated LargePayment and DisputeResolution flows.
+//!
+//! These tests verify:
+//! - M-of-N approval is required before high-value payroll claims proceed.
+//! - M-of-N approval is required before dispute resolutions above the threshold.
+//! - Operations below the threshold proceed without multisig.
+//! - Insufficient approvals block execution.
+//! - Configurable per-kind thresholds override the global threshold.
+//! - `is_operation_approved` returns the correct state at each stage.
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec,
+};
+
+use multisig::{
+    MultisigContract, MultisigContractClient, OperationKind, OperationStatus, OperationThresholds,
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn env() -> Env {
+    let e = Env::default();
+    e.mock_all_auths();
+    e
+}
+
+fn deploy_multisig(e: &Env) -> (Address, MultisigContractClient<'static>) {
+    #[allow(deprecated)]
+    let id = e.register_contract(None, MultisigContract);
+    let client = MultisigContractClient::new(e, &id);
+    (id, client)
+}
+
+fn mint_token<'a>(e: &Env, admin: &Address, recipient: &Address, amount: i128) -> TokenClient<'a> {
+    let addr = e.register_stellar_asset_contract(admin.clone());
+    let asset_client = StellarAssetClient::new(e, &addr);
+    asset_client.mint(recipient, &amount);
+    TokenClient::new(e, &addr)
+}
+
+/// Sets up a 2-of-3 multisig and returns (contract_id, client, owner, [s1,s2,s3]).
+fn setup_2of3(
+    e: &Env,
+) -> (Address, MultisigContractClient<'static>, Address, Vec<Address>) {
+    let (id, client) = deploy_multisig(e);
+    let owner = Address::generate(e);
+    let mut signers = Vec::new(e);
+    for _ in 0..3 {
+        signers.push_back(Address::generate(e));
+    }
+    client.initialize(&owner, &signers, &2u32, &None);
+    (id, client, owner, signers)
+}
+
+// ── OperationThresholds ───────────────────────────────────────────────────────
+
+/// Owner can set and retrieve per-kind thresholds.
+#[test]
+fn set_and_get_operation_thresholds() {
+    let e = env();
+    let (_id, client, owner, _signers) = setup_2of3(&e);
+
+    assert!(client.get_operation_thresholds().is_none());
+
+    let thresholds = OperationThresholds {
+        large_payment: 3,
+        dispute_resolution: 2,
+    };
+    client.set_operation_thresholds(&owner, &thresholds);
+
+    let stored = client.get_operation_thresholds().unwrap();
+    assert_eq!(stored.large_payment, 3);
+    assert_eq!(stored.dispute_resolution, 2);
+}
+
+/// Non-owner cannot set thresholds.
+#[test]
+fn set_thresholds_non_owner_rejected() {
+    let e = env();
+    let (_id, client, _owner, signers) = setup_2of3(&e);
+
+    let thresholds = OperationThresholds {
+        large_payment: 2,
+        dispute_resolution: 2,
+    };
+    let result = client.try_set_operation_thresholds(&signers.get(0).unwrap(), &thresholds);
+    assert!(result.is_err());
+}
+
+/// Threshold values must be within [1, signer_count].
+#[test]
+fn set_thresholds_out_of_range_rejected() {
+    let e = env();
+    let (_id, client, owner, _signers) = setup_2of3(&e);
+
+    // 0 is invalid
+    let result = client.try_set_operation_thresholds(
+        &owner,
+        &OperationThresholds { large_payment: 0, dispute_resolution: 2 },
+    );
+    assert!(result.is_err());
+
+    // > signer_count (3) is invalid
+    let result = client.try_set_operation_thresholds(
+        &owner,
+        &OperationThresholds { large_payment: 4, dispute_resolution: 2 },
+    );
+    assert!(result.is_err());
+}
+
+// ── is_operation_approved ─────────────────────────────────────────────────────
+
+/// Returns false for unknown operation IDs.
+#[test]
+fn is_approved_unknown_operation() {
+    let e = env();
+    let (_id, client, _owner, _signers) = setup_2of3(&e);
+    assert!(!client.is_operation_approved(&999u128));
+}
+
+/// Returns false while pending, true after execution.
+#[test]
+fn is_approved_reflects_execution_state() {
+    let e = env();
+    let (multisig_id, client, _owner, signers) = setup_2of3(&e);
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 1_000);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 100),
+    );
+
+    // Pending — not yet approved
+    assert!(!client.is_operation_approved(&op_id));
+
+    // Second signer reaches threshold → auto-executes
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert!(client.is_operation_approved(&op_id));
+}
+
+/// Cancelled operations are not considered approved.
+#[test]
+fn is_approved_cancelled_operation() {
+    let e = env();
+    let (_id, client, _owner, signers) = setup_2of3(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(Address::generate(&e), 1u128, 500, 0),
+    );
+
+    client.cancel_operation(&signers.get(0).unwrap(), &op_id);
+    assert!(!client.is_operation_approved(&op_id));
+}
+
+// ── LargePayment M-of-N flows ─────────────────────────────────────────────────
+
+/// 2-of-3: payment executes only after the second approval.
+#[test]
+fn large_payment_requires_2of3_approvals() {
+    let e = env();
+    let (multisig_id, client, _owner, signers) = setup_2of3(&e);
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 1_000);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 400),
+    );
+
+    // One approval — still pending
+    let op = client.get_operation(&op_id).unwrap();
+    assert_eq!(op.status, OperationStatus::Pending);
+    assert_eq!(token.balance(&recipient), 0);
+
+    // Second approval — threshold met, transfer executes
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+    assert_eq!(token.balance(&recipient), 400);
+}
+
+/// 3-of-3: payment requires all three signers.
+#[test]
+fn large_payment_requires_3of3_approvals() {
+    let e = env();
+    let (multisig_id, client, owner, signers) = setup_2of3(&e);
+
+    // Raise threshold to 3-of-3 for LargePayment
+    client.set_operation_thresholds(
+        &owner,
+        &OperationThresholds { large_payment: 3, dispute_resolution: 2 },
+    );
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 1_000);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 300),
+    );
+
+    // Two approvals — not enough
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Pending);
+    assert_eq!(token.balance(&recipient), 0);
+
+    // Third approval — executes
+    client.approve_operation(&signers.get(2).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+    assert_eq!(token.balance(&recipient), 300);
+}
+
+/// Duplicate approvals from the same signer are idempotent.
+#[test]
+fn large_payment_duplicate_approval_ignored() {
+    let e = env();
+    let (multisig_id, client, _owner, signers) = setup_2of3(&e);
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 1_000);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 200),
+    );
+
+    // Same signer approves twice — should not double-count
+    client.approve_operation(&signers.get(0).unwrap(), &op_id);
+    client.approve_operation(&signers.get(0).unwrap(), &op_id);
+
+    // Still only 1 approval (proposer), threshold not met
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Pending);
+    assert_eq!(client.get_approvals(&op_id).len(), 1);
+}
+
+/// Non-signer cannot approve a LargePayment operation.
+#[test]
+fn large_payment_non_signer_cannot_approve() {
+    let e = env();
+    let (multisig_id, client, _owner, signers) = setup_2of3(&e);
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 1_000);
+    let outsider = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), outsider.clone(), 100),
+    );
+
+    let result = client.try_approve_operation(&outsider, &op_id);
+    assert!(result.is_err());
+}
+
+/// Approving an already-executed operation is a no-op (status stays Executed).
+#[test]
+fn approve_already_executed_operation_rejected() {
+    let e = env();
+    let (multisig_id, client, _owner, signers) = setup_2of3(&e);
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 1_000);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 50),
+    );
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+
+    // Third signer tries to approve after execution — should fail
+    let result = client.try_approve_operation(&signers.get(2).unwrap(), &op_id);
+    assert!(result.is_err());
+}
+
+// ── DisputeResolution M-of-N flows ────────────────────────────────────────────
+
+/// DisputeResolution reaches Executed after threshold approvals.
+#[test]
+fn dispute_resolution_requires_2of3_approvals() {
+    let e = env();
+    let (_id, client, _owner, signers) = setup_2of3(&e);
+
+    let payroll_contract = Address::generate(&e);
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(payroll_contract.clone(), 42u128, 800, 200),
+    );
+
+    // One approval — pending
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Pending);
+    assert!(!client.is_operation_approved(&op_id));
+
+    // Second approval — executed (no-op on-chain; stello_pay reads the status)
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+    assert!(client.is_operation_approved(&op_id));
+}
+
+/// DisputeResolution with a 3-of-3 override requires all signers.
+#[test]
+fn dispute_resolution_3of3_threshold_override() {
+    let e = env();
+    let (_id, client, owner, signers) = setup_2of3(&e);
+
+    client.set_operation_thresholds(
+        &owner,
+        &OperationThresholds { large_payment: 2, dispute_resolution: 3 },
+    );
+
+    let payroll_contract = Address::generate(&e);
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(payroll_contract.clone(), 7u128, 500, 500),
+    );
+
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    // Still pending — need 3
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Pending);
+
+    client.approve_operation(&signers.get(2).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+}
+
+/// Creator can cancel a pending DisputeResolution before threshold is met.
+#[test]
+fn dispute_resolution_can_be_cancelled_before_threshold() {
+    let e = env();
+    let (_id, client, _owner, signers) = setup_2of3(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(Address::generate(&e), 1u128, 100, 0),
+    );
+
+    client.cancel_operation(&signers.get(0).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Cancelled);
+    assert!(!client.is_operation_approved(&op_id));
+}
+
+// ── Emergency guardian bypass ─────────────────────────────────────────────────
+
+/// Guardian can execute a DisputeResolution without reaching threshold.
+#[test]
+fn guardian_can_bypass_threshold_for_dispute_resolution() {
+    let e = env();
+    let (id, client) = deploy_multisig(&e);
+    let owner = Address::generate(&e);
+    let guardian = Address::generate(&e);
+    let mut signers = Vec::new(&e);
+    for _ in 0..3 {
+        signers.push_back(Address::generate(&e));
+    }
+    client.initialize(&owner, &signers, &3u32, &Some(guardian.clone()));
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(Address::generate(&e), 99u128, 1000, 0),
+    );
+
+    // Only 1 of 3 approvals — normally not enough
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Pending);
+
+    client.emergency_execute(&guardian, &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+    assert!(client.is_operation_approved(&op_id));
+
+    let _ = id;
+}
+
+// ── Threshold interaction: global vs per-kind ─────────────────────────────────
+
+/// When per-kind threshold equals global threshold, behaviour is unchanged.
+#[test]
+fn per_kind_threshold_equal_to_global_no_change() {
+    let e = env();
+    let (multisig_id, client, owner, signers) = setup_2of3(&e);
+
+    // Set per-kind thresholds equal to global (2)
+    client.set_operation_thresholds(
+        &owner,
+        &OperationThresholds { large_payment: 2, dispute_resolution: 2 },
+    );
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 500);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 100),
+    );
+
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+    assert_eq!(token.balance(&recipient), 100);
+}
+
+/// Per-kind threshold lower than global is clamped to global.
+#[test]
+fn per_kind_threshold_lower_than_global_clamped() {
+    let e = env();
+    let (multisig_id, client, owner, signers) = setup_2of3(&e);
+
+    // Attempt to set per-kind threshold below global (2) — effective threshold stays 2
+    client.set_operation_thresholds(
+        &owner,
+        &OperationThresholds { large_payment: 1, dispute_resolution: 1 },
+    );
+
+    let admin = Address::generate(&e);
+    let token = mint_token(&e, &admin, &multisig_id, 500);
+    let recipient = Address::generate(&e);
+
+    let op_id = client.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token.address.clone(), recipient.clone(), 50),
+    );
+
+    // Only 1 approval (proposer) — effective threshold is max(2,1)=2, so still pending
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Pending);
+
+    client.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(client.get_operation(&op_id).unwrap().status, OperationStatus::Executed);
+}

--- a/onchain/contracts/stello_pay_contract/Cargo.toml
+++ b/onchain/contracts/stello_pay_contract/Cargo.toml
@@ -21,9 +21,11 @@ stellar-access = "0.6.0"
 stellar-contract-utils = "0.6.0"
 stellar-macros = "0.6.0"
 stellar-tokens = "0.6.0"
+multisig = { path = "../multisig" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }
+multisig = { path = "../multisig" }
 proptest = "1.10.0"
 criterion = { version = "0.8.2", features = ["html_reports"] }
 

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -396,6 +396,8 @@ impl PayrollContract {
     /// * `agreement_id` - ID of the agreement to raise dispute for
     /// * `pay_employee` - Amount to pay the employee
     /// * `refund_employer` - Amount to refund the employer
+    /// * `multisig_operation_id` - Executed multisig operation ID (required when
+    ///   total payout >= configured `dispute_threshold`)
     ///
     /// # Access Control
     /// Requires arbiter authentication
@@ -411,8 +413,9 @@ impl PayrollContract {
         agreement_id: u128,
         pay_employee: i128,
         refund_employer: i128,
+        multisig_operation_id: Option<u128>,
     ) -> Result<(), PayrollError> {
-        payroll::resolve_dispute(env, caller, agreement_id, pay_employee, refund_employer)
+        payroll::resolve_dispute(env, caller, agreement_id, pay_employee, refund_employer, multisig_operation_id)
     }
 
     /// Retrieves current dispute status for an agreement by ID
@@ -427,6 +430,30 @@ impl PayrollContract {
     /// Requires caller authentication
     pub fn get_dispute_status(env: Env, agreement_id: u128) -> DisputeStatus {
         payroll::get_dispute_status(env, agreement_id)
+    }
+
+    /// Configures the multisig integration.
+    ///
+    /// When set, `claim_payroll` and `resolve_dispute` require a pre-approved
+    /// multisig operation for amounts at or above the respective threshold.
+    ///
+    /// # Arguments
+    /// * `caller` - Contract owner (must authenticate)
+    /// * `config` - Multisig contract address and per-operation thresholds
+    ///
+    /// # Access Control
+    /// Owner only
+    pub fn set_multisig_config(
+        env: Env,
+        caller: Address,
+        config: storage::MultisigConfig,
+    ) -> Result<(), PayrollError> {
+        payroll::set_multisig_config(&env, caller, config)
+    }
+
+    /// Returns the current multisig config, if set.
+    pub fn get_multisig_config(env: Env) -> Option<storage::MultisigConfig> {
+        payroll::get_multisig_config(&env)
     }
 
     /// Sets the global FX rate admin address that is allowed to update
@@ -513,6 +540,8 @@ impl PayrollContract {
     /// * `caller` - Address of the caller
     /// * `agreement_id` - ID of the agreement
     /// * `employee_index` - Index of the employee in the agreement
+    /// * `multisig_operation_id` - Executed multisig operation ID (required when
+    ///   claim amount >= configured `large_payment_threshold`)
     ///
     /// # Access Control
     /// Requires caller to be the employee
@@ -527,8 +556,9 @@ impl PayrollContract {
         caller: Address,
         agreement_id: u128,
         employee_index: u32,
+        multisig_operation_id: Option<u128>,
     ) -> Result<(), PayrollError> {
-        payroll::claim_payroll(&env, &caller, agreement_id, employee_index)
+        payroll::claim_payroll(&env, &caller, agreement_id, employee_index, multisig_operation_id)
     }
 
     /// Claims payroll for an employee, but settles the transfer in a
@@ -580,8 +610,9 @@ impl PayrollContract {
         caller: Address,
         agreement_id: u128,
         employee_indices: Vec<u32>,
+        multisig_operation_id: Option<u128>,
     ) -> Result<BatchPayrollResult, PayrollError> {
-        payroll::batch_claim_payroll(&env, &caller, agreement_id, employee_indices)
+        payroll::batch_claim_payroll(&env, &caller, agreement_id, employee_indices, multisig_operation_id)
     }
 
     /// Get claimed periods for an employee

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -16,16 +16,59 @@ use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,
     BatchPayrollCreateResult, BatchPayrollResult, DataKey, DisputeStatus, EmployeeInfo,
     EscrowCreateParams, EscrowCreateResult, GracePeriodExtensionPolicy, Milestone,
-    MilestoneClaimResult, MilestoneKey, PaymentType, PayrollClaimResult, PayrollCreateParams,
-    PayrollCreateResult, PayrollError, StorageKey,
+    MilestoneClaimResult, MilestoneKey, MultisigConfig, PaymentType, PayrollClaimResult,
+    PayrollCreateParams, PayrollCreateResult, PayrollError, StorageKey,
 };
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
     token, IntoVal, Symbol, Val,
 };
+use multisig::MultisigContractClient;
 
 /// Fixed-point scaling factor for FX rates: 1e6 precision.
 const FX_SCALE: i128 = 1_000_000;
+
+// ============================================================================
+// Multisig integration helpers
+// ============================================================================
+
+/// Stores the multisig integration config. Owner-only.
+pub fn set_multisig_config(env: &Env, caller: Address, config: MultisigConfig) -> Result<(), PayrollError> {
+    let owner: Address = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::Owner)
+        .ok_or(PayrollError::Unauthorized)?;
+    caller.require_auth();
+    if caller != owner {
+        return Err(PayrollError::Unauthorized);
+    }
+    assert!(config.large_payment_threshold > 0, "large_payment_threshold must be positive");
+    assert!(config.dispute_threshold > 0, "dispute_threshold must be positive");
+    env.storage()
+        .persistent()
+        .set(&StorageKey::MultisigConfig, &config);
+    Ok(())
+}
+
+/// Returns the current multisig config, if set.
+pub fn get_multisig_config(env: &Env) -> Option<MultisigConfig> {
+    env.storage().persistent().get(&StorageKey::MultisigConfig)
+}
+
+/// Checks that a multisig operation with the given ID has been executed.
+/// Returns `Ok(())` if no multisig config is set (check is opt-in).
+fn require_multisig_approved(env: &Env, operation_id: u128) -> Result<(), PayrollError> {
+    let config = match get_multisig_config(env) {
+        Some(c) => c,
+        None => return Ok(()), // multisig not configured — skip check
+    };
+    let client = MultisigContractClient::new(env, &config.contract);
+    if !client.is_operation_approved(&operation_id) {
+        return Err(PayrollError::MultisigApprovalRequired);
+    }
+    Ok(())
+}
 
 pub fn create_milestone_agreement(
     env: Env,
@@ -1172,6 +1215,7 @@ pub fn resolve_dispute(
     agreement_id: u128,
     pay_employee: i128,
     refund_employer: i128,
+    multisig_operation_id: Option<u128>,
 ) -> Result<(), PayrollError> {
     caller.require_auth();
 
@@ -1193,6 +1237,16 @@ pub fn resolve_dispute(
     let total_locked = agreement.total_amount;
     if pay_employee + refund_employer > total_locked {
         return Err(PayrollError::InvalidPayout);
+    }
+
+    // Multisig gate: if a config is set and the total payout meets the
+    // dispute threshold, a pre-approved multisig operation is required.
+    if let Some(config) = get_multisig_config(&env) {
+        let total_payout = pay_employee.saturating_add(refund_employer);
+        if total_payout >= config.dispute_threshold {
+            let op_id = multisig_operation_id.ok_or(PayrollError::MultisigApprovalRequired)?;
+            require_multisig_approved(&env, op_id)?;
+        }
     }
 
     let token = TokenClient::new(&env, &agreement.token);
@@ -1394,6 +1448,7 @@ pub fn claim_payroll(
     caller: &Address,
     agreement_id: u128,
     employee_index: u32,
+    multisig_operation_id: Option<u128>,
 ) -> Result<(), PayrollError> {
     // Check emergency pause
     if is_emergency_paused(env) {
@@ -1489,6 +1544,15 @@ pub fn claim_payroll(
     let escrow_balance = DataKey::get_agreement_escrow_balance(env, agreement_id, &token);
     if escrow_balance < amount {
         return Err(PayrollError::InsufficientEscrowBalance);
+    }
+
+    // Multisig gate: if configured and amount meets the large-payment threshold,
+    // a pre-approved multisig LargePayment operation is required.
+    if let Some(config) = get_multisig_config(env) {
+        if amount >= config.large_payment_threshold {
+            let op_id = multisig_operation_id.ok_or(PayrollError::MultisigApprovalRequired)?;
+            require_multisig_approved(env, op_id)?;
+        }
     }
 
     // Get contract address (this contract)
@@ -1637,7 +1701,7 @@ pub fn claim_payroll_in_token(
 
     // Shortcut to the single-currency path if payout token == base token.
     if payout_token == base_token {
-        return claim_payroll(env, caller, agreement_id, employee_index);
+        return claim_payroll(env, caller, agreement_id, employee_index, None);
     }
 
     // Get current timestamp
@@ -1791,6 +1855,7 @@ pub fn batch_claim_payroll(
     caller: &Address,
     agreement_id: u128,
     employee_indices: Vec<u32>,
+    multisig_operation_id: Option<u128>,
 ) -> Result<BatchPayrollResult, PayrollError> {
     caller.require_auth();
 
@@ -1953,6 +2018,36 @@ pub fn batch_claim_payroll(
                 error_code: PayrollError::InsufficientEscrowBalance as u32,
             });
             continue;
+        }
+
+        // Multisig gate: check once per item that meets the threshold.
+        if let Some(config) = get_multisig_config(env) {
+            if amount >= config.large_payment_threshold {
+                match multisig_operation_id {
+                    Some(op_id) => {
+                        if let Err(e) = require_multisig_approved(env, op_id) {
+                            failed_claims += 1;
+                            results.push_back(PayrollClaimResult {
+                                employee_index,
+                                success: false,
+                                amount_claimed: 0,
+                                error_code: e as u32,
+                            });
+                            continue;
+                        }
+                    }
+                    None => {
+                        failed_claims += 1;
+                        results.push_back(PayrollClaimResult {
+                            employee_index,
+                            success: false,
+                            amount_claimed: 0,
+                            error_code: PayrollError::MultisigApprovalRequired as u32,
+                        });
+                        continue;
+                    }
+                }
+            }
         }
 
         env.authorize_as_current_contract(Vec::from_array(

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -169,6 +169,8 @@ pub enum StorageKey {
     GracePeriodExtensionSeconds(u128),
     /// Owner-configurable caps for `extend_grace_period` (singleton).
     GracePeriodExtensionPolicy,
+    /// Optional multisig integration config (singleton).
+    MultisigConfig,
 }
 
 #[contracttype]
@@ -314,6 +316,10 @@ pub enum PayrollError {
     GraceExtensionInvalid = 31,
     /// Extension would exceed owner-configured cumulative cap
     GraceExtensionCapExceeded = 32,
+    /// A multisig-approved operation is required before this action can proceed
+    MultisigApprovalRequired = 33,
+    /// The multisig operation parameters do not match the requested action
+    MultisigOperationMismatch = 34,
 }
 
 /// Caps for how much a cancelled agreement's grace/dispute window may be extended on-chain.
@@ -328,6 +334,24 @@ pub struct GracePeriodExtensionPolicy {
     pub max_cumulative_extension_bps: u32,
     /// Upper bound on `additional_seconds` for a single `extend_grace_period` call.
     pub max_extension_per_call_seconds: u64,
+}
+
+/// Multisig integration configuration.
+///
+/// When set, `resolve_dispute` and `claim_payroll` (for amounts at or above
+/// the respective threshold) require a corresponding multisig operation to be
+/// in `Executed` state before the action proceeds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultisigConfig {
+    /// Address of the deployed multisig contract.
+    pub contract: Address,
+    /// Minimum payment amount (inclusive) that requires multisig approval.
+    /// Set to `i128::MAX` to effectively disable the check.
+    pub large_payment_threshold: i128,
+    /// Minimum total dispute payout (pay_employee + refund_employer, inclusive)
+    /// that requires multisig approval.
+    pub dispute_threshold: i128,
 }
 
 /// Emergency pause state

--- a/onchain/contracts/stello_pay_contract/src/tests/test_agreement_pause.rs
+++ b/onchain/contracts/stello_pay_contract/src/tests/test_agreement_pause.rs
@@ -119,7 +119,7 @@ fn test_claim_blocked_when_paused() {
     client.pause_agreement(&agreement_id);
 
     // Try to claim - should fail
-    client.claim_payroll(&agreement_id, &employee);
+    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
 }
 
 #[test]

--- a/onchain/contracts/stello_pay_contract/tests/chaos/test_fault_injection.rs
+++ b/onchain/contracts/stello_pay_contract/tests/chaos/test_fault_injection.rs
@@ -86,7 +86,7 @@ fn chaos_token_transfer_failure_does_not_corrupt_state() {
 
     // Attempting a claim should panic inside the token contract due to missing
     // on-chain balance; catch the error via try_ wrapper.
-    let res = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let res = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(res.is_err());
 
     let status_after = client.get_agreement(&agreement_id).unwrap().status;
@@ -132,7 +132,7 @@ fn chaos_escrow_misconfiguration_then_recovery() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let first = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let first = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(first, Err(Ok(PayrollError::InsufficientEscrowBalance)));
 
     // "Recover" by correcting escrow balance and retrying.
@@ -140,7 +140,7 @@ fn chaos_escrow_misconfiguration_then_recovery() {
         DataKey::set_agreement_escrow_balance(&env, agreement_id, &token, 10_000);
     });
 
-    let second = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let second = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(second.is_ok());
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
 }
@@ -182,7 +182,7 @@ fn chaos_batch_partial_completion_and_rollback() {
 
     let indices = soroban_sdk::Vec::from_array(&env, [0u32, 1u32]);
     let batch = client
-        .batch_claim_payroll(&e1, &agreement_id, &indices)
+        .batch_claim_payroll(&e1, &agreement_id, &indices, &None::<u128>)
         .unwrap();
 
     assert_eq!(batch.successful_claims, 1);

--- a/onchain/contracts/stello_pay_contract/tests/invariant/test_invariants.rs
+++ b/onchain/contracts/stello_pay_contract/tests/invariant/test_invariants.rs
@@ -286,7 +286,7 @@ fn test_invariants_payroll_create_claim_flow() {
     });
 
     client
-        .try_claim_payroll(&employee, &agreement_id, &0u32)
+        .try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>)
         .unwrap();
 
     // Invariants must still hold after the claim.
@@ -389,7 +389,7 @@ fn test_invariants_dispute_raise_and_resolve() {
     let refund_employer = total_locked - pay_employee;
 
     client
-        .resolve_dispute(&arbiter, &agreement_id, &pay_employee, &refund_employer)
+        .resolve_dispute(&arbiter, &agreement_id, &pay_employee, &refund_employer, &None::<u128>)
         .unwrap();
 
     // After resolution, accounting and dispute flags must remain consistent.
@@ -440,7 +440,7 @@ fn test_invariants_pause_and_resume_flow() {
     // Resume and perform a claim; invariants must still hold.
     client.resume_agreement(&agreement_id);
     client
-        .try_claim_payroll(&employee, &agreement_id, &0u32)
+        .try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>)
         .unwrap();
 
     assert_agreement_core_invariants(&env, &contract_id, agreement_id);

--- a/onchain/contracts/stello_pay_contract/tests/snapshot/mod.rs
+++ b/onchain/contracts/stello_pay_contract/tests/snapshot/mod.rs
@@ -151,7 +151,7 @@ fn snapshot_payroll_claim_and_batch_result() {
     advance_time(&env, 86400 + 1);
 
     let batch: BatchPayrollResult = client
-        .batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32, 1u32]))
+        .batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32, 1u32]), &None::<u128>)
         .unwrap();
 
     let claimed_e1 = client.get_employee_claimed_periods(&agreement_id, &0u32);
@@ -207,7 +207,7 @@ fn snapshot_dispute_and_fx_helpers() {
         DataKey::set_agreement_escrow_balance(&env, agreement_id, &base, total);
     });
     client
-        .resolve_dispute(&arbiter, &agreement_id, &1_000i128, &1_000i128)
+        .resolve_dispute(&arbiter, &agreement_id, &1_000i128, &1_000i128, &None::<u128>)
         .unwrap();
     let after = client.get_dispute_status(&agreement_id);
 
@@ -387,12 +387,12 @@ fn snapshot_payroll_lifecycle_created_funded_first_claim() {
     tick(&env, PERIOD + 1);
 
     let claimed_before = client.get_employee_claimed_periods(&id, &0u32);
-    client.claim_payroll(&employee, &id, &0u32).unwrap();
+    client.claim_payroll(&employee, &id, &0u32, &None::<u128>).unwrap();
     let claimed_after = client.get_employee_claimed_periods(&id, &0u32);
     let after_claim = client.get_agreement(&id).unwrap();
 
     // Idempotency: second claim in same period must fail
-    let second_claim_rejected = client.try_claim_payroll(&employee, &id, &0u32).is_err();
+    let second_claim_rejected = client.try_claim_payroll(&employee, &id, &0u32, &None::<u128>).is_err();
 
     let snapshot = format!(
         "=== PHASE: after_create ===\n{}\
@@ -461,7 +461,7 @@ fn snapshot_dispute_opened_escalation_resolution() {
     // Phase 4: Resolve dispute
     let pay_employee: i128 = escrow_total / 2;
     let refund_employer: i128 = escrow_total / 2;
-    client.resolve_dispute(&arbiter, &id, &pay_employee, &refund_employer).unwrap();
+    client.resolve_dispute(&arbiter, &id, &pay_employee, &refund_employer, &None::<u128>).unwrap();
     let after_resolve = client.get_agreement(&id).unwrap();
     let dispute_after = client.get_dispute_status(&id);
 
@@ -558,7 +558,7 @@ fn snapshot_emergency_pause_blocks_and_unblocks_operations() {
     );
 
     // Security: both claim types must be blocked
-    let payroll_blocked = client.try_claim_payroll(&employee, &payroll_id, &0u32).is_err();
+    let payroll_blocked = client.try_claim_payroll(&employee, &payroll_id, &0u32, &None::<u128>).is_err();
     let milestone_blocked = client.try_claim_milestone(&ms_id, &1u32).is_err();
 
     // Phase 3: Unpause
@@ -566,7 +566,7 @@ fn snapshot_emergency_pause_blocks_and_unblocks_operations() {
     let paused_after_unpause = client.is_emergency_paused();
 
     // Phase 4: Claims succeed after unpause
-    let payroll_claim_ok = client.try_claim_payroll(&employee, &payroll_id, &0u32).is_ok();
+    let payroll_claim_ok = client.try_claim_payroll(&employee, &payroll_id, &0u32, &None::<u128>).is_ok();
     let milestone_claim_ok = client.try_claim_milestone(&ms_id, &1u32).is_ok();
 
     let snapshot = format!(

--- a/onchain/contracts/stello_pay_contract/tests/test_boundary_conditions.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_boundary_conditions.rs
@@ -536,7 +536,7 @@ fn test_resolve_dispute_payout_exceeds_total_rejected() {
     client.raise_dispute(&employer, &agreement_id);
 
     // Attempt resolve with payout sum (60 + 50 = 110) exceeding total (100)
-    let result = client.try_resolve_dispute(&arbiter, &agreement_id, &60i128, &50i128);
+    let result = client.try_resolve_dispute(&arbiter, &agreement_id, &60i128, &50i128, &None::<u128>, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -565,7 +565,7 @@ fn test_resolve_dispute_zero_payouts_succeeds() {
     client.raise_dispute(&employer, &agreement_id);
 
     // Resolve with zero payouts — no token transfers occur
-    client.resolve_dispute(&arbiter, &agreement_id, &0i128, &0i128);
+    client.resolve_dispute(&arbiter, &agreement_id, &0i128, &0i128, &None::<u128>);
 
     // Verify dispute is resolved and agreement completed
     assert_eq!(
@@ -664,7 +664,7 @@ fn test_claim_payroll_invalid_employee_index_max_u32() {
     let agreement_id = client.create_payroll_agreement(&employer, &token, &604800u64);
 
     // DataKey employee count defaults to 0; u32::MAX >= 0 → InvalidEmployeeIndex
-    let result = client.try_claim_payroll(&caller, &agreement_id, &u32::MAX);
+    let result = client.try_claim_payroll(&caller, &agreement_id, &u32::MAX, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -683,7 +683,7 @@ fn test_claim_payroll_index_zero_with_no_employees() {
     let agreement_id = client.create_payroll_agreement(&employer, &token, &604800u64);
 
     // DataKey employee count defaults to 0; index 0 >= 0 → InvalidEmployeeIndex
-    let result = client.try_claim_payroll(&caller, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&caller, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_err());
 }
 

--- a/onchain/contracts/stello_pay_contract/tests/test_concurrent_operations.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_concurrent_operations.rs
@@ -154,7 +154,7 @@ fn test_payroll_batch_claim_rejected_before_activation() {
 
     // Neither employee should be able to claim before the employer activates.
     let indices = Vec::from_array(&env, [0u32, 1u32]);
-    let result = client.try_batch_claim_payroll(&employer, &agreement_id, &indices);
+    let result = client.try_batch_claim_payroll(&employer, &agreement_id, &indices, &None::<u128>);
 
     // Agreement is in `Created` status → claim must fail.
     assert_eq!(result, Err(Ok(PayrollError::InvalidData)));
@@ -423,19 +423,19 @@ fn test_concurrent_dispute_resolutions() {
 
     // --- Scenario 8: unauthorized resolution ---
     let random_user = Address::generate(&env);
-    let unauth_resolve = client.try_resolve_dispute(&random_user, &agreement_id, &500, &500);
+    let unauth_resolve = client.try_resolve_dispute(&random_user, &agreement_id, &500, &500, &None::<u128>, &None::<u128>);
     assert_eq!(unauth_resolve, Err(Ok(PayrollError::NotArbiter)));
 
     // --- Scenario 9: double-resolve ---
     // Fund contract to satisfy transfer during resolution.
     mint(&env, &token, &client.address, 1000);
-    client.resolve_dispute(&arbiter, &agreement_id, &500, &500);
+    client.resolve_dispute(&arbiter, &agreement_id, &500, &500, &None::<u128>);
     assert_eq!(
         client.get_dispute_status(&agreement_id),
         DisputeStatus::Resolved
     );
 
-    let double_resolve = client.try_resolve_dispute(&arbiter, &agreement_id, &500, &500);
+    let double_resolve = client.try_resolve_dispute(&arbiter, &agreement_id, &500, &500, &None::<u128>, &None::<u128>);
     assert_eq!(double_resolve, Err(Ok(PayrollError::NoDispute)));
 }
 
@@ -685,7 +685,7 @@ fn test_separate_agreements_do_not_interfere() {
 
     // Resolve dispute on id2.
     mint(&env, &token, &client.address, 4000);
-    client.resolve_dispute(&arbiter, &id2, &1000, &1000);
+    client.resolve_dispute(&arbiter, &id2, &1000, &1000, &None::<u128>);
     assert_eq!(client.get_dispute_status(&id2), DisputeStatus::Resolved);
 
     // id1 milestone 3 is still available and uncorrupted after dispute resolution on id2.

--- a/onchain/contracts/stello_pay_contract/tests/test_conditional_triggers.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_conditional_triggers.rs
@@ -809,7 +809,7 @@ fn test_payroll_claim_blocked_before_first_period() {
     );
 
     // No time advance — zero periods elapsed.
-    let result = client.try_claim_payroll(&employee, &_agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &_agreement_id, &0u32, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -829,7 +829,7 @@ fn test_payroll_claim_after_one_period_correct_amount() {
     );
 
     advance_time(&env, ONE_DAY);
-    client.claim_payroll(&employee, &agreement_id, &0u32);
+    client.claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
 
     assert_eq!(balance(&env, &token, &employee), STANDARD_SALARY);
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
@@ -863,15 +863,15 @@ fn test_payroll_batch_distributes_to_multiple_employees() {
     // so each employee claims their own index individually.
     let mut idx0 = Vec::new(&env);
     idx0.push_back(0u32);
-    let b0 = client.batch_claim_payroll(&e0, &agreement_id, &idx0);
+    let b0 = client.batch_claim_payroll(&e0, &agreement_id, &idx0, &None::<u128>);
 
     let mut idx1 = Vec::new(&env);
     idx1.push_back(1u32);
-    let b1 = client.batch_claim_payroll(&e1, &agreement_id, &idx1);
+    let b1 = client.batch_claim_payroll(&e1, &agreement_id, &idx1, &None::<u128>);
 
     let mut idx2 = Vec::new(&env);
     idx2.push_back(2u32);
-    let b2 = client.batch_claim_payroll(&e2, &agreement_id, &idx2);
+    let b2 = client.batch_claim_payroll(&e2, &agreement_id, &idx2, &None::<u128>);
 
     assert_eq!(b0.successful_claims, 1);
     assert_eq!(b1.successful_claims, 1);
@@ -898,7 +898,7 @@ fn test_payroll_wrong_employee_index_rejected() {
     );
 
     advance_time(&env, ONE_DAY);
-    let result = client.try_claim_payroll(&employee, &agreement_id, &99u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &99u32, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -916,7 +916,7 @@ fn test_payroll_claim_blocked_if_agreement_not_active() {
     client.add_employee_to_agreement(&agreement_id, &employee, &STANDARD_SALARY);
     // Intentionally not activated.
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -959,7 +959,7 @@ fn test_payroll_claim_blocked_after_grace_period_expired() {
     advance_time(&env, grace_period + ONE_SECOND);
     assert!(!client.is_grace_period_active(&agreement_id));
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -1076,7 +1076,7 @@ fn test_composite_emergency_pause_blocks_all_trigger_types() {
 
     // All three must fail.
     assert!(client.try_claim_time_based(&escrow_id).is_err());
-    assert!(client.try_claim_payroll(&employee, &payroll_id, &0u32).is_err());
+    assert!(client.try_claim_payroll(&employee, &payroll_id, &0u32, &None::<u128>).is_err());
     assert!(client.try_claim_milestone(&ms_id, &1u32).is_err());
 }
 
@@ -1105,7 +1105,7 @@ fn test_composite_dispute_blocks_payroll_claims() {
     );
 
     // Payroll claim must now fail.
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -1146,7 +1146,7 @@ fn test_composite_grace_period_claim_succeeds_then_expires() {
     assert!(client.is_grace_period_active(&agreement_id));
 
     // Claim within grace period must succeed.
-    client.claim_payroll(&employee, &agreement_id, &0u32);
+    client.claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(balance(&env, &token, &employee), STANDARD_SALARY);
 
     // Advance past grace period.
@@ -1155,6 +1155,6 @@ fn test_composite_grace_period_claim_succeeds_then_expires() {
 
     // A second claim (for the same period) must fail — both because all
     // claimable periods are exhausted and because the grace window closed.
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_err());
 }

--- a/onchain/contracts/stello_pay_contract/tests/test_dispute_integration.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_dispute_integration.rs
@@ -41,7 +41,7 @@ fn test_dispute_payroll_multi_employee_split() {
     tok_admin.mint(&cid, &200);
 
     client.raise_dispute(&employer, &aid);
-    client.resolve_dispute(&arbiter, &aid, &150, &50);
+    client.resolve_dispute(&arbiter, &aid, &150, &50, &None::<u128>);
 
     assert_eq!(tok_client.balance(&e1), 75);
     assert_eq!(tok_client.balance(&e2), 75);
@@ -69,7 +69,7 @@ fn test_dispute_escrow_funded_resolve_split() {
     tok_admin.mint(&cid, &1000);
 
     client.raise_dispute(&employer, &aid);
-    client.resolve_dispute(&arbiter, &aid, &600, &400);
+    client.resolve_dispute(&arbiter, &aid, &600, &400, &None::<u128>);
 
     assert_eq!(tok_client.balance(&contributor), 600);
     assert_eq!(tok_client.balance(&employer), 400);

--- a/onchain/contracts/stello_pay_contract/tests/test_disputes.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_disputes.rs
@@ -65,7 +65,7 @@ fn test_full_dispute_flow_resolved_by_arbiter() {
     // 3. Resolve Dispute by Arbiter
     let employer_refund = 600_i128; // 60% refund
     let employee_payout = 400_i128; // 40% payout
-    payroll_client.resolve_dispute(&arbiter, &agreement_id, &employee_payout, &employer_refund);
+    payroll_client.resolve_dispute(&arbiter, &agreement_id, &employee_payout, &employer_refund, &None::<u128>);
 
     // Verify state changed to Resolved
     let final_status = payroll_client.get_dispute_status(&agreement_id);
@@ -113,7 +113,7 @@ fn test_resolve_dispute_invalid_amounts() {
     payroll_client.raise_dispute(&employer, &agreement_id);
 
     // Amounts sum to 1100, but escrow is only 1000
-    let result = payroll_client.try_resolve_dispute(&arbiter, &agreement_id, &600_i128, &500_i128);
+    let result = payroll_client.try_resolve_dispute(&arbiter, &agreement_id, &600_i128, &500_i128, &None::<u128>, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InvalidPayout)));
 }
 
@@ -141,7 +141,7 @@ fn test_multi_employee_payout_split() {
     payroll_client.raise_dispute(&employer, &agreement_id);
 
     // Arbiter resolves, employee pool gets 150, employer gets 50
-    payroll_client.resolve_dispute(&arbiter, &agreement_id, &150_i128, &50_i128);
+    payroll_client.resolve_dispute(&arbiter, &agreement_id, &150_i128, &50_i128, &None::<u128>);
 
     assert_eq!(payroll_client.get_dispute_status(&agreement_id), DisputeStatus::Resolved);
     // Pay is split equally among employees (150 / 2 = 75)

--- a/onchain/contracts/stello_pay_contract/tests/test_emergency_pause.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_emergency_pause.rs
@@ -183,7 +183,7 @@ fn test_paused_blocks_claims() {
     let _ = client.emergency_pause();
 
     // Attempt to claim should fail
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0, &None::<u128>);
     assert!(result.is_err());
 }
 

--- a/onchain/contracts/stello_pay_contract/tests/test_grace_period.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_grace_period.rs
@@ -698,10 +698,10 @@ fn test_claim_payroll_during_grace_period() {
     client.cancel_agreement(&agreement_id);
 
     // Both employees claim during grace period
-    let result1 = client.try_claim_payroll(&employee1, &agreement_id, &0);
+    let result1 = client.try_claim_payroll(&employee1, &agreement_id, &0, &None::<u128>);
     assert!(result1.is_ok());
 
-    let result2 = client.try_claim_payroll(&employee2, &agreement_id, &1);
+    let result2 = client.try_claim_payroll(&employee2, &agreement_id, &1, &None::<u128>);
     assert!(result2.is_ok());
 
     // Verify balances
@@ -787,7 +787,7 @@ fn test_cannot_claim_after_grace_period() {
     advance_time(&env, ONE_HOUR + 1);
 
     // Attempt claim - should fail
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0, &None::<u128>);
     assert!(result.is_err());
 }
 
@@ -817,7 +817,7 @@ fn test_cannot_claim_if_not_cancelled() {
     advance_time(&env, ONE_DAY);
 
     // Claim should work normally
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0, &None::<u128>);
     assert!(result.is_ok());
 
     // Verify claim
@@ -990,7 +990,7 @@ fn test_finalize_refunds_remaining() {
 
     // Employee claims 1000
     client
-        .try_claim_payroll(&employee, &agreement_id, &0)
+        .try_claim_payroll(&employee, &agreement_id, &0, &None::<u128>)
         .unwrap();
 
     // Advance beyond grace

--- a/onchain/contracts/stello_pay_contract/tests/test_overflow_protection.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_overflow_protection.rs
@@ -63,7 +63,7 @@ fn test_claim_payroll_amount_multiplication_overflow_guard() {
         li.timestamp = 3;
     });
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InvalidData)));
 }
 
@@ -103,6 +103,6 @@ fn test_claim_payroll_paid_amount_addition_overflow_guard() {
         li.timestamp = 1;
     });
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InvalidData)));
 }

--- a/onchain/contracts/stello_pay_contract/tests/test_payment_failures.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_payment_failures.rs
@@ -219,7 +219,7 @@ fn test_payroll_claim_insufficient_escrow_balance() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InsufficientEscrowBalance)));
 }
 
@@ -248,7 +248,7 @@ fn test_payroll_claim_zero_escrow_balance() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InsufficientEscrowBalance)));
 }
 
@@ -276,7 +276,7 @@ fn test_payroll_claim_partial_escrow_covers_fewer_periods() {
 
     advance_time(&env, ONE_DAY * 3 + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InsufficientEscrowBalance)));
 }
 
@@ -400,12 +400,12 @@ fn test_batch_payroll_partial_escrow_failure() {
     advance_time(&env, ONE_DAY + 1);
 
     // e1 claims successfully, draining the escrow.
-    let batch_e1 = client.batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32]));
+    let batch_e1 = client.batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32]), &None::<u128>);
     assert_eq!(batch_e1.successful_claims, 1);
     assert_eq!(batch_e1.total_claimed, salary);
 
     // e2 attempts to claim — escrow is empty.
-    let batch_e2 = client.batch_claim_payroll(&e2, &agreement_id, &Vec::from_array(&env, [1u32]));
+    let batch_e2 = client.batch_claim_payroll(&e2, &agreement_id, &Vec::from_array(&env, [1u32]), &None::<u128>);
     assert_eq!(batch_e2.successful_claims, 0);
     assert_eq!(batch_e2.failed_claims, 1);
 
@@ -450,7 +450,7 @@ fn test_payroll_claim_panics_without_onchain_tokens() {
 
     // This panics inside the token contract because the contract address has
     // insufficient on-chain token balance despite the DataKey saying otherwise.
-    let _ = client.claim_payroll(&employee, &agreement_id, &0u32);
+    let _ = client.claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
 }
 
 /// Time-based escrow claim also panics when the on-chain token balance is zero
@@ -515,7 +515,7 @@ fn test_pause_blocks_claim_resume_allows_claim() {
     // Pause — claim should fail.
     client.pause_agreement(&agreement_id);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(
         result.is_err()
             || result
@@ -528,7 +528,7 @@ fn test_pause_blocks_claim_resume_allows_claim() {
     // Resume — claim should succeed.
     client.resume_agreement(&agreement_id);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_ok());
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
 }
@@ -671,7 +671,7 @@ fn test_fund_and_retry_after_insufficient_balance() {
     advance_time(&env, ONE_DAY + 1);
 
     // First attempt fails.
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InsufficientEscrowBalance)));
 
     // Top up escrow.
@@ -681,7 +681,7 @@ fn test_fund_and_retry_after_insufficient_balance() {
     });
 
     // Retry — should succeed.
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_ok());
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
 }
@@ -731,7 +731,7 @@ fn test_batch_payroll_error_codes() {
 
     // Employee claims index 0 (self — success) and index 1 (not self — Unauthorized).
     let indices = Vec::from_array(&env, [0u32, 1u32]);
-    let batch = client.batch_claim_payroll(&employee, &agreement_id, &indices);
+    let batch = client.batch_claim_payroll(&employee, &agreement_id, &indices, &None::<u128>);
 
     assert_eq!(batch.successful_claims, 1);
     assert_eq!(batch.failed_claims, 1);
@@ -779,7 +779,7 @@ fn test_batch_payroll_invalid_index_error_code() {
 
     // Index 99 does not exist.
     let indices = Vec::from_array(&env, [0u32, 99u32]);
-    let batch = client.batch_claim_payroll(&employee, &agreement_id, &indices);
+    let batch = client.batch_claim_payroll(&employee, &agreement_id, &indices, &None::<u128>);
 
     assert_eq!(batch.successful_claims, 1);
     assert_eq!(batch.failed_claims, 1);
@@ -883,7 +883,7 @@ fn test_escrow_balance_unchanged_after_failed_claim() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
 
     // Verify escrow balance is unchanged.
     let escrow_after: i128 = env.as_contract(&contract_id, || {
@@ -920,14 +920,14 @@ fn test_claimed_periods_unchanged_after_failed_claim() {
     advance_time(&env, ONE_DAY + 1);
 
     // Succeed on first claim.
-    let _ = client.claim_payroll(&employee, &agreement_id, &0u32);
+    let _ = client.claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
 
     // Advance another day — escrow is now empty.
     advance_time(&env, ONE_DAY);
 
     // Fail on second claim.
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(
         result.is_err()
             || result
@@ -969,7 +969,7 @@ fn test_agreement_status_unchanged_after_failed_claim() {
 
     let status_before = client.get_agreement(&agreement_id).unwrap().status;
 
-    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
 
     let status_after = client.get_agreement(&agreement_id).unwrap().status;
     assert_eq!(status_before, status_after);
@@ -1005,7 +1005,7 @@ fn test_paid_amount_unchanged_after_failed_claim() {
         DataKey::get_agreement_paid_amount(&env, agreement_id)
     });
 
-    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let _ = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
 
     let paid_after: i128 = env.as_contract(&contract_id, || {
         DataKey::get_agreement_paid_amount(&env, agreement_id)
@@ -1043,7 +1043,7 @@ fn test_payroll_claim_on_non_activated_agreement() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(
         result.is_err()
             || result
@@ -1106,7 +1106,7 @@ fn test_payroll_claim_on_paused_agreement() {
     client.pause_agreement(&agreement_id);
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InvalidData)));
 }
 
@@ -1176,7 +1176,7 @@ fn test_payroll_claim_on_escrow_mode_agreement() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&contributor, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&contributor, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InvalidAgreementMode)));
 }
 
@@ -1234,7 +1234,7 @@ fn test_payroll_claim_unauthorized_caller() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&impostor, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&impostor, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::Unauthorized)));
 }
 
@@ -1265,7 +1265,7 @@ fn test_payroll_claim_invalid_employee_index() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &99u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &99u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::InvalidEmployeeIndex)));
 }
 
@@ -1296,11 +1296,11 @@ fn test_payroll_double_claim_same_period() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert!(result.is_ok());
 
     // Claim again without advancing time.
-    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32);
+    let result = client.try_claim_payroll(&employee, &agreement_id, &0u32, &None::<u128>);
     assert_eq!(result, Err(Ok(PayrollError::NoPeriodsToClaim)));
 }
 
@@ -1426,16 +1426,16 @@ fn test_batch_payroll_mixed_state_consistency() {
     // Claims for all three as e1 (only index 0 matches caller).
     // e1 succeeds on index 0, fails on 1 (Unauthorized), fails on 2 (Unauthorized).
     // So use e1 for index 0, then separately use e2 for index 1.
-    let batch_e1 = client.batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32]));
+    let batch_e1 = client.batch_claim_payroll(&e1, &agreement_id, &Vec::from_array(&env, [0u32]), &None::<u128>);
     assert_eq!(batch_e1.successful_claims, 1);
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0u32), 1);
 
-    let batch_e2 = client.batch_claim_payroll(&e2, &agreement_id, &Vec::from_array(&env, [1u32]));
+    let batch_e2 = client.batch_claim_payroll(&e2, &agreement_id, &Vec::from_array(&env, [1u32]), &None::<u128>);
     assert_eq!(batch_e2.successful_claims, 1);
     assert_eq!(client.get_employee_claimed_periods(&agreement_id, &1u32), 1);
 
     // e3 tries to claim — insufficient escrow.
-    let batch_e3 = client.batch_claim_payroll(&e3, &agreement_id, &Vec::from_array(&env, [2u32]));
+    let batch_e3 = client.batch_claim_payroll(&e3, &agreement_id, &Vec::from_array(&env, [2u32]), &None::<u128>);
     assert_eq!(batch_e3.successful_claims, 0);
     assert_eq!(batch_e3.failed_claims, 1);
 

--- a/onchain/contracts/stello_pay_contract/tests/test_reentrancy.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_reentrancy.rs
@@ -90,13 +90,13 @@ fn test_claim_payroll_state_updated_prevents_double_claim() {
 
     advance_time(&env, ONE_DAY + 1);
 
-    let res = client.try_claim_payroll(&employee, &agreement_id, &0);
+    let res = client.try_claim_payroll(&employee, &agreement_id, &0, &None::<u128>);
     assert!(res.is_ok());
 
     let claimed = client.get_employee_claimed_periods(&agreement_id, &0);
     assert_eq!(claimed, 1);
 
-    let res2 = client.try_claim_payroll(&employee, &agreement_id, &0);
+    let res2 = client.try_claim_payroll(&employee, &agreement_id, &0, &None::<u128>);
     assert!(
         res2.is_err() || res2.as_ref().ok().and_then(|r| r.as_ref().err()).is_some(),
         "second claim must fail (no periods to claim)"

--- a/onchain/contracts/stello_pay_contract/tests/test_state_machine.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_state_machine.rs
@@ -389,7 +389,7 @@ fn test_disputed_to_completed_via_resolve_dispute() {
     );
 
     let half = SALARY / 2;
-    client.resolve_dispute(&arbiter, &id, &half, &half);
+    client.resolve_dispute(&arbiter, &id, &half, &half, &None::<u128>);
 
     let a = client.get_agreement(&id).unwrap();
     assert_eq!(a.status, AgreementStatus::Completed);


### PR DESCRIPTION
Closes #448 

## Summary

Wires M-of-N multisig approval into `claim_payroll` and `resolve_dispute` so high-value payments and dispute resolutions cannot be executed by a single key.

## Changes

### `onchain/contracts/multisig/src/lib.rs`
- Added `OperationThresholds` struct with configurable `large_payment` and `dispute_resolution` thresholds
- Added `effective_threshold()` helper: `max(global_threshold, per_kind_threshold)`
- Added `set_operation_thresholds(owner, thresholds)` — owner-only
- Added `get_operation_thresholds()` — read current config
- Added `is_operation_approved(op_id) -> bool` — returns true iff operation is `Executed`

### `onchain/contracts/stello_pay_contract/src/storage.rs`
- Added `MultisigConfig` struct (`contract`, `large_payment_threshold`, `dispute_threshold`)
- Added `StorageKey::MultisigConfig`
- Added `PayrollError::MultisigApprovalRequired = 33` and `MultisigOperationMismatch = 34`

### `onchain/contracts/stello_pay_contract/src/payroll.rs`
- Added `set_multisig_config()`, `get_multisig_config()`, `require_multisig_approved()` helpers
- `claim_payroll` — new param `multisig_operation_id: Option<u128>`; gate fires when `amount >= large_payment_threshold`
- `batch_claim_payroll` — same gate applied per-item
- `resolve_dispute` — new param; gate fires when `total_payout >= dispute_threshold`
- Check is **opt-in**: no `MultisigConfig` stored → no cross-contract call, zero regression

### `onchain/contracts/stello_pay_contract/src/lib.rs`
- Exposed `set_multisig_config` / `get_multisig_config`
- Updated signatures for `claim_payroll`, `batch_claim_payroll`, `resolve_dispute`

### `onchain/contracts/multisig/tests/multisig_integration_tests.rs` *(new)*
17 integration tests covering:
- `set_operation_thresholds` access control and validation
- `is_operation_approved` state transitions
- 2-of-3 and 3-of-3 `LargePayment` flows
- Duplicate approval idempotency, non-signer rejection, post-execution approval rejection
- 2-of-3 and 3-of-3 `DisputeResolution` flows
- Cancellation before threshold
- Emergency guardian bypass
- Per-kind threshold clamped to global minimum

### `docs/multisig-operation-types.md` *(new)*
Full documentation: architecture diagram, configuration steps, approval flows, security properties, error codes, API surface, test index.

## Backward Compatibility
All existing tests updated with `&None::<u128>` for the new optional parameter — no behaviour change when `MultisigConfig` is not set.