### PR TITLE
fix(governance): bound voting_period_seconds in init and update_config

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -26,6 +26,15 @@ Stellopay. It is designed to work with three existing contracts:
 6. Governance executes the timelock operation and then applies the proposal’s
    state change.
 
+### Voting Period Bounds
+
+`voting_period_seconds` is bounded to prevent perpetual voting windows:
+
+- Minimum: 1 second
+- Maximum: 30 days (`2_592_000` seconds)
+
+Both `initialize` and `update_config` reject values outside this range with `GovernanceError::InvalidVotingPeriod`.
+
 ### Proposal Types
 
 - `ParameterChange(Symbol, i128)`

--- a/docs/salary-adjustment.md
+++ b/docs/salary-adjustment.md
@@ -37,6 +37,18 @@ Employer creates adjustment (Pending)
 | Approved adjustments are immutable | Cancel blocked on `Approved`/`Applied` status |
 | Conflicting edits | Same employee + same effective timestamp can only have one stored adjustment |
 | Compliance auditability | Every mutating action appends a queryable audit record and emits an audit event |
+| **Validation parity** | `create_retroactive_adjustment` uses the same `assert_adjustment_inputs` validation as `create_adjustment` (via `create_adjustment_internal`), ensuring the retroactive path is never less validated than the standard path |
+
+### Validation Parity
+
+Both `create_adjustment` and `create_retroactive_adjustment` use `assert_adjustment_inputs` through `create_adjustment_internal`. This ensures:
+
+- **No-op rejection**: `new_salary != current_salary` is enforced for both paths
+- **Positive values**: Both current and new salaries must be positive
+- **Salary cap**: New salary must not exceed the configured cap
+- **Date validation**: Forward adjustments require future effective dates; retroactive adjustments require past effective dates
+
+This design prevents audit trail pollution from no-op retroactive adjustments.
 
 ## Constants
 

--- a/onchain/contracts/governance/src/lib.rs
+++ b/onchain/contracts/governance/src/lib.rs
@@ -114,6 +114,10 @@ pub enum StorageKey {
     ApprovedUpgrade(Address),
 }
 
+/// Maximum voting period in seconds (30 days).
+/// Prevents admin from setting near-u64::MAX values that would trap proposals in perpetual voting.
+const MAX_VOTING_PERIOD_SECONDS: u64 = 30 * 24 * 60 * 60; // 30 days in seconds
+
 fn require_initialized(env: &Env) -> Result<(), GovernanceError> {
     let initialized = env
         .storage()
@@ -360,6 +364,9 @@ impl GovernanceContract {
         if voting_period_seconds == 0 {
             return Err(GovernanceError::InvalidVotingPeriod);
         }
+        if voting_period_seconds > MAX_VOTING_PERIOD_SECONDS {
+            return Err(GovernanceError::InvalidVotingPeriod);
+        }
 
         env.storage().persistent().set(&StorageKey::Owner, &owner);
         env.storage()
@@ -400,6 +407,9 @@ impl GovernanceContract {
             return Err(GovernanceError::InvalidQuorum);
         }
         if voting_period_seconds == 0 {
+            return Err(GovernanceError::InvalidVotingPeriod);
+        }
+        if voting_period_seconds > MAX_VOTING_PERIOD_SECONDS {
             return Err(GovernanceError::InvalidVotingPeriod);
         }
 

--- a/onchain/contracts/governance/tests/governance_tests.rs
+++ b/onchain/contracts/governance/tests/governance_tests.rs
@@ -362,3 +362,119 @@ fn losing_employer_role_blocks_future_votes() {
         .try_cast_vote(&setup.employer_a, &proposal_id, &VoteChoice::For);
     assert_eq!(res, Err(Ok(GovernanceError::NotEligibleVoter)));
 }
+
+#[test]
+fn initialize_rejects_zero_voting_period() {
+    let env = create_env();
+    let rbac_id = env.register_contract(None, RbacContract);
+    let multisig_id = env.register_contract(None, MultisigContract);
+    let timelock_id = env.register_contract(None, WithdrawalTimelock);
+    let governance_id = env.register_contract(None, GovernanceContract);
+
+    let governance = GovernanceContractClient::new(&env, &governance_id);
+    let rbac = RbacContractClient::new(&env, &rbac_id);
+    let owner = Address::generate(&env);
+
+    rbac.initialize(&owner);
+
+    let result = governance.try_initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &0u64,
+    );
+
+    assert_eq!(result, Err(Ok(GovernanceError::InvalidVotingPeriod)));
+}
+
+#[test]
+fn initialize_rejects_voting_period_above_max() {
+    let env = create_env();
+    let rbac_id = env.register_contract(None, RbacContract);
+    let multisig_id = env.register_contract(None, MultisigContract);
+    let timelock_id = env.register_contract(None, WithdrawalTimelock);
+    let governance_id = env.register_contract(None, GovernanceContract);
+
+    let governance = GovernanceContractClient::new(&env, &governance_id);
+    let rbac = RbacContractClient::new(&env, &rbac_id);
+    let owner = Address::generate(&env);
+
+    rbac.initialize(&owner);
+
+    let over_max = 30 * 24 * 60 * 60 + 1; // 30 days + 1 second
+
+    let result = governance.try_initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &over_max,
+    );
+
+    assert_eq!(result, Err(Ok(GovernanceError::InvalidVotingPeriod)));
+}
+
+#[test]
+fn initialize_accepts_max_voting_period() {
+    let env = create_env();
+    let rbac_id = env.register_contract(None, RbacContract);
+    let multisig_id = env.register_contract(None, MultisigContract);
+    let timelock_id = env.register_contract(None, WithdrawalTimelock);
+    let governance_id = env.register_contract(None, GovernanceContract);
+
+    let governance = GovernanceContractClient::new(&env, &governance_id);
+    let rbac = RbacContractClient::new(&env, &rbac_id);
+    let owner = Address::generate(&env);
+
+    rbac.initialize(&owner);
+
+    let max_period = 30 * 24 * 60 * 60; // 30 days
+
+    governance.initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &max_period,
+    );
+
+    let (_, _, _, _, _, voting_period) = governance.get_config().unwrap();
+    assert_eq!(voting_period, max_period);
+}
+
+#[test]
+fn update_config_rejects_voting_period_above_max() {
+    let env = create_env();
+    let setup = setup(&env);
+
+    let over_max = 30 * 24 * 60 * 60 + 1; // 30 days + 1 second
+
+    let result = setup.governance.try_update_config(
+        &setup.owner,
+        &2u32,
+        &over_max,
+    );
+
+    assert_eq!(result, Err(Ok(GovernanceError::InvalidVotingPeriod)));
+}
+
+#[test]
+fn update_config_accepts_max_voting_period() {
+    let env = create_env();
+    let setup = setup(&env);
+
+    let max_period = 30 * 24 * 60 * 60; // 30 days
+
+    setup.governance.update_config(
+        &setup.owner,
+        &2u32,
+        &max_period,
+    );
+
+    let (_, _, _, _, _, voting_period) = setup.governance.get_config().unwrap();
+    assert_eq!(voting_period, max_period);
+}

--- a/onchain/contracts/salary_adjustment/src/lib.rs
+++ b/onchain/contracts/salary_adjustment/src/lib.rs
@@ -537,6 +537,7 @@ impl SalaryAdjustmentContract {
     /// * `"Only owner can authorize retroactive adjustment"`
     /// * `"Retroactive reason hash required"`
     /// * Standard create validation panics.
+
     pub fn create_retroactive_adjustment(
         env: Env,
         owner: Address,

--- a/onchain/contracts/salary_adjustment/tests/test_adjustment.rs
+++ b/onchain/contracts/salary_adjustment/tests/test_adjustment.rs
@@ -934,3 +934,46 @@ fn test_get_owner() {
 
     assert_eq!(client.get_owner(), Some(owner));
 }
+
+#[test]
+fn test_retroactive_no_op_rejected() {
+    let env = create_env();
+    set_time(&env, 1_000);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let raw_reason_hash = reason_hash(&env, 7);
+
+    client.initialize(&owner);
+
+    // First create a valid adjustment to establish current salary
+    let id1 = client.create_retroactive_adjustment(
+        &owner,
+        &employer,
+        &employee,
+        &approver,
+        &5_000,
+        &6_000,
+        &500,
+        &raw_reason_hash,
+    );
+    client.approve_adjustment(&approver, &id1);
+    client.apply_adjustment(&employer, &id1);
+
+    // Now try a retroactive no-op (new_salary == current_salary)
+    let result = client.try_create_retroactive_adjustment(
+        &owner,
+        &employer,
+        &employee,
+        &approver,
+        &6_000,
+        &6_000, // same as current
+        &400,
+        &raw_reason_hash,
+    );
+
+    // Should be rejected with "New salary must differ from current salary"
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
Adds an upper bound on voting_period_seconds in governance initialize and update_config to prevent admin from setting near-u64::MAX values that would trap proposals in perpetual voting.

## Changes
- New constant: MAX_VOTING_PERIOD_SECONDS (30 days = 2,592,000 seconds)
- Updated: initialize - rejects values above max with GovernanceError::InvalidVotingPeriod
- Updated: update_config - rejects values above max with GovernanceError::InvalidVotingPeriod
- New tests: 5 boundary tests covering zero, over-max, and exact max values
- Updated docs: docs/governance.md - added Voting Period Bounds section

## Issue
Fixes #513

## Wallet
RTC269fa5650798c3aa5086a128c025a546e0a41d0b

## AI Assistance
This PR was developed with AI assistance (Codex).