### PR TITLE
ci: cache rust workflow artifacts

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: stable
 
 jobs:
   contracts:
@@ -19,6 +20,17 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+
+      # Cache downloaded crates and workspace build outputs only; tool binaries
+      # are installed fresh so restored cache contents are revalidated by Cargo.
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            onchain/target
+          key: ${{ runner.os }}-cargo-contracts-${{ env.RUST_TOOLCHAIN }}-llvm-tools-wasm-${{ hashFiles('onchain/Cargo.lock', '**/rust-toolchain', '**/rust-toolchain.toml') }}
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  RUST_TOOLCHAIN: stable
+
 jobs:
   security:
     runs-on: ubuntu-latest
@@ -17,15 +20,28 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # Reuse Cargo downloads and onchain build outputs across scan runs while
+      # leaving installed audit tools outside the cache.
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            onchain/target
+          key: ${{ runner.os }}-cargo-security-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('onchain/Cargo.lock', '**/rust-toolchain', '**/rust-toolchain.toml') }}
+
       - name: Install cargo-audit
         run: |
           cargo install cargo-audit --locked || echo "cargo-audit already installed"
 
       - name: Run cargo-audit (dependency vulnerability scan)
+        working-directory: onchain
         run: |
           cargo audit || true
 
       - name: Run Clippy (static analysis)
+        working-directory: onchain
         run: |
           cargo clippy --all-targets --all-features -- -D warnings || true
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -15,6 +15,33 @@ It performs:
 4. **WASM build** — `stellar contract build` in `onchain/contracts/stello_pay_contract` and `onchain/contracts/template_versioning`.
 5. **Coverage** — `cargo llvm-cov` over the same two packages; produces `onchain/codecov.json` and uploads it as a workflow artifact.
 
+## Rust cache
+
+`contracts.yml` and `security-scan.yml` cache Cargo downloads and the
+`onchain/target` build directory with `actions/cache@v4`. The cache paths are
+limited to:
+
+- `~/.cargo/registry`
+- `~/.cargo/git`
+- `onchain/target`
+
+The cache key includes the runner OS, workflow purpose, the Rust toolchain
+marker (`stable`), and a hash of `onchain/Cargo.lock` plus any
+`rust-toolchain`/`rust-toolchain.toml` files. Changing dependencies, pinning a
+different toolchain file, or moving a workflow to a different toolchain marker
+creates a new cache entry instead of reusing old build artifacts.
+
+The cache intentionally excludes `~/.cargo/bin`, so tools such as
+`stellar-cli`, `cargo-audit`, and `cargo-llvm-cov` are installed or provisioned
+by their workflow steps instead of restored from cache. GitHub Actions also
+scopes caches by branch and pull request merge ref; untrusted fork PRs can read
+eligible base-branch caches but cannot replace the trusted `main` cache used by
+pushes to `main`. The workflows use `pull_request`, not `pull_request_target`,
+so forked PRs do not receive repository secrets.
+
+The legacy manual `.github/workflows/ci.yml` workflow does not run Cargo and
+therefore has no Rust cache step.
+
 ### Optional Codecov
 
 To publish reports to [Codecov](https://codecov.io), add a repository secret `CODECOV_TOKEN` and uncomment (or enable) the Codecov step in `contracts.yml`. The job is configured so missing token does not fail the workflow by default.


### PR DESCRIPTION
$## Summary\n- add Cargo registry/git and onchain target caching to Rust-heavy workflows\n- key caches by runner, workflow purpose, toolchain marker, and lockfile/toolchain inputs\n- document cache scope, invalidation, and fork PR safety in CI docs\n\n## Validation\n- parsed GitHub workflow YAML files\n- git diff --check\n\nCloses #525