### PR TITLE
feat(stello_pay_contract): add exchange-rate timestamps, staleness ch…

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1589,6 +1589,26 @@ pub fn set_exchange_rate(
         return Err(PayrollError::Unauthorized);
     }
 
+    // Enforce max-deviation if configured: compare with previous rate.
+    if let Some(max_dev_bps) = DataKey::get_exchange_rate_max_deviation_bps(env) {
+        if let Some(prev) = DataKey::get_exchange_rate(env, &base, &quote) {
+            // compute allowed delta = prev.rate * max_dev_bps / 10000
+            let prev_rate = prev.rate;
+            // Avoid negative or zero prev_rate (shouldn't happen)
+            if prev_rate > 0 {
+                let allowed_delta = (prev_rate
+                    .checked_mul(max_dev_bps as i128)
+                    .unwrap_or(i128::MAX))
+                    .checked_div(10_000i128)
+                    .unwrap_or(i128::MAX);
+                let diff = if rate > prev_rate { rate - prev_rate } else { prev_rate - rate };
+                if diff > allowed_delta {
+                    return Err(PayrollError::ExchangeRateInvalid);
+                }
+            }
+        }
+    }
+
     DataKey::set_exchange_rate(env, &base, &quote, rate);
 
     Ok(())
@@ -2636,11 +2656,24 @@ fn convert_amount(
         return Ok(amount);
     }
 
-    let rate = DataKey::get_exchange_rate(env, from_token, to_token)
+    let info = DataKey::get_exchange_rate(env, from_token, to_token)
         .ok_or(PayrollError::ExchangeRateNotFound)?;
 
+    let rate = info.rate;
     if rate <= 0 {
         return Err(PayrollError::ExchangeRateInvalid);
+    }
+
+    // Enforce staleness (max-age) if configured
+    if let Some(max_age) = DataKey::get_exchange_rate_max_age_seconds(env) {
+        let now = env.ledger().timestamp();
+        // Protect against underflow
+        if now < info.updated_at {
+            return Err(PayrollError::ExchangeRateInvalid);
+        }
+        if now - info.updated_at > max_age {
+            return Err(PayrollError::ExchangeRateNotFound);
+        }
     }
 
     let scaled = amount

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -168,6 +168,13 @@ pub enum StorageKey {
     PauseApprovals,
     /// Global admin allowed to update FX rates (e.g. an oracle contract)
     ExchangeRateAdmin,
+    /// Optional max age (seconds) for using an FX rate. If set, any rate older
+    /// than this value (based on stored `updated_at`) will be considered stale.
+    ExchangeRateMaxAgeSeconds,
+    /// Optional max single-update deviation expressed in basis points (10000 = 100%).
+    /// If set, a new update that changes the rate by more than this fraction
+    /// relative to the previous stored rate will be rejected.
+    ExchangeRateMaxDeviationBps,
     /// Cumulative grace extension (seconds) applied on top of `Agreement::grace_period_seconds`
     /// for cancelled agreements (`agreement_id` -> u64).
     GracePeriodExtensionSeconds(u128),
@@ -253,6 +260,13 @@ pub struct PayrollCreateResult {
     pub success: bool,
     /// Mirrors PayrollError discriminant where applicable; 0 = success
     pub error_code: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExchangeRateInfo {
+    pub rate: i128,
+    pub updated_at: u64,
 }
 
 #[contracttype]
@@ -407,7 +421,7 @@ pub enum DataKey {
     /// multi-currency conversion helpers.
     ///
     /// Key: ExchangeRate(Address, Address)
-    /// Value: i128 (scaled rate)
+    /// Value: ExchangeRateInfo { rate: i128, updated_at: u64 }
     ExchangeRate(Address, Address),
 }
 
@@ -532,8 +546,13 @@ impl DataKey {
 
     /// Get the configured FX rate for a `(base, quote)` currency pair, if any.
     ///
-    /// The returned value is the fixed-point rate `quote_per_base * FX_SCALE`.
-    pub fn get_exchange_rate(env: &Env, base: &Address, quote: &Address) -> Option<i128> {
+    /// The returned value is an `ExchangeRateInfo` containing the fixed-point
+    /// rate `quote_per_base * FX_SCALE` and the `updated_at` ledger timestamp.
+    pub fn get_exchange_rate(
+        env: &Env,
+        base: &Address,
+        quote: &Address,
+    ) -> Option<ExchangeRateInfo> {
         let key: DataKey = DataKey::ExchangeRate(base.clone(), quote.clone());
         env.storage().persistent().get(&key)
     }
@@ -541,9 +560,41 @@ impl DataKey {
     /// Set the FX rate for a `(base, quote)` currency pair.
     ///
     /// Callers are responsible for enforcing any necessary access control;
-    /// this helper only performs the storage write.
+    /// this helper writes the rate together with the current ledger timestamp.
     pub fn set_exchange_rate(env: &Env, base: &Address, quote: &Address, rate: i128) {
         let key: DataKey = DataKey::ExchangeRate(base.clone(), quote.clone());
-        env.storage().persistent().set(&key, &rate);
+        let info = ExchangeRateInfo {
+            rate,
+            updated_at: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&key, &info);
+    }
+
+    /// Get optional configured max-age (seconds) for FX rates.
+    pub fn get_exchange_rate_max_age_seconds(env: &Env) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::ExchangeRateMaxAgeSeconds)
+    }
+
+    /// Set optional configured max-age (seconds) for FX rates.
+    pub fn set_exchange_rate_max_age_seconds(env: &Env, seconds: u64) {
+        env.storage()
+            .persistent()
+            .set(&StorageKey::ExchangeRateMaxAgeSeconds, &seconds);
+    }
+
+    /// Get optional configured max single-update deviation in basis points.
+    pub fn get_exchange_rate_max_deviation_bps(env: &Env) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::ExchangeRateMaxDeviationBps)
+    }
+
+    /// Set optional configured max single-update deviation in basis points.
+    pub fn set_exchange_rate_max_deviation_bps(env: &Env, bps: u32) {
+        env.storage()
+            .persistent()
+            .set(&StorageKey::ExchangeRateMaxDeviationBps, &bps);
     }
 }

--- a/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
 };
 
 use stello_pay_contract::storage::{DataKey, PayrollError};
+use stello_pay_contract::storage::ExchangeRateInfo;
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
 /// Create a fresh test environment with a deployed payroll contract, owner,
@@ -53,6 +54,46 @@ fn test_convert_currency_basic() {
     let amount: i128 = 10;
     let converted = client.convert_currency(&base, &quote, &amount);
     assert_eq!(converted, 20);
+}
+
+#[test]
+fn test_exchange_rate_staleness_rejected() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    let rate: i128 = 1_000_000;
+
+    // configure max age to 1 second
+    DataKey::set_exchange_rate_max_age_seconds(&env, 1u64);
+
+    client.set_exchange_rate(&owner, &base, &quote, &rate);
+
+    // advance ledger far beyond max age
+    env.ledger().with_mut(|li| li.timestamp += 10u64);
+
+    let res = client.convert_currency(&base, &quote, &10i128);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_exchange_rate_deviation_rejected() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    // initial rate
+    let r1: i128 = 1_000_000; // 1.0
+    client.set_exchange_rate(&owner, &base, &quote, &r1);
+
+    // set max deviation to 100 bps (1%)
+    DataKey::set_exchange_rate_max_deviation_bps(&env, 100u32);
+
+    // attempt a >1% update should be rejected
+    let r2 = r1 + (r1 / 50); // +2%
+    let res = client.set_exchange_rate(&owner, &base, &quote, &r2);
+    assert!(res.is_err());
 }
 
 /// End‑to‑end test for `claim_payroll_in_token`:


### PR DESCRIPTION
…ecks, and max-update deviation

**Description**  
Adds timestamped FX rate storage and safety checks: exchange rates are now stored as `ExchangeRateInfo { rate, updated_at }`; `set_exchange_rate` enforces an optional per-contract max single-update deviation (bps); `convert_amount`/`convert_currency` enforce an optional max-age (seconds) and reject stale rates. Includes storage helpers for configuring `ExchangeRateMaxAgeSeconds` and `ExchangeRateMaxDeviationBps`, and tests covering staleness and deviation behavior.

**Related Issue**  
Fixes #468 

## Checklist
- [ ] I have tested the changes locally
- [ ] I have added/updated documentation as needed
- [x] I have reviewed the code and ensured it follows the project guidelines
- [x] I have added necessary tests (unit/integration)
- [ ] My changes generate no new warnings/errors
- [ ] I have checked for code formatting issues

## Screenshots/Recordings
None

## Additional Notes
- Key modified files: storage.rs, payroll.rs, test_multi_currency.rs.
- Important: This changes the on-chain value shape for `DataKey::ExchangeRate` (from `i128` → `ExchangeRateInfo`). Existing deployments will need a migration or a deliberate state reset. Consider adding a migration path (bump `ContractVersion` and convert legacy `i128` entries into `ExchangeRateInfo` with a safe `updated_at`) before upgrading on production.
- Recommend running:  
```bash
cargo test -p stello_pay_contract
```