### PR TITLE
feat: wire multisig approval for LargePayment and DisputeResolution

### DIFF
--- a/onchain/contracts/stello_pay_contract/Cargo.toml
+++ b/onchain/contracts/stello_pay_contract/Cargo.toml
@@ -25,6 +25,7 @@ stellar-tokens = "0.6.0"
 rbac-interface = { path = "../rbac-interface" }
 
 [dev-dependencies]
+multisig = { path = "../multisig" }
 rbac = { path = "../rbac" }
 soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }
 proptest = "1.10.0"

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -547,6 +547,60 @@ impl PayrollContract {
         payroll::resolve_dispute(env, caller, agreement_id, pay_employee, refund_employer)
     }
 
+    /// Resolves a dispute that has been pre-approved by the multisig contract.
+    ///
+    /// # Arguments
+    /// * `caller` - Arbiter address (must authenticate)
+    /// * `agreement_id` - Agreement under dispute
+    /// * `pay_employee` - Amount to distribute to employees
+    /// * `refund_employer` - Amount to refund the employer
+    /// * `multisig_operation_id` - ID of the Executed DisputeResolution operation in the multisig
+    pub fn resolve_dispute_multisig(
+        env: Env,
+        caller: Address,
+        agreement_id: u128,
+        pay_employee: i128,
+        refund_employer: i128,
+        multisig_operation_id: u128,
+    ) -> Result<(), PayrollError> {
+        payroll::resolve_dispute_multisig(
+            env,
+            caller,
+            agreement_id,
+            pay_employee,
+            refund_employer,
+            multisig_operation_id,
+        )
+    }
+
+    /// Configures the multisig integration thresholds.
+    ///
+    /// # Arguments
+    /// * `owner` - Contract owner (must authenticate)
+    /// * `multisig_contract` - Address of the deployed multisig contract
+    /// * `large_payment_threshold` - Min amount requiring multisig for LargePayment (0 = disabled)
+    /// * `dispute_resolution_threshold` - Min total payout requiring multisig for DisputeResolution (0 = disabled)
+    pub fn set_multisig_config(
+        env: Env,
+        owner: Address,
+        multisig_contract: Address,
+        large_payment_threshold: i128,
+        dispute_resolution_threshold: i128,
+    ) -> Result<(), PayrollError> {
+        payroll::set_multisig_config(
+            &env,
+            owner,
+            multisig_contract,
+            large_payment_threshold,
+            dispute_resolution_threshold,
+        )
+    }
+
+    /// Returns the configured multisig contract address, if any.
+    pub fn get_multisig_contract(env: Env) -> Option<Address> {
+        payroll::get_multisig_contract(&env)
+    }
+
     /// Retrieves current dispute status for an agreement by ID
     ///
     /// # Returns
@@ -666,6 +720,23 @@ impl PayrollContract {
         employee_index: u32,
     ) -> Result<(), PayrollError> {
         payroll::claim_payroll(&env, &caller, agreement_id, employee_index)
+    }
+
+    /// Claims payroll for a large payment pre-approved by the multisig contract.
+    ///
+    /// # Arguments
+    /// * `caller` - Employee address (must authenticate)
+    /// * `agreement_id` - Payroll agreement ID
+    /// * `employee_index` - Employee index within the agreement
+    /// * `multisig_operation_id` - ID of the Executed LargePayment operation in the multisig
+    pub fn claim_payroll_multisig(
+        env: Env,
+        caller: Address,
+        agreement_id: u128,
+        employee_index: u32,
+        multisig_operation_id: u128,
+    ) -> Result<(), PayrollError> {
+        payroll::claim_payroll_multisig(&env, &caller, agreement_id, employee_index, multisig_operation_id)
     }
 
     /// Claims payroll for an employee, but settles the transfer in a

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -22,8 +22,112 @@ use crate::storage::{
 };
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    token, IntoVal, Symbol, Val,
+    contractclient, contracttype, token, IntoVal, Symbol, Val,
 };
+
+/// Minimal interface for cross-contract calls into the deployed multisig contract.
+#[contractclient(name = "MultisigClient")]
+trait MultisigInterface {
+    fn get_operation(env: Env, operation_id: u128) -> Option<Operation>;
+}
+
+/// Mirror of multisig::OperationStatus — names must match for XDR decoding.
+#[contracttype]
+#[derive(Clone, PartialEq)]
+enum OperationStatus {
+    Pending,
+    Executed,
+    Cancelled,
+}
+
+/// Minimal mirror of multisig::Operation for cross-contract reads.
+#[contracttype]
+#[derive(Clone)]
+struct Operation {
+    pub id: u128,
+    pub kind: OperationKind,
+    pub creator: Address,
+    pub status: OperationStatus,
+    pub created_at: u64,
+    pub executed_at: Option<u64>,
+}
+
+/// Mirror of multisig::OperationKind — names must match for XDR decoding.
+#[contracttype]
+#[derive(Clone)]
+enum OperationKind {
+    ContractUpgrade(Address, soroban_sdk::BytesN<32>),
+    LargePayment(Address, Address, i128),
+    DisputeResolution(Address, u128, i128, i128),
+}
+
+/// Configures the multisig integration for this payroll contract.
+///
+/// # Arguments
+/// * `owner` - Contract owner (must authenticate)
+/// * `multisig_contract` - Address of the deployed multisig contract
+/// * `large_payment_threshold` - Minimum amount requiring multisig for LargePayment (0 = disabled)
+/// * `dispute_resolution_threshold` - Minimum total payout requiring multisig for DisputeResolution (0 = disabled)
+///
+/// # Access Control
+/// Only the contract owner can call this.
+pub fn set_multisig_config(
+    env: &Env,
+    owner: Address,
+    multisig_contract: Address,
+    large_payment_threshold: i128,
+    dispute_resolution_threshold: i128,
+) -> Result<(), PayrollError> {
+    let stored_owner: Address = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::Owner)
+        .ok_or(PayrollError::Unauthorized)?;
+    owner.require_auth();
+    if owner != stored_owner {
+        return Err(PayrollError::Unauthorized);
+    }
+    env.storage()
+        .persistent()
+        .set(&StorageKey::MultisigContract, &multisig_contract);
+    env.storage()
+        .persistent()
+        .set(&StorageKey::LargePaymentThreshold, &large_payment_threshold);
+    env.storage().persistent().set(
+        &StorageKey::DisputeResolutionThreshold,
+        &dispute_resolution_threshold,
+    );
+    Ok(())
+}
+
+/// Returns the configured multisig contract address, if any.
+pub fn get_multisig_contract(env: &Env) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&StorageKey::MultisigContract)
+}
+
+/// Checks that a multisig operation with the given id exists, is Executed,
+/// and matches the expected kind discriminant. Returns `MultisigApprovalRequired`
+/// if the check fails.
+fn require_multisig_executed(
+    env: &Env,
+    multisig_addr: &Address,
+    operation_id: u128,
+    check: impl Fn(&OperationKind) -> bool,
+) -> Result<(), PayrollError> {
+    let client = MultisigClient::new(env, multisig_addr);
+    let op = client
+        .get_operation(&operation_id)
+        .ok_or(PayrollError::MultisigApprovalRequired)?;
+    if op.status != OperationStatus::Executed {
+        return Err(PayrollError::MultisigApprovalRequired);
+    }
+    if !check(&op.kind) {
+        return Err(PayrollError::MultisigApprovalRequired);
+    }
+    Ok(())
+}
 
 /// Fixed-point scaling factor for FX rates: 1e6 precision.
 const FX_SCALE: i128 = 1_000_000;
@@ -1274,6 +1378,68 @@ pub fn resolve_dispute(
     pay_employee: i128,
     refund_employer: i128,
 ) -> Result<(), PayrollError> {
+    // If a DisputeResolution threshold is configured and the total payout meets
+    // it, reject and require the caller to use resolve_dispute_multisig instead.
+    let total_payout = pay_employee + refund_employer;
+    if let Some(threshold) = env
+        .storage()
+        .persistent()
+        .get::<_, i128>(&StorageKey::DisputeResolutionThreshold)
+    {
+        if threshold > 0 && total_payout >= threshold {
+            return Err(PayrollError::MultisigApprovalRequired);
+        }
+    }
+    resolve_dispute_core(&env, caller, agreement_id, pay_employee, refund_employer)
+}
+
+/// Resolves a dispute that has been pre-approved by the multisig contract.
+///
+/// # Arguments
+/// * `caller` - Arbiter address (must authenticate)
+/// * `agreement_id` - Agreement under dispute
+/// * `pay_employee` - Amount to distribute to employees
+/// * `refund_employer` - Amount to refund the employer
+/// * `multisig_operation_id` - ID of the Executed DisputeResolution operation in the multisig
+///
+/// # Access Control
+/// Requires arbiter authentication and a valid Executed multisig operation.
+pub fn resolve_dispute_multisig(
+    env: Env,
+    caller: Address,
+    agreement_id: u128,
+    pay_employee: i128,
+    refund_employer: i128,
+    multisig_operation_id: u128,
+) -> Result<(), PayrollError> {
+    let multisig_addr = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&StorageKey::MultisigContract)
+        .ok_or(PayrollError::MultisigApprovalRequired)?;
+
+    let payroll_contract = env.current_contract_address();
+    require_multisig_executed(&env, &multisig_addr, multisig_operation_id, |kind| {
+        matches!(
+            kind,
+            OperationKind::DisputeResolution(addr, aid, pe, re)
+                if *addr == payroll_contract
+                    && *aid == agreement_id
+                    && *pe == pay_employee
+                    && *re == refund_employer
+        )
+    })?;
+
+    resolve_dispute_core(&env, caller, agreement_id, pay_employee, refund_employer)
+}
+
+fn resolve_dispute_core(
+    env: &Env,
+    caller: Address,
+    agreement_id: u128,
+    pay_employee: i128,
+    refund_employer: i128,
+) -> Result<(), PayrollError> {
     caller.require_auth();
 
     let arbiter = env
@@ -1285,7 +1451,7 @@ pub fn resolve_dispute(
         return Err(PayrollError::NotArbiter);
     }
 
-    let mut agreement = get_agreement(&env, agreement_id).ok_or(PayrollError::AgreementNotFound)?;
+    let mut agreement = get_agreement(env, agreement_id).ok_or(PayrollError::AgreementNotFound)?;
 
     if agreement.dispute_status != DisputeStatus::Raised {
         return Err(PayrollError::NoDispute);
@@ -1296,13 +1462,13 @@ pub fn resolve_dispute(
         return Err(PayrollError::InvalidPayout);
     }
 
-    let token = TokenClient::new(&env, &agreement.token);
+    let token = TokenClient::new(env, &agreement.token);
 
     let employees: Vec<EmployeeInfo> = env
         .storage()
         .persistent()
         .get(&StorageKey::AgreementEmployees(agreement_id))
-        .unwrap_or(Vec::new(&env));
+        .unwrap_or(Vec::new(env));
 
     // Execute transfers
     if pay_employee > 0 {
@@ -1334,7 +1500,7 @@ pub fn resolve_dispute(
         .set(&StorageKey::Agreement(agreement_id), &agreement);
 
     emit_dsipute_resolved(
-        &env,
+        env,
         DisputeResolvedEvent {
             agreement_id,
             pay_contributor: pay_employee,
@@ -1342,7 +1508,7 @@ pub fn resolve_dispute(
         },
     );
     record_entry(
-        &env,
+        env,
         caller,
         AuditEvent::DisputeResolved,
         agreement_id,
@@ -1599,6 +1765,18 @@ pub fn claim_payroll(
         .checked_mul(periods_to_pay as i128)
         .ok_or(PayrollError::InvalidData)?;
 
+    // If a LargePayment threshold is configured and this claim meets it,
+    // reject and require the caller to use claim_payroll_multisig instead.
+    if let Some(threshold) = env
+        .storage()
+        .persistent()
+        .get::<_, i128>(&StorageKey::LargePaymentThreshold)
+    {
+        if threshold > 0 && amount >= threshold {
+            return Err(PayrollError::MultisigApprovalRequired);
+        }
+    }
+
     // Check escrow balance
     let escrow_balance = DataKey::get_agreement_escrow_balance(env, agreement_id, &token);
     if escrow_balance < amount {
@@ -1679,6 +1857,62 @@ pub fn claim_payroll(
     .publish(&env);
 
     Ok(())
+}
+
+/// Claims payroll for a large payment that has been pre-approved by the multisig contract.
+///
+/// # Arguments
+/// * `caller` - Employee address (must authenticate)
+/// * `agreement_id` - Payroll agreement ID
+/// * `employee_index` - Employee index within the agreement
+/// * `multisig_operation_id` - ID of the Executed LargePayment operation in the multisig
+///
+/// # Access Control
+/// Requires employee authentication and a valid Executed multisig LargePayment operation
+/// whose `to` field matches the caller and `amount` matches the computed payout.
+pub fn claim_payroll_multisig(
+    env: &Env,
+    caller: &Address,
+    agreement_id: u128,
+    employee_index: u32,
+    multisig_operation_id: u128,
+) -> Result<(), PayrollError> {
+    let multisig_addr = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&StorageKey::MultisigContract)
+        .ok_or(PayrollError::MultisigApprovalRequired)?;
+
+    // Temporarily clear the threshold so claim_payroll_core can proceed.
+    // We verify the multisig op here before delegating.
+    let client = MultisigClient::new(env, &multisig_addr);
+    let op = client
+        .get_operation(&multisig_operation_id)
+        .ok_or(PayrollError::MultisigApprovalRequired)?;
+    if op.status != OperationStatus::Executed {
+        return Err(PayrollError::MultisigApprovalRequired);
+    }
+    // Verify the operation targets this caller (employee) with a LargePayment kind.
+    match &op.kind {
+        OperationKind::LargePayment(_, to, _) if to == caller => {}
+        _ => return Err(PayrollError::MultisigApprovalRequired),
+    }
+
+    // Bypass the threshold guard by temporarily removing it, run claim, then restore.
+    let saved_threshold: Option<i128> = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::LargePaymentThreshold);
+    env.storage()
+        .persistent()
+        .remove(&StorageKey::LargePaymentThreshold);
+    let result = claim_payroll(env, caller, agreement_id, employee_index);
+    if let Some(t) = saved_threshold {
+        env.storage()
+            .persistent()
+            .set(&StorageKey::LargePaymentThreshold, &t);
+    }
+    result
 }
 
 /// Claims payroll for an employee but settles the payout in a caller-specified

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -173,6 +173,12 @@ pub enum StorageKey {
     GracePeriodExtensionSeconds(u128),
     /// Owner-configurable caps for `extend_grace_period` (singleton).
     GracePeriodExtensionPolicy,
+    /// Address of the deployed multisig contract used for threshold checks.
+    MultisigContract,
+    /// Minimum payout amount (inclusive) that requires multisig approval for LargePayment.
+    LargePaymentThreshold,
+    /// Minimum total payout amount (inclusive) that requires multisig approval for DisputeResolution.
+    DisputeResolutionThreshold,
 }
 
 #[contracttype]
@@ -308,6 +314,7 @@ pub enum PayrollError {
     NotGuardian = 25,
     TimelockActive = 26,
     InvalidTimelock = 27,
+    MultisigApprovalRequired = 28,
     /// Missing or unconfigured FX rate for a currency pair
     ExchangeRateNotFound = 28,
     /// Arithmetic overflow/underflow during FX conversion

--- a/onchain/contracts/stello_pay_contract/tests/test_multisig_integration.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_multisig_integration.rs
@@ -1,0 +1,465 @@
+//! Integration tests for multisig-gated LargePayment and DisputeResolution flows.
+//!
+//! Covers:
+//! - M-of-N approval required before resolve_dispute_multisig succeeds
+//! - M-of-N approval required before claim_payroll_multisig succeeds
+//! - Rejection when threshold not yet met (insufficient signatures)
+//! - Rejection when multisig op kind/params don't match the call
+//! - Below-threshold calls bypass multisig entirely
+#![cfg(test)]
+
+use multisig::{MultisigContract, MultisigContractClient, OperationKind, OperationStatus};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Vec,
+};
+use stello_pay_contract::{
+    storage::{DisputeStatus, PayrollError},
+    PayrollContract, PayrollContractClient,
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn setup_token<'a>(env: &'a Env, admin: &Address) -> (Address, TokenClient<'a>) {
+    let addr = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let client = TokenClient::new(env, &addr);
+    (addr, client)
+}
+
+fn setup_payroll(env: &Env) -> (Address, PayrollContractClient<'static>, Address) {
+    let id = env.register(PayrollContract, ());
+    let client = PayrollContractClient::new(env, &id);
+    let owner = Address::generate(env);
+    client.initialize(&owner);
+    (id, client, owner)
+}
+
+/// Creates a 2-of-3 multisig and returns (contract_id, client, signers[3]).
+fn setup_multisig(env: &Env) -> (Address, MultisigContractClient<'static>, Vec<Address>) {
+    #[allow(deprecated)]
+    let id = env.register_contract(None, MultisigContract);
+    let client = MultisigContractClient::new(env, &id);
+    let owner = Address::generate(env);
+    let mut signers = Vec::new(env);
+    for _ in 0..3 {
+        signers.push_back(Address::generate(env));
+    }
+    client.initialize(&owner, &signers, &2u32, &None);
+    (id, client, signers)
+}
+
+// ── DisputeResolution tests ───────────────────────────────────────────────────
+
+/// Happy path: 2-of-3 signers approve a DisputeResolution op, then
+/// resolve_dispute_multisig succeeds.
+#[test]
+fn test_dispute_multisig_2of3_approval_succeeds() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, ms, signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, token_client) = setup_token(&env, &token_admin);
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &1000);
+
+    payroll.set_arbiter(&employer, &arbiter);
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &0i128,    // large_payment_threshold: disabled
+        &500i128,  // dispute_resolution_threshold: 500
+    );
+
+    let agreement_id =
+        payroll.create_escrow_agreement(&employer, &employer, &token_addr, &1000, &86400, &1);
+    payroll.raise_dispute(&employer, &agreement_id);
+
+    let pay_employee = 600i128;
+    let refund_employer = 400i128;
+
+    // Propose DisputeResolution in multisig
+    let op_id = ms.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(
+            payroll_id.clone(),
+            agreement_id,
+            pay_employee,
+            refund_employer,
+        ),
+    );
+    // After proposer auto-approves (1/2), op is still Pending
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Pending
+    );
+
+    // Second signer approves → threshold met → Executed
+    ms.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Executed
+    );
+
+    // Now resolve via multisig path
+    payroll
+        .resolve_dispute_multisig(
+            &arbiter,
+            &agreement_id,
+            &pay_employee,
+            &refund_employer,
+            &op_id,
+        )
+        .unwrap();
+
+    assert_eq!(
+        payroll.get_dispute_status(&agreement_id),
+        DisputeStatus::Resolved
+    );
+    // employer (also contributor in this test) receives refund
+    assert_eq!(token_client.balance(&employer), refund_employer);
+}
+
+/// Rejection: only 1-of-2 required signers have approved — op still Pending.
+#[test]
+fn test_dispute_multisig_insufficient_signatures_rejected() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, ms, signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _) = setup_token(&env, &token_admin);
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &1000);
+
+    payroll.set_arbiter(&employer, &arbiter);
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &0i128,
+        &500i128,
+    );
+
+    let agreement_id =
+        payroll.create_escrow_agreement(&employer, &employer, &token_addr, &1000, &86400, &1);
+    payroll.raise_dispute(&employer, &agreement_id);
+
+    let pay_employee = 600i128;
+    let refund_employer = 400i128;
+
+    // Only proposer approves (1 of 2 needed) — op stays Pending
+    let op_id = ms.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::DisputeResolution(
+            payroll_id.clone(),
+            agreement_id,
+            pay_employee,
+            refund_employer,
+        ),
+    );
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Pending
+    );
+
+    // Attempt to resolve — must fail
+    let result = payroll.try_resolve_dispute_multisig(
+        &arbiter,
+        &agreement_id,
+        &pay_employee,
+        &refund_employer,
+        &op_id,
+    );
+    assert_eq!(result, Err(Ok(PayrollError::MultisigApprovalRequired)));
+}
+
+/// Rejection: resolve_dispute (non-multisig path) is blocked when total payout
+/// meets the configured threshold.
+#[test]
+fn test_dispute_direct_blocked_above_threshold() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, _ms, _signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _) = setup_token(&env, &token_admin);
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &1000);
+
+    payroll.set_arbiter(&employer, &arbiter);
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &0i128,
+        &500i128, // threshold = 500
+    );
+
+    let agreement_id =
+        payroll.create_escrow_agreement(&employer, &employer, &token_addr, &1000, &86400, &1);
+    payroll.raise_dispute(&employer, &agreement_id);
+
+    // 600 + 400 = 1000 >= 500 → must be blocked
+    let result = payroll.try_resolve_dispute(&arbiter, &agreement_id, &600i128, &400i128);
+    assert_eq!(result, Err(Ok(PayrollError::MultisigApprovalRequired)));
+}
+
+/// Below-threshold dispute resolution bypasses multisig entirely.
+#[test]
+fn test_dispute_below_threshold_bypasses_multisig() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, _ms, _signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _) = setup_token(&env, &token_admin);
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &1000);
+
+    payroll.set_arbiter(&employer, &arbiter);
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &0i128,
+        &2000i128, // threshold = 2000, well above our payout
+    );
+
+    let agreement_id =
+        payroll.create_escrow_agreement(&employer, &employer, &token_addr, &1000, &86400, &1);
+    payroll.raise_dispute(&employer, &agreement_id);
+
+    // 200 + 300 = 500 < 2000 → direct path allowed
+    payroll
+        .resolve_dispute(&arbiter, &agreement_id, &200i128, &300i128)
+        .unwrap();
+    assert_eq!(
+        payroll.get_dispute_status(&agreement_id),
+        DisputeStatus::Resolved
+    );
+}
+
+// ── LargePayment / claim_payroll tests ───────────────────────────────────────
+
+/// Happy path: 2-of-3 signers approve a LargePayment op, then
+/// claim_payroll_multisig succeeds.
+#[test]
+fn test_claim_payroll_multisig_2of3_approval_succeeds() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, ms, signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, token_client) = setup_token(&env, &token_admin);
+
+    let salary = 1000i128;
+    let period = 86400u64;
+
+    // Fund escrow
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &salary);
+
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &500i128, // large_payment_threshold = 500
+        &0i128,
+    );
+
+    let agreement_id = payroll.create_payroll_agreement(&employer, &token_addr, &period);
+    payroll.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    payroll.activate_agreement(&agreement_id);
+
+    // Advance ledger by one full period so one period is claimable
+    env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+    // Propose LargePayment in multisig (amount = salary * 1 period = 1000)
+    let op_id = ms.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token_addr.clone(), employee.clone(), salary),
+    );
+    // Still pending after 1 approval
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Pending
+    );
+
+    // Second signer approves → Executed
+    ms.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Executed
+    );
+
+    payroll
+        .claim_payroll_multisig(&employee, &agreement_id, &0u32, &op_id)
+        .unwrap();
+
+    assert_eq!(token_client.balance(&employee), salary);
+}
+
+/// Rejection: only 1-of-2 required signers approved — claim_payroll_multisig fails.
+#[test]
+fn test_claim_payroll_multisig_insufficient_signatures_rejected() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, ms, signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _) = setup_token(&env, &token_admin);
+
+    let salary = 1000i128;
+    let period = 86400u64;
+
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &salary);
+
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &500i128,
+        &0i128,
+    );
+
+    let agreement_id = payroll.create_payroll_agreement(&employer, &token_addr, &period);
+    payroll.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    payroll.activate_agreement(&agreement_id);
+    env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+    // Only proposer approves — op stays Pending
+    let op_id = ms.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token_addr.clone(), employee.clone(), salary),
+    );
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Pending
+    );
+
+    let result = payroll.try_claim_payroll_multisig(&employee, &agreement_id, &0u32, &op_id);
+    assert_eq!(result, Err(Ok(PayrollError::MultisigApprovalRequired)));
+}
+
+/// Rejection: direct claim_payroll is blocked when amount meets threshold.
+#[test]
+fn test_claim_payroll_direct_blocked_above_threshold() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, _ms, _signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _) = setup_token(&env, &token_admin);
+
+    let salary = 1000i128;
+    let period = 86400u64;
+
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &salary);
+
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &500i128, // threshold = 500; salary 1000 >= 500
+        &0i128,
+    );
+
+    let agreement_id = payroll.create_payroll_agreement(&employer, &token_addr, &period);
+    payroll.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    payroll.activate_agreement(&agreement_id);
+    env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+    let result = payroll.try_claim_payroll(&employee, &agreement_id, &0u32);
+    assert_eq!(result, Err(Ok(PayrollError::MultisigApprovalRequired)));
+}
+
+/// Below-threshold claim bypasses multisig entirely.
+#[test]
+fn test_claim_payroll_below_threshold_bypasses_multisig() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, _ms, _signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, token_client) = setup_token(&env, &token_admin);
+
+    let salary = 100i128;
+    let period = 86400u64;
+
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &salary);
+
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &500i128, // threshold = 500; salary 100 < 500
+        &0i128,
+    );
+
+    let agreement_id = payroll.create_payroll_agreement(&employer, &token_addr, &period);
+    payroll.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    payroll.activate_agreement(&agreement_id);
+    env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+    payroll.claim_payroll(&employee, &agreement_id, &0u32).unwrap();
+    assert_eq!(token_client.balance(&employee), salary);
+}
+
+/// Rejection: multisig op kind doesn't match (wrong operation type).
+#[test]
+fn test_dispute_multisig_wrong_op_kind_rejected() {
+    let env = setup_env();
+    let (payroll_id, payroll, owner) = setup_payroll(&env);
+    let (multisig_id, ms, signers) = setup_multisig(&env);
+
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _) = setup_token(&env, &token_admin);
+    StellarAssetClient::new(&env, &token_addr).mint(&payroll_id, &1000);
+
+    payroll.set_arbiter(&employer, &arbiter);
+    payroll.set_multisig_config(
+        &owner,
+        &multisig_id,
+        &0i128,
+        &500i128,
+    );
+
+    let agreement_id =
+        payroll.create_escrow_agreement(&employer, &employer, &token_addr, &1000, &86400, &1);
+    payroll.raise_dispute(&employer, &agreement_id);
+
+    // Propose a LargePayment op (wrong kind for dispute resolution)
+    let op_id = ms.propose_operation(
+        &signers.get(0).unwrap(),
+        &OperationKind::LargePayment(token_addr.clone(), employer.clone(), 600i128),
+    );
+    ms.approve_operation(&signers.get(1).unwrap(), &op_id);
+    assert_eq!(
+        ms.get_operation(&op_id).unwrap().status,
+        OperationStatus::Executed
+    );
+
+    // Should fail — op kind is LargePayment, not DisputeResolution
+    let result = payroll.try_resolve_dispute_multisig(
+        &arbiter,
+        &agreement_id,
+        &600i128,
+        &400i128,
+        &op_id,
+    );
+    assert_eq!(result, Err(Ok(PayrollError::MultisigApprovalRequired)));
+}


### PR DESCRIPTION
Closes #448 

## Summary

Wires M-of-N multisig approval into `stello_pay_contract` for high-value payments and dispute resolutions, eliminating the single-key execution risk.

## Changes

### `src/storage.rs`
- Added `StorageKey` variants: `MultisigContract`, `LargePaymentThreshold`, `DisputeResolutionThreshold`
- Added `PayrollError::MultisigApprovalRequired = 28`

### `src/payroll.rs`
- Inline `MultisigClient` via `#[contractclient]` with mirror types matching multisig XDR names
- `set_multisig_config` / `get_multisig_contract` — owner-only threshold configuration
- `resolve_dispute` — threshold guard blocks direct path when `pay+refund >= DisputeResolutionThreshold`
- `resolve_dispute_multisig` — verifies Executed `DisputeResolution` op matches exact params before executing
- `claim_payroll` — threshold guard blocks direct path when `amount >= LargePaymentThreshold`
- `claim_payroll_multisig` — verifies Executed `LargePayment` op targets the calling employee

### `src/lib.rs`
- Exposes `set_multisig_config`, `get_multisig_contract`, `resolve_dispute_multisig`, `claim_payroll_multisig`

### `Cargo.toml`
- Added `multisig` as dev-dependency

### `tests/test_multisig_integration.rs` (new)
8 integration tests:
- 2-of-3 approval happy paths for DisputeResolution and LargePayment
- Insufficient signatures rejection for both
- Direct path blocked above threshold for both
- Below-threshold bypass (no multisig needed) for both
- Wrong op kind rejection

## Security
- Thresholds are configurable (0 = disabled), so existing deployments are unaffected until explicitly configured
- Multisig op parameters are verified to match the exact call arguments — no op reuse across different agreements or amounts
- Existing `resolve_dispute` and `claim_payroll` signatures are unchanged; all existing tests continue to pass