### PR TITLE
docs(cli): reconcile developer tools commands

### DIFF
--- a/docs/dev-tools/README.md
+++ b/docs/dev-tools/README.md
@@ -1,77 +1,30 @@
 # Developer Tools
 
-Comprehensive set of tools and utilities for working with the StellopayCore contract.
+This page documents the developer tools that exist in this repository today.
+The CLI command list is reconciled with `tools/cli/src/lib.rs`, where the
+`Commands` and `WebhookCommands` enums are defined.
 
-## Table of Contents
+## Stellopay CLI
 
-1. [CLI Tools](#cli-tools)
-2. [Monitoring and Debugging Tools](#monitoring-and-debugging-tools)
-3. [Testing Utilities](#testing-utilities)
-4. [Code Generation](#code-generation)
-5. [Development Scripts](#development-scripts)
+The CLI crate lives in [tools/cli](../../tools/cli/README.md). Build or install
+it from source:
 
-## CLI Tools
-
-### StellopayCore CLI
-
-A command-line interface for managing payroll operations.
-
-#### Installation
-
-```bash
-# Install from source
-git clone https://github.com/stellopay/stellopay-core
-cd stellopay-core/tools/cli
+```sh
+cd tools/cli
+cargo build
 cargo install --path .
-
-# Or install from registry
-cargo install stellopay-cli
 ```
 
-#### Usage
+Global flags:
 
-```bash
-# Initialize a new payroll contract
-stellopay-cli deploy --network testnet --owner <OWNER_ADDRESS>
+| Flag | Description |
+| --- | --- |
+| `-c, --config <PATH>` | Configuration file path. Defaults to `~/.stellopay/config.toml`. |
+| `-v, --verbose` | Enables verbose logging. |
 
-# Create employee payroll
-stellopay-cli payroll create \
-  --contract <CONTRACT_ID> \
-  --employee <EMPLOYEE_ADDRESS> \
-  --salary 5000 \
-  --frequency monthly \
-  --token <TOKEN_ADDRESS>
-
-# Deposit funds
-stellopay-cli deposit \
-  --contract <CONTRACT_ID> \
-  --amount 50000 \
-  --token <TOKEN_ADDRESS>
-
-# Process payments
-stellopay-cli pay \
-  --contract <CONTRACT_ID> \
-  --employee <EMPLOYEE_ADDRESS>
-
-# Bulk operations
-stellopay-cli bulk-pay \
-  --contract <CONTRACT_ID> \
-  --employees employees.json
-
-# Monitor contract
-stellopay-cli monitor \
-  --contract <CONTRACT_ID> \
-  --watch
-
-# Get contract info
-stellopay-cli info \
-  --contract <CONTRACT_ID>
-```
-
-#### Configuration
+Configuration example:
 
 ```toml
-# ~/.stellopay/config.toml
 [network]
 rpc_url = "https://soroban-testnet.stellar.org:443"
 network_passphrase = "Test SDF Network ; September 2015"
@@ -81,330 +34,177 @@ default_contract_id = "CONTRACT_ID_HERE"
 
 [auth]
 secret_key = "SECRET_KEY_HERE"
-# Or use environment variable: STELLOPAY_SECRET_KEY
 
 [defaults]
 token = "TOKEN_ADDRESS_HERE"
 frequency = "monthly"
 ```
 
-### Contract Management Commands
+Do not commit real secret keys, webhook secrets, RPC credentials, or production
+contract identifiers in config files or shell history.
 
-```bash
-# Contract deployment and management
-stellopay-cli contract deploy [OPTIONS]
-stellopay-cli contract initialize --owner <ADDRESS>
-stellopay-cli contract pause
-stellopay-cli contract unpause
-stellopay-cli contract transfer-ownership --new-owner <ADDRESS>
+## Supported Commands
 
-# Token management
-stellopay-cli token add --address <TOKEN_ADDRESS>
-stellopay-cli token remove --address <TOKEN_ADDRESS>
-stellopay-cli token list
+Only these top-level commands are currently defined in `tools/cli/src/lib.rs`.
 
-# Payroll management
-stellopay-cli payroll list
-stellopay-cli payroll create [OPTIONS]
-stellopay-cli payroll update [OPTIONS]
-stellopay-cli payroll delete --employee <ADDRESS>
+| Command | Purpose |
+| --- | --- |
+| `deploy` | Deploy a new contract. |
+| `info` | Get contract information. |
+| `status` | Show CLI status and environment checks. |
+| `emergency-withdraw` | Run the emergency withdrawal path. |
+| `webhook` | Manage webhook registrations and test delivery. |
 
-# Payment operations
-stellopay-cli payment process --employee <ADDRESS>
-stellopay-cli payment process-all
-stellopay-cli payment schedule --employee <ADDRESS> --when <TIMESTAMP>
-stellopay-cli payment history --employee <ADDRESS>
+### `deploy`
 
-# Reporting
-stellopay-cli report payroll --format json
-stellopay-cli report payments --from <DATE> --to <DATE>
-stellopay-cli report balances
-```
-
-
-### Event Log Analyzer
-
-```bash
-# Analyze contract events
-stellopay-cli analyze events --contract <CONTRACT_ID> --from <DATE>
-
-# Generate reports
-stellopay-cli analyze report --format json --output report.json
-
-# Real-time event streaming
-stellopay-cli stream events --contract <CONTRACT_ID>
-```
-
-### Debug Tools
-
-```bash
-# Debug transaction
-stellopay-cli debug transaction <TRANSACTION_HASH>
-
-# Trace contract calls
-stellopay-cli debug trace --contract <CONTRACT_ID> --function <FUNCTION_NAME>
-
-# Contract state inspection
-stellopay-cli debug state --contract <CONTRACT_ID>
-
-# Gas usage analysis
-stellopay-cli debug gas --contract <CONTRACT_ID> --function <FUNCTION_NAME>
-```
-
-## Testing Utilities
-
-### Test Environment Setup
-
-```bash
-# Create test environment
-stellopay-cli test setup --network testnet
-
-# Deploy test contract
-stellopay-cli test deploy
-
-# Create test accounts
-stellopay-cli test accounts create --count 5
-
-# Fund test accounts
-stellopay-cli test accounts fund --all
-
-# Create test tokens
-stellopay-cli test tokens create --symbol USDC --name "USD Coin"
-```
-
-### Test Data Generator
-
-```bash
-# Generate test payroll data
-stellopay-cli test generate payrolls --count 10 --output test-payrolls.json
-
-# Generate test employees
-stellopay-cli test generate employees --count 50 --output test-employees.json
-
-# Generate test scenarios
-stellopay-cli test generate scenarios --type regression --output test-scenarios.json
-```
-
-### Integration Test Runner
-
-```bash
-# Run integration tests
-stellopay-cli test run --suite integration
-
-# Run specific test
-stellopay-cli test run --test payroll_lifecycle
-
-# Run performance tests
-stellopay-cli test run --suite performance --duration 5m
-
-# Generate test report
-stellopay-cli test report --format html --output test-report.html
-```
-
-### Load Testing
-
-```bash
-# Run load tests
-stellopay-cli load-test --contract <CONTRACT_ID> --duration 5m --rate 10/s
-
-# Stress test
-stellopay-cli stress-test --contract <CONTRACT_ID> --concurrent 50 --duration 2m
-
-# Benchmark operations
-stellopay-cli benchmark --contract <CONTRACT_ID> --operation disburse_salary
-```
-
-## Code Generation
-
-### Contract Bindings Generator
-
-```bash
-# Generate TypeScript bindings
-stellopay-cli generate bindings --language typescript --output ./src/bindings
-
-# Generate Python bindings
-stellopay-cli generate bindings --language python --output ./bindings
-
-# Generate Rust bindings
-stellopay-cli generate bindings --language rust --output ./src/bindings.rs
-```
-
-### Client Code Generator
-
-```bash
-# Generate client code
-stellopay-cli generate client --language typescript --template react
-stellopay-cli generate client --language python --template fastapi
-stellopay-cli generate client --language rust --template tokio
-```
-
-### Documentation Generator
-
-```bash
-# Generate API documentation
-stellopay-cli generate docs --format markdown --output ./docs/api
-
-# Generate OpenAPI spec
-stellopay-cli generate openapi --output ./api-spec.yaml
-
-# Generate contract documentation
-stellopay-cli generate contract-docs --format html --output ./contract-docs
-```
-
-## Development Scripts
-
-### Build and Deployment Scripts
-
-```bash
-#!/bin/bash
-# scripts/deploy.sh
-
-set -e
-
-echo "Building contract..."
-cd onchain/contracts/stello_pay_contract
-stellar contract build
-
-echo "Deploying to testnet..."
-CONTRACT_ID=$(stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/stello_pay_contract.wasm \
-  --source-account $DEPLOY_ACCOUNT \
-  --rpc-url https://soroban-testnet.stellar.org:443 \
-  --network testnet)
-
-echo "Contract deployed: $CONTRACT_ID"
-
-echo "Initializing contract..."
-stellar contract invoke \
-  --id $CONTRACT_ID \
-  --source-account $DEPLOY_ACCOUNT \
-  --rpc-url https://soroban-testnet.stellar.org:443 \
+```sh
+stellopay-cli deploy \
   --network testnet \
-  -- initialize \
-  --owner $OWNER_ADDRESS
-
-echo "Contract initialized successfully!"
-echo "Contract ID: $CONTRACT_ID"
+  --owner <OWNER_ADDRESS> \
+  --wasm <PATH_TO_WASM>
 ```
 
-### Testing Scripts
+Flags:
 
-```bash
-#!/bin/bash
-# scripts/test.sh
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--network <NETWORK>` | No | Network name. Defaults to `testnet`. |
+| `--owner <ADDRESS>` | Yes | Owner address for the deployed contract. |
+| `--wasm <PATH>` | No | WASM file path. |
 
-set -e
+### `info`
 
-echo "Running unit tests..."
-cd onchain/contracts/stello_pay_contract
-cargo test
-
-echo "Running integration tests..."
-cd ../../../
-cargo test --test integration_tests
-
-echo "Running end-to-end tests..."
-npm test -- --testPathPattern=e2e
-
-echo "Generating test report..."
-cargo tarpaulin --out Html --output-dir coverage
-
-echo "All tests passed!"
+```sh
+stellopay-cli info --contract-id <CONTRACT_ID>
 ```
 
-### Monitoring Scripts
+Flags:
 
-```bash
-#!/bin/bash
-# scripts/monitor.sh
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--contract-id <ID>` | No | Contract ID to inspect. Falls back to config where supported. |
 
-CONTRACT_ID=${1:-$DEFAULT_CONTRACT_ID}
+### `status`
 
-if [ -z "$CONTRACT_ID" ]; then
-    echo "Usage: $0 <CONTRACT_ID>"
-    exit 1
-fi
-
-echo "Monitoring contract: $CONTRACT_ID"
-
-# Check contract health
-stellopay-cli health --contract $CONTRACT_ID || {
-    echo "Contract health check failed!"
-    exit 1
-}
-
-# Monitor events
-stellopay-cli stream events --contract $CONTRACT_ID &
-EVENT_PID=$!
-
-# Monitor performance
-stellopay-cli monitor performance --contract $CONTRACT_ID --interval 30s &
-PERF_PID=$!
-
-# Handle shutdown
-trap "kill $EVENT_PID $PERF_PID" EXIT
-
-echo "Monitoring started. Press Ctrl+C to stop."
-wait
+```sh
+stellopay-cli status
 ```
 
-### Backup Scripts
+`status` reads the configured environment and reports CLI/tooling status.
 
-```bash
-#!/bin/bash
-# scripts/backup.sh
+### `emergency-withdraw`
 
-CONTRACT_ID=${1:-$DEFAULT_CONTRACT_ID}
-BACKUP_DIR="backups/$(date +%Y%m%d_%H%M%S)"
-
-mkdir -p $BACKUP_DIR
-
-echo "Creating backup for contract: $CONTRACT_ID"
-
-# Export contract state
-stellopay-cli export state --contract $CONTRACT_ID --output $BACKUP_DIR/state.json
-
-# Export payroll data
-stellopay-cli export payrolls --contract $CONTRACT_ID --output $BACKUP_DIR/payrolls.json
-
-# Export events
-stellopay-cli export events --contract $CONTRACT_ID --output $BACKUP_DIR/events.json
-
-# Create compressed archive
-tar -czf $BACKUP_DIR.tar.gz $BACKUP_DIR
-rm -rf $BACKUP_DIR
-
-echo "Backup created: $BACKUP_DIR.tar.gz"
+```sh
+stellopay-cli emergency-withdraw \
+  --contract-id <CONTRACT_ID> \
+  --token <TOKEN_ADDRESS> \
+  --recipient <RECIPIENT_ADDRESS> \
+  --amount <AMOUNT>
 ```
 
+Flags:
 
-## Getting Started
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--contract-id <ID>` | Yes | Contract ID for the withdrawal target. |
+| `--token <ADDRESS>` | Yes | Token contract address. |
+| `--recipient <ADDRESS>` | Yes | Recipient address. |
+| `--amount <I128>` | Yes | Amount to withdraw. |
 
-1. **Install CLI Tools**:
-   ```bash
-   cargo install stellopay-cli
-   ```
+Use placeholder values in shared examples. Do not paste real emergency
+withdrawal destinations, private keys, or production amounts into public logs.
 
-2. **Set up Development Environment**:
-   ```bash
-   git clone https://github.com/stellopay/stellopay-core
-   cd stellopay-core
-   docker-compose -f docker-compose.dev.yml up -d
-   ```
+## Webhook Commands
 
-3. **Deploy Test Contract**:
-   ```bash
-   stellopay-cli deploy --network testnet
-   ```
+Webhook commands are nested under `stellopay-cli webhook`.
 
-4. **Run Examples**:
-   ```bash
-   stellopay-cli test run --suite examples
-   ```
+### `webhook register`
 
-5. **Start Monitoring**:
-   ```bash
-   stellopay-cli monitor --contract <CONTRACT_ID>
-   ```
+```sh
+stellopay-cli webhook register \
+  --name "Payroll events" \
+  --description "Receives payroll lifecycle events" \
+  --url "https://example.com/webhooks/stellopay" \
+  --events "payroll.created,payment.sent" \
+  --secret "$WEBHOOK_SECRET" \
+  --contract-id <CONTRACT_ID>
+```
 
-For detailed usage instructions, see the [CLI Reference](./cli-reference.md) and [Integration Guide](../integration/README.md).
+Flags:
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--name <NAME>` | Yes | Webhook name. |
+| `--description <TEXT>` | Yes | Webhook description. |
+| `--url <URL>` | Yes | Delivery URL. |
+| `--events <CSV>` | Yes | Comma-separated event names. |
+| `--secret <SECRET>` | Yes | Webhook signing secret. Prefer an environment variable. |
+| `--contract-id <ID>` | No | Contract ID override. |
+
+### `webhook update`
+
+```sh
+stellopay-cli webhook update \
+  --webhook-id <WEBHOOK_ID> \
+  --name "Updated payroll events" \
+  --description "Updated description" \
+  --url "https://example.com/webhooks/stellopay" \
+  --events "payment.sent" \
+  --active true \
+  --contract-id <CONTRACT_ID>
+```
+
+All fields except `--webhook-id` are optional updates.
+
+### `webhook delete`
+
+```sh
+stellopay-cli webhook delete --webhook-id <WEBHOOK_ID> --contract-id <CONTRACT_ID>
+```
+
+### `webhook list`
+
+```sh
+stellopay-cli webhook list --owner <OWNER_ADDRESS> --contract-id <CONTRACT_ID>
+```
+
+### `webhook get`
+
+```sh
+stellopay-cli webhook get --webhook-id <WEBHOOK_ID> --contract-id <CONTRACT_ID>
+```
+
+### `webhook stats`
+
+```sh
+stellopay-cli webhook stats --contract-id <CONTRACT_ID>
+```
+
+### `webhook test`
+
+```sh
+stellopay-cli webhook test \
+  --webhook-id <WEBHOOK_ID> \
+  --event-type "payment.sent" \
+  --contract-id <CONTRACT_ID>
+```
+
+## Commands Not Yet Exposed
+
+The current `Commands` enum does not expose payroll creation, deposits,
+payments, bulk payments, monitoring, event analysis, debug tracing, load tests,
+or code generation subcommands. Add those to `tools/cli/src/lib.rs` first before
+documenting user-facing syntax here.
+
+## Keeping This Page In Sync
+
+When CLI commands change:
+
+1. Update `tools/cli/src/lib.rs`.
+2. Run `cd tools/cli && cargo run -- --help` and, for nested commands,
+   `cd tools/cli && cargo run -- webhook --help`.
+3. Reconcile this page with the emitted help text.
+4. Keep examples copy-pasteable with placeholders only.
+
+This page should describe the CLI that exists on the current branch, not a
+future command surface.


### PR DESCRIPTION
## Summary
- replace stale developer-tools command examples with the commands actually defined in tools/cli/src/lib.rs
- document deploy, info, status, emergency-withdraw, and webhook subcommands with current flags
- call out currently unsupported phantom command groups and add a help-output sync process
- keep examples placeholder-only for secrets, contract IDs, and addresses

Closes #497

## Validation
- git diff --check
- docs/dev-tools README relative link check