### PR TITLE
fix(fee_collector): validate tier limits strictly increasing and positive in update_tiered_schedule

### DIFF
--- a/onchain/contracts/fee_collector/src/lib.rs
+++ b/onchain/contracts/fee_collector/src/lib.rs
@@ -410,11 +410,17 @@ impl FeeCollectorContract {
         admin.require_auth();
         require_admin(&env, &admin);
 
+        let mut prev_limit: i128 = 0;
         for tier in new_schedule.iter() {
+            assert!(
+                tier.limit > prev_limit,
+                "Tier limits must be strictly increasing and positive"
+            );
             assert!(
                 tier.fee_bps <= MAX_FEE_BPS,
                 "Fee in tier exceeds maximum allowed"
             );
+            prev_limit = tier.limit;
         }
 
         env.storage()

--- a/onchain/contracts/fee_collector/tests/test_tiered_fees.rs
+++ b/onchain/contracts/fee_collector/tests/test_tiered_fees.rs
@@ -93,3 +93,97 @@ fn test_update_tiered_schedule_unauthorized() {
     let schedule = Vec::new(&env);
     client.update_tiered_schedule(&attacker, &schedule);
 }
+
+
+#[test]
+#[should_panic(expected = "Tier limits must be strictly increasing and positive")]
+fn test_update_tiered_schedule_negative_limit_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let client = FeeCollectorContractClient::new(&env, &env.register(FeeCollectorContract, ()));
+
+    client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
+
+    let mut schedule = Vec::new(&env);
+    schedule.push_back(FeeTier { limit: -100, fee_bps: 500 });
+
+    client.update_tiered_schedule(&admin, &schedule);
+}
+
+#[test]
+#[should_panic(expected = "Tier limits must be strictly increasing and positive")]
+fn test_update_tiered_schedule_zero_limit_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let client = FeeCollectorContractClient::new(&env, &env.register(FeeCollectorContract, ()));
+
+    client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
+
+    let mut schedule = Vec::new(&env);
+    schedule.push_back(FeeTier { limit: 0, fee_bps: 500 });
+
+    client.update_tiered_schedule(&admin, &schedule);
+}
+
+#[test]
+#[should_panic(expected = "Tier limits must be strictly increasing and positive")]
+fn test_update_tiered_schedule_non_increasing_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let client = FeeCollectorContractClient::new(&env, &env.register(FeeCollectorContract, ()));
+
+    client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
+
+    let mut schedule = Vec::new(&env);
+    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
+    schedule.push_back(FeeTier { limit: 500, fee_bps: 250 }); // lower than previous
+
+    client.update_tiered_schedule(&admin, &schedule);
+}
+
+#[test]
+#[should_panic(expected = "Tier limits must be strictly increasing and positive")]
+fn test_update_tiered_schedule_duplicate_limit_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let client = FeeCollectorContractClient::new(&env, &env.register(FeeCollectorContract, ()));
+
+    client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
+
+    let mut schedule = Vec::new(&env);
+    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
+    schedule.push_back(FeeTier { limit: 1000, fee_bps: 250 }); // same as previous
+
+    client.update_tiered_schedule(&admin, &schedule);
+}
+
+#[test]
+fn test_update_tiered_schedule_valid_limits_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let client = FeeCollectorContractClient::new(&env, &env.register(FeeCollectorContract, ()));
+
+    client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
+
+    let mut schedule = Vec::new(&env);
+    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
+    schedule.push_back(FeeTier { limit: 5000, fee_bps: 250 });
+    schedule.push_back(FeeTier { limit: i128::MAX, fee_bps: 100 });
+
+    client.update_tiered_schedule(&admin, &schedule);
+}


### PR DESCRIPTION
Issue: https://github.com/Stellopay/stellopay-core/issues/515

Adds validation to update_tiered_schedule so that tier thresholds (limit fields) must be strictly increasing and positive. Previously only fee_bps was validated.

Changes:
1. lib.rs: prev_limit tracking - each tier must have limit > prev_limit (starting from 0)
2. test_tiered_fees.rs: 5 test cases (negative, zero, non-increasing, duplicate, valid)

Not changed: runtime fee calculation, storage schema, events.

AI Assistance Disclosure: This PR was authored with assistance from an AI coding agent (Codex/GPT-5). All changes were reviewed and verified.