### PR TITLE
ci: add cargo-deny dependency policy

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -17,18 +17,28 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Run cargo-deny (dependency policy)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: stable
+          manifest-path: ./onchain/Cargo.toml
+          command: check advisories bans licenses sources
+          arguments: --all-features
+
       - name: Install cargo-audit
         run: |
           cargo install cargo-audit --locked || echo "cargo-audit already installed"
 
       - name: Run cargo-audit (dependency vulnerability scan)
+        working-directory: onchain
         run: |
           cargo audit || true
 
       - name: Run Clippy (static analysis)
+        working-directory: onchain
         run: |
           cargo clippy --all-targets --all-features -- -D warnings || true
 
       - name: Security scan summary
         run: |
-          echo "Static security scans completed (cargo-audit, clippy)."
+          echo "Static security scans completed (cargo-deny, cargo-audit, clippy)."

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,39 @@
+[graph]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "wasm32-unknown-unknown",
+]
+
+[advisories]
+yanked = "deny"
+unmaintained = "workspace"
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+unused-allowed-license = "allow"
+private = { ignore = true }
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ private = { ignore = true }
 
 [bans]
 multiple-versions = "warn"
-wildcards = "warn"
+wildcards = "deny"
 
 [sources]
 unknown-registry = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ private = { ignore = true }
 
 [bans]
 multiple-versions = "warn"
-wildcards = "deny"
+wildcards = "warn"
 
 [sources]
 unknown-registry = "deny"

--- a/docs/security-testing-tools.md
+++ b/docs/security-testing-tools.md
@@ -1,11 +1,12 @@
 # Security Testing Tools Integration
 
-This document describes the security testing tooling integrated for issue #236.
+This document describes the security testing tooling integrated for the Rust/Soroban workspace.
 
 ## Overview
 
 The security tooling integration provides:
 
+- **Dependency policy enforcement** using `cargo-deny` (advisories, licenses, bans, and sources).
 - **Static analysis** using `cargo-audit` (dependency vulnerability scan).
 - **Linting / code quality** using `cargo clippy` (with warnings reported in CI).
 - **Automated CI integration** via GitHub Actions (`.github/workflows/security-scan.yml`).
@@ -16,16 +17,31 @@ The security tooling integration provides:
 
 The workflow runs on every push and pull request to `main` and performs:
 
-1. **Dependency vulnerability scan**
+1. **Dependency policy check**
+   - Runs `cargo-deny` against the `onchain` workspace.
+   - Blocks the workflow on vulnerability advisories, yanked crates, disallowed licenses, wildcard dependency versions, unknown registries, and unknown Git sources.
+
+2. **Dependency vulnerability scan**
    - Installs `cargo-audit`.
    - Runs `cargo audit` against the workspace to detect known CVEs and insecure dependencies.
 
-2. **Static analysis (Clippy)**
+3. **Static analysis (Clippy)**
    - Runs `cargo clippy --all-targets --all-features`.
    - Reports lints and warnings; can be tightened to `-D warnings` once the codebase is fully clean.
 
-3. **Summary step**
+4. **Summary step**
    - Emits a short summary so logs clearly show scan completion.
+
+## Dependency Policy
+
+The root `deny.toml` keeps the dependency policy intentionally small:
+
+- Advisories: vulnerability and unsoundness advisories use the cargo-deny defaults, yanked crates fail CI, and unmaintained advisories fail only for direct workspace dependencies. There are no advisory ignores.
+- Licenses: third-party crates must use permissive licenses already common in the Rust/Soroban ecosystem. Private workspace crates marked `publish = false` are ignored so the check stays focused on external dependencies.
+- Bans: wildcard dependency versions fail. Duplicate transitive versions warn instead of failing because the current Soroban dependency graph contains upstream duplicates that should be reduced opportunistically rather than ignored.
+- Sources: dependencies must come from crates.io. Git dependencies are denied unless an explicit future exception is reviewed and added.
+
+When a new dependency fails this policy, prefer upgrading or replacing the dependency. Add exceptions only with a short reason tied to the dependency's license, source, or advisory impact.
 
 ## Usage
 
@@ -33,14 +49,16 @@ The workflow runs on every push and pull request to `main` and performs:
 - Local: Developers can run the same tools locally:
 
 ```bash
+cargo install cargo-deny --locked
+cargo deny --manifest-path onchain/Cargo.toml check advisories bans licenses sources
 cargo install cargo-audit --locked
-cargo audit
-cargo clippy --all-targets --all-features
+(cd onchain && cargo audit)
+(cd onchain && cargo clippy --all-targets --all-features)
 ```
 
 ## Notes
 
 - Tools like Slither/Mythril primarily target EVM/Solidity; for this Rust/Soroban codebase,
-  `cargo-audit` and `clippy` are used as the primary static security analyzers.
+  `cargo-deny`, `cargo-audit`, and `clippy` are used as the primary static security analyzers.
 - Dynamic security behavior is exercised via the existing `cargo test` suites, including
   dedicated tests for disputes, grace periods, and reentrancy behavior.

--- a/docs/security-testing-tools.md
+++ b/docs/security-testing-tools.md
@@ -19,7 +19,8 @@ The workflow runs on every push and pull request to `main` and performs:
 
 1. **Dependency policy check**
    - Runs `cargo-deny` against the `onchain` workspace.
-   - Blocks the workflow on vulnerability advisories, yanked crates, disallowed licenses, wildcard dependency versions, unknown registries, and unknown Git sources.
+   - Blocks the workflow on vulnerability advisories, yanked crates, disallowed licenses, unknown registries, and unknown Git sources.
+   - Reports wildcard dependency versions as warnings until the current workspace path dependencies are pinned.
 
 2. **Dependency vulnerability scan**
    - Installs `cargo-audit`.
@@ -38,7 +39,7 @@ The root `deny.toml` keeps the dependency policy intentionally small:
 
 - Advisories: vulnerability and unsoundness advisories use the cargo-deny defaults, yanked crates fail CI, and unmaintained advisories fail only for direct workspace dependencies. There are no advisory ignores.
 - Licenses: third-party crates must use permissive licenses already common in the Rust/Soroban ecosystem. Private workspace crates marked `publish = false` are ignored so the check stays focused on external dependencies.
-- Bans: wildcard dependency versions fail. Duplicate transitive versions warn instead of failing because the current Soroban dependency graph contains upstream duplicates that should be reduced opportunistically rather than ignored.
+- Bans: wildcard dependency versions and duplicate transitive versions warn instead of failing because the current workspace graph contains local path wildcards and upstream Soroban duplicates that should be reduced opportunistically rather than ignored.
 - Sources: dependencies must come from crates.io. Git dependencies are denied unless an explicit future exception is reviewed and added.
 
 When a new dependency fails this policy, prefer upgrading or replacing the dependency. Add exceptions only with a short reason tied to the dependency's license, source, or advisory impact.

--- a/onchain/contracts/payroll_escrow/Cargo.toml
+++ b/onchain/contracts/payroll_escrow/Cargo.toml
@@ -2,6 +2,7 @@
 name = "payroll_escrow"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
$## Summary\n- add a root cargo-deny policy for advisories, licenses, bans, and dependency sources\n- wire cargo-deny into the security scan workflow as a blocking dependency-policy check\n- document the policy and local commands for dependency changes\n\n## Validation\n- parsed deny.toml and updated Cargo.toml\n- parsed security-scan workflow YAML\n- git diff --check\n\nCloses #500