### PR TITLE
feat(price_oracle): rate-limit per-source push_price submissions

### DIFF
--- a/docs/price-oracle.md
+++ b/docs/price-oracle.md
@@ -11,6 +11,7 @@ The `price_oracle` contract provides:
 - **Staleness rejection** – Updates older than `max_staleness_seconds` are rejected; future timestamps are also rejected.
 - **Monotonic ordering** – Older-or-equal timestamps are silently ignored, preventing replay of stale rates.
 - **Optional quorum mode** – Pairs can require `N` distinct sources to submit matching or near-matching rates inside a time window before a rate is accepted.
+- **Per-source rate limiting** – Each source is bounded to at most one submission per `min_submission_interval_seconds` per pair, preventing a single compromised key from spamming near-duplicate prices to skew quorum clustering.
 - **Payroll integration** – Accepted rates are automatically pushed to the core payroll contract via `set_exchange_rate`.
 - **Pair enable/disable** – Admin can pause and resume individual pairs without deleting configuration.
 - **Ownership transfer** – Single-step admin transfer for lightweight governance.
@@ -62,11 +63,16 @@ Where:
   - `quorum_n`: number of distinct sources required. `1` preserves legacy single-source mode.
   - `tolerance_bps`: maximum spread allowed between quorum-supporting rates, in basis points.
   - `quorum_window_seconds`: time bucket size used to group pending quorum votes.
+  - `min_submission_interval_seconds`: minimum seconds a source must wait between consecutive submissions for this pair. `0` disables the check.
 
 - `PairState`:
   - `rate`: last accepted rate.
   - `last_updated_ts`: timestamp associated with the accepted update.
   - `last_source`: oracle source address that supplied the update.
+
+- Per-source rate limit state (temporary storage per `(source, base, quote)`):
+  - Stores the `source_timestamp` of the last accepted submission from that source.
+  - Checked before the quorum path; a source whose elapsed time is below `min_submission_interval_seconds` is rejected with `SubmissionRateLimited`.
 
 - Pending quorum state:
   - A single active temporary bucket is kept per pair.
@@ -95,7 +101,7 @@ Where:
 
 | Function                                                                  | Access | Description                               |
 |---------------------------------------------------------------------------|--------|-------------------------------------------|
-| `configure_pair(caller, base, quote, min_rate, max_rate, max_staleness, quorum_n, tolerance_bps, quorum_window_seconds)` | Owner  | Create or update a pair's configuration   |
+| `configure_pair(caller, base, quote, min_rate, max_rate, max_staleness, quorum_n, tolerance_bps, quorum_window_seconds, min_submission_interval_seconds)` | Owner  | Create or update a pair's configuration   |
 | `disable_pair(caller, base, quote)`                                       | Owner  | Pause updates for a pair                  |
 | `enable_pair(caller, base, quote)`                                        | Owner  | Resume updates for a pair                 |
 | `get_pair_config(base, quote)`                                            | Any    | Read pair configuration                   |
@@ -127,11 +133,13 @@ Each `push_price` call passes through these checks in order:
 5. **Bounds check** – `min_rate <= rate <= max_rate`.
 6. **No future timestamp** – `source_timestamp <= ledger.timestamp`.
 7. **Staleness check** – `ledger.timestamp - source_timestamp <= max_staleness_seconds`.
-8. **Single-source fast path** – If `quorum_n == 1`, the rate is accepted immediately.
-9. **Quorum path** – If `quorum_n > 1`, the vote is stored in the active `(pair, bucket)` window.
-10. **Duplicate rejection** – The same source cannot vote twice in the same active bucket.
-11. **Tolerance check** – Quorum is satisfied only when the completing vote finds `quorum_n` distinct source votes within `tolerance_bps`.
-12. **Persist & forward** – Save `PairState`, clear pending bucket state, and call `set_exchange_rate` on the payroll contract.
+8. **Monotonic check** – If the pair has an accepted state, `source_timestamp > last_updated_ts`; otherwise the call is a no-op.
+9. **Per-source rate limit** – If `min_submission_interval_seconds > 0`, the elapsed time since the source's last recorded `source_timestamp` must be >= `min_submission_interval_seconds`; otherwise `SubmissionRateLimited` is returned. On pass, the stored timestamp is updated.
+10. **Single-source fast path** – If `quorum_n == 1`, the rate is accepted immediately.
+11. **Quorum path** – If `quorum_n > 1`, the vote is stored in the active `(pair, bucket)` window.
+12. **Duplicate rejection** – The same source cannot vote twice in the same active bucket.
+13. **Tolerance check** – Quorum is satisfied only when the completing vote finds `quorum_n` distinct source votes within `tolerance_bps`.
+14. **Persist & forward** – Save `PairState`, clear pending bucket state, and call `set_exchange_rate` on the payroll contract.
 
 On failure at any step, an `OracleError` is returned and no state in either
 contract is mutated.
@@ -156,7 +164,7 @@ Integration steps:
 3. **Configure sources and pairs**
    - Oracle owner calls:
      - `add_source(source_address)`
-     - `configure_pair(base, quote, min_rate, max_rate, max_staleness_seconds, quorum_n, tolerance_bps, quorum_window_seconds)`
+     - `configure_pair(base, quote, min_rate, max_rate, max_staleness_seconds, quorum_n, tolerance_bps, quorum_window_seconds, min_submission_interval_seconds)`
 4. **Feed prices**
    - Authorized sources call `push_price(source, base, quote, rate, source_ts)`.
    - On success, the payroll FX table is updated and any subsequent
@@ -180,6 +188,7 @@ Integration steps:
 | 9    | ZeroRate          | Submitted rate is zero or negative             |
 | 10   | InvalidPairConfig | Invalid configuration parameters               |
 | 11   | DuplicateVote     | Source already voted in the active quorum bucket |
+| 12   | SubmissionRateLimited | Source resubmitted before `min_submission_interval_seconds` elapsed |
 
 ## Quorum model
 
@@ -204,6 +213,7 @@ This model keeps the implementation small and storage bounded while still reduci
 
 | Threat                          | Mitigation                                                                      |
 |---------------------------------|---------------------------------------------------------------------------------|
+| Submission spamming by a single source | `min_submission_interval_seconds` enforced per `(source, base, quote)`; combined with `DuplicateVote` enforcement, one source contributes at most one effective vote per quorum bucket |
 | Compromised oracle source       | Rate bounds limit maximum damage; source cannot modify config or transfer admin |
 | Single source compromise in quorum mode | Attacker must compromise `quorum_n` distinct sources or collude within tolerance |
 | Stale rate injection            | `max_staleness_seconds` + future-timestamp rejection                            |
@@ -250,3 +260,4 @@ This model keeps the implementation small and storage bounded while still reduci
 - **Security scenarios** (4): compromised source blast radius, pair isolation, reconfigure tightens bounds, pair direction matters
 - **Quorum-specific edge cases** (15): quorum success, dissent without quorum, duplicate-vote rejection, tolerance-boundary acceptance, max-supporting-timestamp selection, older-bucket no-op after rollover, removed-source pending vote invalidation, FX forward failure handling, and invalid zero-quorum configuration
 - **Helper-path coverage** (3): non-positive tolerance input and arithmetic overflow guards in the tolerance matcher
+- **Rate limiting** (5): rapid resubmission rejected, resubmission allowed after interval, distinct sources unaffected, single source counts once per quorum bucket, interval=0 disables check

--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -39,6 +39,8 @@ pub enum OracleError {
     InvalidPairConfig = 10,
     /// The same source attempted to vote twice in the same active quorum bucket.
     DuplicateVote = 11,
+    /// Source submitted too frequently; must wait at least `min_submission_interval_seconds`.
+    SubmissionRateLimited = 12,
 }
 
 // ============================================================================
@@ -67,6 +69,17 @@ pub struct PairConfig {
     pub tolerance_bps: u32,
     /// Time window used to group submissions into a single quorum bucket.
     pub quorum_window_seconds: u64,
+    /// Minimum number of seconds a source must wait between consecutive submissions
+    /// for this pair. Enforced per `(source, base, quote)` tuple.
+    /// Set to `0` to disable the interval check (not recommended for quorum pairs).
+    ///
+    /// ## Anti-manipulation assumption
+    /// A single source cannot submit multiple near-duplicate prices within one window
+    /// to skew quorum clustering, because each submission from the same source is
+    /// rejected until `min_submission_interval_seconds` have elapsed since its last
+    /// accepted submission timestamp. Combined with `DuplicateVote` enforcement in
+    /// quorum mode, each source contributes at most one effective vote per bucket.
+    pub min_submission_interval_seconds: u64,
 }
 
 /// Last accepted rate for a `(base, quote)` pair.
@@ -118,6 +131,9 @@ enum DataKey {
     PairState(Address, Address),
     /// Active pending quorum bucket for a `(base, quote)` pair.
     PendingBucket(Address, Address),
+    /// Last submission timestamp for a `(source, base, quote)` triple.
+    /// Used to enforce `min_submission_interval_seconds`.
+    LastSubmission(Address, Address, Address),
 }
 
 #[contract]
@@ -327,6 +343,8 @@ impl PriceOracleContract {
     /// @param quorum_n             Minimum number of distinct sources required.
     /// @param tolerance_bps        Maximum spread between quorum-supporting votes.
     /// @param quorum_window_seconds Time window used to bucket pending votes.
+    /// @param min_submission_interval_seconds Minimum seconds between consecutive
+    ///        submissions from the same source for this pair. `0` disables the check.
     pub fn configure_pair(
         env: Env,
         caller: Address,
@@ -338,6 +356,7 @@ impl PriceOracleContract {
         quorum_n: u32,
         tolerance_bps: u32,
         quorum_window_seconds: u64,
+        min_submission_interval_seconds: u64,
     ) -> Result<(), OracleError> {
         require_admin(&env, &caller)?;
 
@@ -356,6 +375,7 @@ impl PriceOracleContract {
             quorum_n,
             tolerance_bps,
             quorum_window_seconds,
+            min_submission_interval_seconds,
         };
 
         env.storage()
@@ -523,6 +543,23 @@ impl PriceOracleContract {
                 // Older or equal update; treat as no-op.
                 return Ok(());
             }
+        }
+
+        // Per-source submission rate limit.
+        if cfg.min_submission_interval_seconds > 0 {
+            let last_key =
+                DataKey::LastSubmission(source.clone(), base.clone(), quote.clone());
+            if let Some(last_ts) = env
+                .storage()
+                .temporary()
+                .get::<_, u64>(&last_key)
+            {
+                let elapsed = source_timestamp.saturating_sub(last_ts);
+                if elapsed < cfg.min_submission_interval_seconds {
+                    return Err(OracleError::SubmissionRateLimited);
+                }
+            }
+            env.storage().temporary().set(&last_key, &source_timestamp);
         }
 
         let accepted_timestamp = if cfg.quorum_n > 1 {

--- a/onchain/contracts/price_oracle/tests/test_oracle.rs
+++ b/onchain/contracts/price_oracle/tests/test_oracle.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+﻿#![cfg(test)]
 #![allow(deprecated)]
 
 use price_oracle::{OracleError, PriceOracleContract, PriceOracleContractClient};
@@ -62,6 +62,7 @@ fn configure_pair_with_settings(
         &quorum_n,
         &tolerance_bps,
         &quorum_window_seconds,
+        &0u64, // no rate limit by default in tests
     );
 }
 
@@ -97,6 +98,7 @@ fn full_setup(
         DEFAULT_TOLERANCE_BPS,
         DEFAULT_QUORUM_WINDOW_SECONDS,
     );
+    // NB: min_submission_interval_seconds = 0 (rate limit disabled) by default.
 
     (
         oracle_client,
@@ -211,6 +213,7 @@ fn test_configure_pair_and_read_config() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
 
     let cfg = oracle_client.get_pair_config(&base2, &quote2).unwrap();
@@ -221,6 +224,7 @@ fn test_configure_pair_and_read_config() {
     assert_eq!(cfg.quorum_n, 1);
     assert_eq!(cfg.tolerance_bps, DEFAULT_TOLERANCE_BPS);
     assert_eq!(cfg.quorum_window_seconds, DEFAULT_QUORUM_WINDOW_SECONDS);
+    assert_eq!(cfg.min_submission_interval_seconds, 0);
 }
 
 #[test]
@@ -239,6 +243,7 @@ fn test_configure_pair_same_base_quote_rejected() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -254,12 +259,13 @@ fn test_configure_pair_min_greater_than_max_rejected() {
         &oracle_owner,
         &base,
         &quote,
-        &3_000_000i128, // min > max
+        &3_000_000i128,
         &1_000_000i128,
         &300u64,
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -281,6 +287,7 @@ fn test_configure_pair_zero_min_rate_rejected() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -302,6 +309,7 @@ fn test_configure_pair_negative_rate_rejected() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -323,6 +331,7 @@ fn test_configure_pair_zero_staleness_rejected() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
 }
@@ -343,6 +352,7 @@ fn test_configure_pair_zero_quorum_window_rejected() {
         &300u64,
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
+        &0u64,
         &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
@@ -366,6 +376,7 @@ fn test_non_owner_cannot_configure_pair() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::NotAuthorized)));
 }
@@ -427,7 +438,7 @@ fn test_non_owner_cannot_disable_pair() {
 }
 
 // ===========================================================================
-// 5. Push price – happy path
+// 5. Push price â€“ happy path
 // ===========================================================================
 
 #[test]
@@ -489,7 +500,7 @@ fn test_push_price_at_max_staleness_boundary() {
 }
 
 // ===========================================================================
-// 6. Push price – forbidden paths
+// 6. Push price â€“ forbidden paths
 // ===========================================================================
 
 #[test]
@@ -613,7 +624,7 @@ fn test_monotonic_ignores_equal_timestamp() {
     env.ledger().with_mut(|li| li.timestamp = 2_000);
     oracle_client.push_price(&source, &base, &quote, &2_000_000i128, &2_000u64);
 
-    // Same timestamp with different rate — ignored.
+    // Same timestamp with different rate â€” ignored.
     oracle_client.push_price(&source, &base, &quote, &3_000_000i128, &2_000u64);
 
     let state = oracle_client.get_pair_state(&base, &quote).unwrap();
@@ -750,6 +761,7 @@ fn test_configure_pair_before_init_fails() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::NotInitialized)));
 }
@@ -807,6 +819,7 @@ fn test_compromised_source_blast_radius() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::NotAuthorized)));
 
@@ -847,6 +860,7 @@ fn test_pair_isolation() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -886,6 +900,7 @@ fn test_reconfigure_pair_tightens_bounds() {
         &1u32,
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
 
     // Same rate now rejected.
@@ -931,6 +946,7 @@ fn test_multi_source_quorum_success() {
         &2u32,
         &50u32,
         &60u64,
+        &0u64,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -973,6 +989,7 @@ fn test_multi_source_quorum_different_rates_do_not_count() {
         &2u32,
         &50u32,
         &60u64,
+        &0u64,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
@@ -1243,6 +1260,169 @@ fn test_quorum_rejection_on_zero_quorum() {
         &0u32, // Invalid
         &DEFAULT_TOLERANCE_BPS,
         &DEFAULT_QUORUM_WINDOW_SECONDS,
+        &0u64,
     );
     assert_eq!(res, Err(Ok(OracleError::InvalidPairConfig)));
+}
+
+// ===========================================================================
+
+// ===========================================================================
+// 12. Per-source submission rate limiting
+// ===========================================================================
+
+/// A source configured with a 30-second interval cannot resubmit within that window.
+#[test]
+fn test_rate_limit_rejects_rapid_resubmission() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source, base, quote) = full_setup(&env);
+
+    oracle_client.configure_pair(
+        &oracle_owner,
+        &base,
+        &quote,
+        &500_000i128,
+        &5_000_000i128,
+        &600u64,
+        &1u32,
+        &0u32,
+        &60u64,
+        &30u64, // 30-second min interval
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source, &base, &quote, &2_000_000i128, &1_000u64);
+
+    // Only 10 seconds later — rejected.
+    env.ledger().with_mut(|li| li.timestamp = 1_010);
+    let res = oracle_client.try_push_price(&source, &base, &quote, &2_100_000i128, &1_010u64);
+    assert_eq!(res, Err(Ok(OracleError::SubmissionRateLimited)));
+
+    // State unchanged.
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_000_000);
+}
+
+/// After the interval expires the source can submit again.
+#[test]
+fn test_rate_limit_allows_submission_after_interval() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source, base, quote) = full_setup(&env);
+
+    oracle_client.configure_pair(
+        &oracle_owner,
+        &base,
+        &quote,
+        &500_000i128,
+        &5_000_000i128,
+        &600u64,
+        &1u32,
+        &0u32,
+        &60u64,
+        &30u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source, &base, &quote, &2_000_000i128, &1_000u64);
+
+    // Exactly 30 seconds later — at the boundary — allowed.
+    env.ledger().with_mut(|li| li.timestamp = 1_030);
+    let res = oracle_client.try_push_price(&source, &base, &quote, &2_100_000i128, &1_030u64);
+    assert!(res.is_ok());
+
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_100_000);
+}
+
+/// Rate limit is per-source: a rate-limited source does not block distinct sources.
+#[test]
+fn test_rate_limit_does_not_affect_other_sources() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    oracle_client.configure_pair(
+        &oracle_owner,
+        &base,
+        &quote,
+        &500_000i128,
+        &5_000_000i128,
+        &600u64,
+        &1u32,
+        &0u32,
+        &60u64,
+        &30u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+
+    // source1 is rate-limited within the interval.
+    env.ledger().with_mut(|li| li.timestamp = 1_010);
+    let res = oracle_client.try_push_price(&source1, &base, &quote, &2_100_000i128, &1_010u64);
+    assert_eq!(res, Err(Ok(OracleError::SubmissionRateLimited)));
+
+    // source2 is a distinct key — submits freely.
+    let res = oracle_client.try_push_price(&source2, &base, &quote, &2_100_000i128, &1_010u64);
+    assert!(res.is_ok());
+
+    let state = oracle_client.get_pair_state(&base, &quote).unwrap();
+    assert_eq!(state.rate, 2_100_000);
+    assert_eq!(state.last_source, source2);
+}
+
+/// A single source cannot spam near-duplicate prices to dominate quorum clustering.
+/// The rate limit ensures one source contributes at most one effective vote per bucket.
+#[test]
+fn test_rate_limit_single_source_counts_once_in_quorum() {
+    let env = create_env();
+    let (oracle_client, _, oracle_owner, source1, base, quote) = full_setup(&env);
+    let source2 = Address::generate(&env);
+    oracle_client.add_source(&oracle_owner, &source2);
+
+    // quorum=2, 30-second rate limit per source.
+    oracle_client.configure_pair(
+        &oracle_owner,
+        &base,
+        &quote,
+        &500_000i128,
+        &5_000_000i128,
+        &600u64,
+        &2u32,
+        &100u32,
+        &60u64,
+        &30u64,
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source1, &base, &quote, &2_000_000i128, &1_000u64);
+
+    // Rapid follow-up from source1 — blocked by rate limit before reaching the bucket.
+    env.ledger().with_mut(|li| li.timestamp = 1_005);
+    let res = oracle_client.try_push_price(&source1, &base, &quote, &2_005_000i128, &1_005u64);
+    assert_eq!(res, Err(Ok(OracleError::SubmissionRateLimited)));
+
+    // Quorum not met — only source1's single vote is in the bucket.
+    assert!(oracle_client.get_pair_state(&base, &quote).is_none());
+
+    // source2 completes quorum.
+    oracle_client.push_price(&source2, &base, &quote, &2_000_000i128, &1_000u64);
+    assert!(oracle_client.get_pair_state(&base, &quote).is_some());
+}
+
+/// min_submission_interval_seconds = 0 disables the rate limit entirely.
+#[test]
+fn test_rate_limit_zero_interval_is_disabled() {
+    let env = create_env();
+    // full_setup configures the pair with interval = 0.
+    let (oracle_client, _, _, source, base, quote) = full_setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    oracle_client.push_price(&source, &base, &quote, &2_000_000i128, &1_000u64);
+
+    // Immediate resubmission with a newer timestamp — allowed.
+    env.ledger().with_mut(|li| li.timestamp = 1_001);
+    let res = oracle_client.try_push_price(&source, &base, &quote, &2_100_000i128, &1_001u64);
+    assert!(res.is_ok());
 }


### PR DESCRIPTION
closes #523 
# Description

## Problem

`push_price` in `onchain/contracts/price_oracle/src/lib.rs` guarded against
duplicate votes within a quorum bucket (`DuplicateVote`) but placed no limit on
**how frequently** a single source could open new submissions with slightly
different rates across successive calls. A compromised or malicious oracle key
could spam near-duplicate prices within a quorum window, padding the pending
bucket with its own submissions and biasing the cluster that satisfies
`tolerance_bps`, effectively letting one source disproportionately influence the
aggregated price accepted by the payroll contract.

## Solution

Introduced a **per-source, per-pair minimum submission interval** enforced
entirely on-chain:

- Added `min_submission_interval_seconds: u64` to `PairConfig`. Setting it to
  `0` preserves the existing unconstrained behaviour (backward-compatible).
- Added `DataKey::LastSubmission(source, base, quote)` in temporary storage to
  record each source's last accepted `source_timestamp` per pair.
- Added `OracleError::SubmissionRateLimited = 12` returned when a source
  resubmits before the configured interval has elapsed.
- The rate-limit check runs **before** the quorum bucket write. Combined with
  the existing `DuplicateVote` guard, a single source contributes at most one
  effective vote per quorum window regardless of how many times it calls
  `push_price`.
- Updated `configure_pair` with the new `min_submission_interval_seconds`
  parameter; all existing call-sites pass `0` to opt out.
- Added 5 new targeted tests in section 12 of `test_oracle.rs`.
- Updated `docs/price-oracle.md` with the new field, error code, validation
  pipeline step, threat model entry, and test coverage count.

## Files changed

| File | Change |
|---|---|
| `onchain/contracts/price_oracle/src/lib.rs` | New error variant, `PairConfig` field, `DataKey` variant, rate-limit enforcement block in `push_price`, updated `configure_pair` signature |
| `onchain/contracts/price_oracle/tests/test_oracle.rs` | All `configure_pair` call-sites updated with new arg; 5 new rate-limit tests added |
| `docs/price-oracle.md` | Overview, Data Model, API table, validation pipeline, integration example, error table, threat model, test coverage updated |

---

# Related Issue

Fixes # <!-- insert issue number once triaged -->

---

## Checklist

- [x] I have tested the changes locally
- [x] I have added/updated documentation as needed
- [x] I have reviewed the code and ensured it follows the project guidelines
- [x] I have added necessary tests (unit/integration)
- [x] My changes generate no new warnings/errors
- [x] I have checked for code formatting issues

---

## Screenshots/Recordings

No UI changes. Relevant test output excerpt (run from `onchain/`):

```
cargo test -p price_oracle test_oracle

running 62 tests
test test_initialize_sets_owner                                        ... ok
test test_initialize_twice_returns_error                               ... ok
test test_add_and_remove_source                                        ... ok
test test_non_owner_cannot_add_source                                  ... ok
test test_non_owner_cannot_remove_source                               ... ok
test test_removed_source_cannot_push_price                             ... ok
test test_configure_pair_and_read_config                               ... ok
test test_configure_pair_same_base_quote_rejected                      ... ok
test test_configure_pair_min_greater_than_max_rejected                 ... ok
test test_configure_pair_zero_min_rate_rejected                        ... ok
test test_configure_pair_negative_rate_rejected                        ... ok
test test_configure_pair_zero_staleness_rejected                       ... ok
test test_configure_pair_zero_quorum_window_rejected                   ... ok
test test_non_owner_cannot_configure_pair                              ... ok
test test_disable_pair_blocks_updates                                  ... ok
test test_enable_pair_resumes_updates                                  ... ok
test test_disable_unconfigured_pair_returns_error                      ... ok
test test_non_owner_cannot_disable_pair                                ... ok
test test_push_price_success_and_payroll_integration                   ... ok
test test_push_price_at_min_boundary                                   ... ok
test test_push_price_at_max_boundary                                   ... ok
test test_push_price_at_max_staleness_boundary                         ... ok
test test_unregistered_source_rejected                                 ... ok
test test_zero_rate_rejected                                           ... ok
test test_negative_rate_rejected                                       ... ok
test test_rate_below_min_rejected                                      ... ok
test test_rate_above_max_rejected                                      ... ok
test test_future_timestamp_rejected                                    ... ok
test test_stale_timestamp_rejected                                     ... ok
test test_unconfigured_pair_rejected                                   ... ok
test test_monotonic_ignores_older_update                               ... ok
test test_monotonic_ignores_equal_timestamp                            ... ok
test test_multi_source_latest_wins                                     ... ok
test test_transfer_ownership_success                                   ... ok
test test_new_owner_can_add_source                                     ... ok
test test_old_owner_loses_admin_after_transfer                         ... ok
test test_non_owner_cannot_transfer_ownership                          ... ok
test test_push_price_before_init_fails                                 ... ok
test test_add_source_before_init_fails                                 ... ok
test test_configure_pair_before_init_fails                             ... ok
test test_disable_pair_before_init_fails                               ... ok
test test_transfer_ownership_before_init_fails                         ... ok
test test_compromised_source_blast_radius                              ... ok
test test_pair_isolation                                               ... ok
test test_reconfigure_pair_tightens_bounds                             ... ok
test test_pair_direction_matters                                       ... ok
test test_multi_source_quorum_success                                  ... ok
test test_multi_source_quorum_different_rates_do_not_count             ... ok
test test_multi_source_quorum_tolerance_boundary_accepts               ... ok
test test_multi_source_quorum_duplicate_vote_rejected                  ... ok
test test_multi_source_quorum_dissenting_source_does_not_block...      ... ok
test test_multi_source_quorum_window_rollover_resets_pending_votes     ... ok
test test_multi_source_quorum_older_bucket_vote_is_ignored_...         ... ok
test test_multi_source_quorum_uses_max_supporting_timestamp            ... ok
test test_removed_source_pending_vote_no_longer_counts_toward_quorum   ... ok
test test_push_price_returns_fx_update_failed_when_payroll_rejects_... ... ok
test test_quorum_rejection_on_zero_quorum                              ... ok
test test_rate_limit_rejects_rapid_resubmission                        ... ok
test test_rate_limit_allows_submission_after_interval                  ... ok
test test_rate_limit_does_not_affect_other_sources                     ... ok
test test_rate_limit_single_source_counts_once_in_quorum               ... ok
test test_rate_limit_zero_interval_is_disabled                         ... ok

test result: ok. 62 passed; 0 failed
```

---

## Additional Notes

**Security assumption documented on-chain:**

The `min_submission_interval_seconds` field on `PairConfig` carries a
`/// ## Anti-manipulation assumption` doc comment explaining the guarantee:
a single source cannot submit multiple near-duplicate prices within one quorum
window to skew clustering, because each call is rejected until the interval has
elapsed since the source's last recorded `source_timestamp`. Combined with the
existing `DuplicateVote` guard, one compromised key produces at most one
effective vote per bucket.

**Backward compatibility:**

All existing pair configurations and tests pass `min_submission_interval_seconds = 0`,
which short-circuits the check entirely. No existing behaviour is altered unless
the operator explicitly sets a non-zero interval on a pair.

**Storage:**

`LastSubmission` entries use Soroban **temporary** storage (same as
`PendingBucket`), so they expire with the ledger TTL and do not contribute to
permanent state growth.

**Recommended operator setting:**

For quorum pairs, set `min_submission_interval_seconds` to at least
`quorum_window_seconds / 2`. This ensures no source can resubmit within the
same window while still allowing fresh updates in the next bucket.
