### PR TITLE
docs(token-vesting): enhance compute_vested_amount doc and add cliff+linear property tests

### DIFF
--- a/onchain/contracts/token_vesting/src/lib.rs
+++ b/onchain/contracts/token_vesting/src/lib.rs
@@ -146,11 +146,30 @@ fn write_schedule(env: &Env, schedule: &VestingSchedule) {
 /// Computes the cumulative vested amount for `schedule` at timestamp `now`.
 ///
 /// For revoked schedules the clock is frozen at `revoked_at`.
-/// - **Linear**: proportional between `start_time` and `end_time`, gated by
-///   an optional `cliff_time` (nothing vests until the cliff is reached).
-/// - **Cliff**: 0 before `cliff_time`, 100% at or after `cliff_time`.
+///
+/// # Vesting kinds
+///
+/// - **Linear**: proportional interpolation between `start_time` and `end_time`,
+///   gated by an optional `cliff_time` (nothing vests until the cliff is reached).
+///   cliff+linear interaction: before the cliff the result is 0 even after start;
+///   at and after the cliff, linear interpolation applies from `start_time`.
+/// - **Cliff**: 0 before `cliff_time`, 100% of `total_amount` at or after `cliff_time`.
 /// - **Custom**: step function — returns the `cumulative_amount` of the last
 ///   checkpoint whose `time <= now`, capped at `total_amount`.
+///
+/// # Arguments
+///
+/// * `now` - Current ledger timestamp (or `revoked_at` for revoked schedules).
+/// * `schedule` - The vesting schedule to evaluate.
+///
+/// # Returns
+///
+/// The cumulative amount vested at `now`, as an `i128`. Never exceeds
+/// `schedule.total_amount`.
+///
+/// # Panics
+///
+/// Never. Pure computation — does not access storage or require auth.
 fn compute_vested_amount(now: u64, schedule: &VestingSchedule) -> i128 {
     if schedule.total_amount <= 0 {
         return 0;

--- a/onchain/contracts/token_vesting/tests/test_vesting.rs
+++ b/onchain/contracts/token_vesting/tests/test_vesting.rs
@@ -1258,3 +1258,160 @@ fn test_early_release_event_emitted() {
     assert_eq!(event.id, sid);
     assert_eq!(event.amount, 200);
 }
+
+// ===========================================================================
+// L. Cliff + Linear interaction property tests (added for #516)
+// ===========================================================================
+
+/// Verifies that a linear schedule with a cliff correctly gates vesting:
+/// - Before both start and cliff: 0
+/// - After start but before cliff: 0 (cliff blocks)
+/// - At cliff: linear interpolation from start to cliff
+/// - Between cliff and end: linear interpolation
+/// - At end: total
+/// - After end: capped at total
+#[test]
+fn cliff_plus_linear_full_spectrum() {
+    let env = create_env();
+    let (client, _owner, employer, beneficiary, token) = full_setup(&env);
+
+    set_time(&env, 0);
+    let sid = client.create_linear_schedule(
+        &employer,
+        &beneficiary,
+        &token.address,
+        &1_000i128,
+        &0u64,
+        &100u64,
+        &Some(30u64),
+        &false,
+    );
+
+    let cases = [
+        (0, 0),    // before start + cliff
+        (10, 0),   // after start, before cliff
+        (20, 0),
+        (30, 300), // exactly at cliff -> 1000 * 30/100 = 300
+        (40, 400),
+        (50, 500),
+        (60, 600),
+        (70, 700),
+        (80, 800),
+        (90, 900),
+        (100, 1000),
+        (110, 1000),
+    ];
+
+    for &(ts, expected) in &cases {
+        set_time(&env, ts);
+        let vested = client.get_vested_amount(&sid);
+        assert_eq!(
+            vested, expected,
+            "cliff+linear vested amount mismatch at t={}: got {}, expected {}",
+            ts, vested, expected
+        );
+    }
+}
+
+/// Edge case: cliff equals end_time (no linear segment after cliff).
+#[test]
+fn cliff_equals_end() {
+    let env = create_env();
+    let (client, _owner, employer, beneficiary, token) = full_setup(&env);
+
+    set_time(&env, 0);
+    let sid = client.create_linear_schedule(
+        &employer,
+        &beneficiary,
+        &token.address,
+        &1_000i128,
+        &0u64,
+        &50u64,
+        &Some(50u64),
+        &false,
+    );
+
+    set_time(&env, 0);
+    assert_eq!(client.get_vested_amount(&sid), 0);
+
+    set_time(&env, 50);
+    assert_eq!(client.get_vested_amount(&sid), 1_000);
+}
+
+/// Edge case: cliff equals start_time (effectively no cliff gate).
+#[test]
+fn cliff_equals_start() {
+    let env = create_env();
+    let (client, _owner, employer, beneficiary, token) = full_setup(&env);
+
+    set_time(&env, 0);
+    let sid = client.create_linear_schedule(
+        &employer,
+        &beneficiary,
+        &token.address,
+        &1_000i128,
+        &30u64,
+        &100u64,
+        &Some(30u64),
+        &false,
+    );
+
+    set_time(&env, 30);
+    assert_eq!(client.get_vested_amount(&sid), 0);
+
+    set_time(&env, 65);
+    // 1000 * (65-30) / (100-30) = 1000 * 35 / 70 = 500
+    assert_eq!(client.get_vested_amount(&sid), 500);
+}
+
+/// Edge case: very small total_amount with cliff.
+#[test]
+fn cliff_plus_linear_small_amount() {
+    let env = create_env();
+    let (client, _owner, employer, beneficiary, token) = full_setup(&env);
+
+    set_time(&env, 0);
+    let sid = client.create_linear_schedule(
+        &employer,
+        &beneficiary,
+        &token.address,
+        &3i128,
+        &0u64,
+        &100u64,
+        &Some(50u64),
+        &false,
+    );
+
+    set_time(&env, 50);
+    // 3 * 50/100 = 1.5 -> integer 1
+    assert_eq!(client.get_vested_amount(&sid), 1);
+
+    set_time(&env, 100);
+    assert_eq!(client.get_vested_amount(&sid), 3);
+}
+
+/// Edge case: revoked linear schedule with cliff.
+#[test]
+fn cliff_plus_linear_revoked() {
+    let env = create_env();
+    let (client, _owner, employer, beneficiary, token) = full_setup(&env);
+
+    set_time(&env, 0);
+    let sid = client.create_linear_schedule(
+        &employer,
+        &beneficiary,
+        &token.address,
+        &1_000i128,
+        &0u64,
+        &100u64,
+        &Some(30u64),
+        &true,
+    );
+
+    set_time(&env, 20);
+    client.revoke(&employer, &sid);
+
+    set_time(&env, 999);
+    assert_eq!(client.get_vested_amount(&sid), 0);
+    assert_eq!(client.get_releasable_amount(&sid), 0);
+}


### PR DESCRIPTION
## Summary

Enhances the doc comment on compute_vested_amount and adds comprehensive property-style tests covering cliff+linear interaction for the token_vesting contract.

Fixes #516.

## Changes

### src/lib.rs
- Expanded doc comment on compute_vested_amount with vesting kind descriptions, cliff+linear interaction note, arguments, return value, and panic section.

### tests/test_vesting.rs (5 new tests)
- cliff_plus_linear_full_spectrum — snapshots vested amounts at 12 timestamps from 0 to 110 on a linear+cliff schedule, covering before-start, before-cliff (blocked by cliff), at-cliff (linear interpolation kicks in), mid-linear, end, and past-end
- cliff_equals_end — edge case where cliff_time == end_time (no linear segment after cliff)
- cliff_equals_start — edge case where cliff_time == start_time (effectively no gate)
- cliff_plus_linear_small_amount — integer truncation behavior with 3 tokens
- cliff_plus_linear_revoked — revocation before cliff freezes vested at 0

## Not changed
- No runtime logic, schema, public API signatures, or Cargo.toml dependencies.
- No proptest dependency added (tests use manual exhaustive enumeration, appropriate for the Soroban #[test] environment).

Wallet: RTC269fa5650798c3aa5086a128c025a546e0a41d0b
AI assistance disclosure: This PR was authored with AI assistance (Codex/GPT-5).