### PR TITLE
fix(dispute_escalation): add SlaDeadlineOverflow error for u64 overflow in keeper_advance_stage

### DIFF
--- a/onchain/contracts/dispute_escalation/src/lib.rs
+++ b/onchain/contracts/dispute_escalation/src/lib.rs
@@ -372,7 +372,7 @@ impl DisputeEscalationContract {
 
         // Open a bounded admin-review window.
         let review_limit = storage::get_pending_review_time_limit(&env);
-        let review_deadline = now + review_limit;
+        let review_deadline = now.checked_add(review_limit).ok_or(DisputeError::SlaDeadlineOverflow)?;
 
         // `phase_started_at` records exactly when the SLA breach was observed.
         dispute.status = DisputeStatus::PendingReview;

--- a/onchain/contracts/dispute_escalation/src/types.rs
+++ b/onchain/contracts/dispute_escalation/src/types.rs
@@ -160,4 +160,6 @@ pub enum DisputeError {
     AlreadyTerminal = 10,
     /// Dispute is already in PendingReview state; keeper_advance_stage cannot be called again.
     AlreadyPendingReview = 11,
+    /// SLA deadline computation overflowed u64; keeper_advance_stage cannot proceed.
+    SlaDeadlineOverflow = 12,
 }

--- a/onchain/contracts/dispute_escalation/tests/test_escalation.rs
+++ b/onchain/contracts/dispute_escalation/tests/test_escalation.rs
@@ -1358,3 +1358,23 @@ fn test_cannot_escalate_from_resolved_state() {
     let res = client.try_escalate_dispute(&user, &id);
     assert_eq!(res, Err(Ok(DisputeError::AlreadyResolved)));
 }
+
+
+#[test]
+fn test_keeper_advance_stage_overflow_returns_distinct_error() {
+    // When pending_review_time_limit is set to u64::MAX, now + limit overflows
+    // and should return SlaDeadlineOverflow, not a silent wraparound.
+    let (env, client, _owner, admin, user) = setup();
+    let id = 1401u128;
+
+    client.file_dispute(&user, &id);
+
+    // Advance past the deadline so keeper_advance_stage is callable
+    advance(&env, DEFAULT_LEVEL_LIMIT + 1);
+
+    // Set a time limit that will overflow when added to the current timestamp
+    client.set_pending_review_time_limit(&admin, &u64::MAX);
+
+    let res = client.try_keeper_advance_stage(&user, &id);
+    assert_eq!(res, Err(Ok(DisputeError::SlaDeadlineOverflow)));
+}


### PR DESCRIPTION
# Issue
https://github.com/Stellopay/stellopay-core/issues/517

## What this PR does
Adds a distinct SlaDeadlineOverflow error variant that is returned when the SLA deadline computation in keeper_advance_stage overflows u64, replacing the previous silent wraparound behavior.

## Changes
1. types.rs: Added SlaDeadlineOverflow = 12 to DisputeError enum
2. lib.rs: Changed now + review_limit to checked_add with ok_or returning SlaDeadlineOverflow
3. test_escalation.rs: Added test_keeper_advance_stage_overflow_returns_distinct_error

## What is NOT changed
- Other SLA deadline computations (file_dispute, escalate_dispute, appeal_ruling) — issue scope is keeper_advance_stage only
- No admin-only guards, state machine logic, event structures, or storage schema

## Verification
- New test covers the overflow path by setting pending_review_time_limit to u64::MAX
- Existing tests remain untouched and should pass unchanged

## AI Assistance Disclosure
This PR was authored with assistance from an AI coding agent (Codex/GPT-5). All changes were reviewed and verified before submission.
