### PR TITLE
chore(ci): enforce workspace formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  noop:
+  formatting:
     runs-on: ubuntu-latest
     steps:
-      - name: Skipped
-        run: echo "Use workflow Contracts CI (.github/workflows/contracts.yml) for automated runs."
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check Rust formatting
+        working-directory: onchain
+        run: cargo fmt --all --check

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Add WASM target
         run: rustup target add wasm32-unknown-unknown
 
+      - name: Check Rust formatting
+        working-directory: onchain
+        run: cargo fmt --all --check
+
       - name: Install Stellar CLI
         run: cargo install stellar-cli --locked
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,8 @@
+# Match the workspace edition and CI stable toolchain.
+msrv = "1.75.0"
+
+# Keep complexity guidance explicit without turning routine contract entrypoints
+# into noisy lint failures.
+cognitive-complexity-threshold = 30
+too-many-arguments-threshold = 8
+type-complexity-threshold = 250

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,14 +7,27 @@ The GitHub Actions workflow **Contracts CI** (`.github/workflows/contracts.yml`)
 It performs:
 
 1. **Rust toolchain** — stable channel, `wasm32-unknown-unknown` target, `llvm-tools-preview` (for coverage instrumentation).
-2. **Stellar CLI** — `cargo install stellar-cli --locked` for `stellar contract build`.
-3. **Unit / integration tests**
+2. **Formatting gate** — `cargo fmt --all --check` from `onchain/`, using the repository-level `rustfmt.toml`.
+3. **Stellar CLI** — `cargo install stellar-cli --locked` for `stellar contract build`.
+4. **Unit / integration tests**
    - `cargo test -p payroll_escrow --verbose`
    - `cargo test -p stello_pay_contract --verbose`
    - `cargo test -p integration_tests --verbose`
    - `cargo test -p template_versioning --verbose`
-4. **WASM build** — `stellar contract build` in `onchain/contracts/stello_pay_contract` and `onchain/contracts/template_versioning`.
-5. **Coverage** — `cargo llvm-cov` over the same two packages; produces `onchain/codecov.json` and uploads it as a workflow artifact.
+5. **WASM build** — `stellar contract build` in `onchain/contracts/stello_pay_contract` and `onchain/contracts/template_versioning`.
+6. **Coverage** — `cargo llvm-cov` over the same two packages; produces `onchain/codecov.json` and uploads it as a workflow artifact.
+
+## Formatting and lint conventions
+
+The repository root contains `rustfmt.toml` and `clippy.toml`. Keep these files
+at the root so every contract crate in `onchain/` inherits the same formatting
+and lint thresholds when commands run from the Cargo workspace.
+
+- Run `cargo fmt --all --check` from `onchain/` before opening a PR.
+- Run `cargo clippy --workspace --all-targets` from `onchain/` when changing Rust logic.
+- Prefer updating the root config over adding per-crate formatting or lint exceptions.
+- Document any future threshold changes here so reviewers know whether the change is
+  a style policy update or a source-code fix.
 
 ### Optional Codecov
 
@@ -53,6 +66,7 @@ Align with CI for reproducible runs:
 
 ```bash
 cd onchain
+cargo fmt --all --check
 cargo test -p payroll_escrow --verbose
 cargo test -p stello_pay_contract --verbose
 cargo test -p integration_tests --verbose
@@ -62,4 +76,4 @@ cd ../.. && cargo llvm-cov test -p stello_pay_contract -p integration_tests --ht
 
 ## Legacy workflow
 
-`.github/workflows/ci.yml` is limited to **manual** runs (`workflow_dispatch`) so PRs are not duplicated. Use **Contracts CI** for branch protection checks.
+`.github/workflows/ci.yml` is limited to **manual** runs (`workflow_dispatch`) so PRs are not duplicated. Its formatting job mirrors the automated **Contracts CI** formatting gate for maintainers who want an on-demand check.

--- a/onchain/contracts/compliance_checker/src/lib.rs
+++ b/onchain/contracts/compliance_checker/src/lib.rs
@@ -179,10 +179,17 @@ impl ComplianceCheckerContract {
             .persistent()
             .get::<_, bool>(&StorageKey::EmergencyPause)
             .unwrap_or(false);
-        
-        let pause_result = if is_paused { Decision::Deny } else { Decision::Allow };
-        traces.push_back(TraceEntry { rule: ReasonCode::EmergencyPaused, result: pause_result });
-        
+
+        let pause_result = if is_paused {
+            Decision::Deny
+        } else {
+            Decision::Allow
+        };
+        traces.push_back(TraceEntry {
+            rule: ReasonCode::EmergencyPaused,
+            result: pause_result,
+        });
+
         if is_paused {
             return Self::make_decision(Decision::Deny, ReasonCode::EmergencyPaused, traces);
         }
@@ -190,25 +197,50 @@ impl ComplianceCheckerContract {
         // 2. Auxiliary Not Allowed check
         if executor != actor {
             let is_allowed = Self::is_auxiliary_allowed(env.clone(), executor);
-            let aux_result = if is_allowed { Decision::Allow } else { Decision::Deny };
-            traces.push_back(TraceEntry { rule: ReasonCode::AuxiliaryNotAllowed, result: aux_result });
+            let aux_result = if is_allowed {
+                Decision::Allow
+            } else {
+                Decision::Deny
+            };
+            traces.push_back(TraceEntry {
+                rule: ReasonCode::AuxiliaryNotAllowed,
+                result: aux_result,
+            });
             if !is_allowed {
-                return Self::make_decision(Decision::Deny, ReasonCode::AuxiliaryNotAllowed, traces);
+                return Self::make_decision(
+                    Decision::Deny,
+                    ReasonCode::AuxiliaryNotAllowed,
+                    traces,
+                );
             }
         }
 
         // 3. Terminal State check
         let is_terminal = current_state == AgreementStatus::Completed;
-        let terminal_result = if is_terminal { Decision::Deny } else { Decision::Allow };
-        traces.push_back(TraceEntry { rule: ReasonCode::TerminalState, result: terminal_result });
+        let terminal_result = if is_terminal {
+            Decision::Deny
+        } else {
+            Decision::Allow
+        };
+        traces.push_back(TraceEntry {
+            rule: ReasonCode::TerminalState,
+            result: terminal_result,
+        });
         if is_terminal {
             return Self::make_decision(Decision::Deny, ReasonCode::TerminalState, traces);
         }
 
         // 4. Invalid Current State check
         let is_current_valid = Self::is_action_allowed_from_state(action, current_state);
-        let current_valid_result = if is_current_valid { Decision::Allow } else { Decision::Deny };
-        traces.push_back(TraceEntry { rule: ReasonCode::InvalidCurrentState, result: current_valid_result });
+        let current_valid_result = if is_current_valid {
+            Decision::Allow
+        } else {
+            Decision::Deny
+        };
+        traces.push_back(TraceEntry {
+            rule: ReasonCode::InvalidCurrentState,
+            result: current_valid_result,
+        });
         if !is_current_valid {
             return Self::make_decision(Decision::Deny, ReasonCode::InvalidCurrentState, traces);
         }
@@ -216,8 +248,15 @@ impl ComplianceCheckerContract {
         // 5. Invalid Target State check
         let expected_target = Self::expected_target_state(action, current_state);
         let is_target_valid = target_state == expected_target;
-        let target_valid_result = if is_target_valid { Decision::Allow } else { Decision::Deny };
-        traces.push_back(TraceEntry { rule: ReasonCode::InvalidTargetState, result: target_valid_result });
+        let target_valid_result = if is_target_valid {
+            Decision::Allow
+        } else {
+            Decision::Deny
+        };
+        traces.push_back(TraceEntry {
+            rule: ReasonCode::InvalidTargetState,
+            result: target_valid_result,
+        });
         if !is_target_valid {
             return Self::make_decision(Decision::Deny, ReasonCode::InvalidTargetState, traces);
         }
@@ -227,17 +266,32 @@ impl ComplianceCheckerContract {
             || action == PayrollAction::ClaimTimeBased
             || action == PayrollAction::ClaimMilestone;
         if is_claim_action && current_state == AgreementStatus::Cancelled {
-            let grace_result = if grace_period_active { Decision::Allow } else { Decision::Deny };
-            traces.push_back(TraceEntry { rule: ReasonCode::GracePeriodRequired, result: grace_result });
+            let grace_result = if grace_period_active {
+                Decision::Allow
+            } else {
+                Decision::Deny
+            };
+            traces.push_back(TraceEntry {
+                rule: ReasonCode::GracePeriodRequired,
+                result: grace_result,
+            });
             if !grace_period_active {
-                return Self::make_decision(Decision::Deny, ReasonCode::GracePeriodRequired, traces);
+                return Self::make_decision(
+                    Decision::Deny,
+                    ReasonCode::GracePeriodRequired,
+                    traces,
+                );
             }
         }
 
         Self::make_decision(Decision::Allow, ReasonCode::Allowed, traces)
     }
 
-    fn make_decision(decision: Decision, reason: ReasonCode, traces: soroban_sdk::Vec<TraceEntry>) -> ComplianceDecision {
+    fn make_decision(
+        decision: Decision,
+        reason: ReasonCode,
+        traces: soroban_sdk::Vec<TraceEntry>,
+    ) -> ComplianceDecision {
         ComplianceDecision {
             decision,
             reason,
@@ -245,7 +299,10 @@ impl ComplianceCheckerContract {
         }
     }
 
-    fn expected_target_state(action: PayrollAction, current_state: AgreementStatus) -> AgreementStatus {
+    fn expected_target_state(
+        action: PayrollAction,
+        current_state: AgreementStatus,
+    ) -> AgreementStatus {
         match action {
             PayrollAction::AddEmployee => AgreementStatus::Created,
             PayrollAction::ActivateAgreement => AgreementStatus::Active,
@@ -268,7 +325,8 @@ impl ComplianceCheckerContract {
             PayrollAction::PauseAgreement => current_state == AgreementStatus::Active,
             PayrollAction::ResumeAgreement => current_state == AgreementStatus::Paused,
             PayrollAction::CancelAgreement => {
-                current_state == AgreementStatus::Created || current_state == AgreementStatus::Active
+                current_state == AgreementStatus::Created
+                    || current_state == AgreementStatus::Active
             }
             PayrollAction::FinalizeGracePeriod => current_state == AgreementStatus::Cancelled,
             PayrollAction::RaiseDispute => {
@@ -280,7 +338,8 @@ impl ComplianceCheckerContract {
             PayrollAction::ClaimPayroll
             | PayrollAction::ClaimTimeBased
             | PayrollAction::ClaimMilestone => {
-                current_state == AgreementStatus::Active || current_state == AgreementStatus::Cancelled
+                current_state == AgreementStatus::Active
+                    || current_state == AgreementStatus::Cancelled
             }
         }
     }

--- a/onchain/contracts/compliance_checker/tests/test_compliance.rs
+++ b/onchain/contracts/compliance_checker/tests/test_compliance.rs
@@ -40,8 +40,8 @@ fn test_valid_transition_allows_activate_created_to_active() {
 
     assert_eq!(decision.decision, Decision::Allow);
     assert_eq!(decision.reason, ReasonCode::Allowed);
-    
-    // Verify traces: 
+
+    // Verify traces:
     // 1. EmergencyPause: Allow
     // 2. TerminalState: Allow
     // 3. InvalidCurrentState: Allow
@@ -143,7 +143,11 @@ fn test_invalid_current_state_matrix_is_denied() {
     let actor = Address::generate(&env);
 
     let deny_cases = [
-        (PayrollAction::AddEmployee, AgreementStatus::Active, AgreementStatus::Created),
+        (
+            PayrollAction::AddEmployee,
+            AgreementStatus::Active,
+            AgreementStatus::Created,
+        ),
         (
             PayrollAction::ActivateAgreement,
             AgreementStatus::Paused,
@@ -248,8 +252,7 @@ fn test_invalid_target_state_is_denied() {
     ];
 
     for (action, current, bad_target) in cases {
-        let decision =
-            client.check_action(&actor, &actor, &action, &current, &bad_target, &false);
+        let decision = client.check_action(&actor, &actor, &action, &current, &bad_target, &false);
         assert_eq!(decision.decision, Decision::Deny);
         assert_eq!(decision.reason, ReasonCode::InvalidTargetState);
     }

--- a/onchain/contracts/compliance_reporting/src/lib.rs
+++ b/onchain/contracts/compliance_reporting/src/lib.rs
@@ -25,11 +25,12 @@
 //! ensuring ledger TTL extensions if long-term on-chain retention is required.
 //! Off-chain indexers should consume events and snapshot data independently.
 
-use soroban_sdk::{
-    contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Vec,
-};
 use audit_logger::{AuditLogEntry, AuditLoggerContract};
 use payment_history::{PaymentHistoryContract, PaymentRecord};
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, symbol_short, Address,
+    Bytes, Env, Vec,
+};
 
 contractclient!(AuditLoggerContract, audit_logger_client);
 contractclient!(PaymentHistoryContract, payment_history_client);
@@ -212,10 +213,7 @@ impl ComplianceReportingContract {
             .persistent()
             .set(&DataKey::Publisher(admin.clone()), &true);
 
-        env.events().publish(
-            (symbol_short!("init"),),
-            (admin,),
-        );
+        env.events().publish((symbol_short!("init"),), (admin,));
 
         Ok(())
     }
@@ -244,10 +242,8 @@ impl ComplianceReportingContract {
             .persistent()
             .set(&DataKey::Publisher(publisher.clone()), &authorized);
 
-        env.events().publish(
-            (symbol_short!("pub_set"),),
-            (publisher, authorized),
-        );
+        env.events()
+            .publish((symbol_short!("pub_set"),), (publisher, authorized));
 
         Ok(())
     }
@@ -276,8 +272,12 @@ impl ComplianceReportingContract {
         Self::require_initialized(&env)?;
         Self::require_admin(&env, &caller)?;
 
-        env.storage().persistent().set(&DataKey::AuditLogger, &audit_logger);
-        env.storage().persistent().set(&DataKey::PaymentHistory, &payment_history);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AuditLogger, &audit_logger);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PaymentHistory, &payment_history);
 
         Ok(())
     }
@@ -298,10 +298,7 @@ impl ComplianceReportingContract {
 
         env.storage().instance().set(&DataKey::Paused, &paused);
 
-        env.events().publish(
-            (symbol_short!("paused"),),
-            (paused,),
-        );
+        env.events().publish((symbol_short!("paused"),), (paused,));
 
         Ok(())
     }
@@ -367,12 +364,7 @@ impl ComplianceReportingContract {
 
         // Assign per-employer ID.
         let count_key = DataKey::RecordCount(employer.clone());
-        let next_id: u32 = env
-            .storage()
-            .persistent()
-            .get(&count_key)
-            .unwrap_or(0u32)
-            + 1;
+        let next_id: u32 = env.storage().persistent().get(&count_key).unwrap_or(0u32) + 1;
 
         // Assign global sequence number.
         let global_seq: u64 = env
@@ -577,7 +569,9 @@ impl ComplianceReportingContract {
         // 3. Fetch AuditLogger events
         let al_client = audit_logger_client::Client::new(&env, &audit_logger_addr);
         // Assuming there is a way to get logs.
-        let events = al_client.get_latest_logs(&MAX_QUERY_LIMIT).unwrap_or_else(|_| Vec::new(&env));
+        let events = al_client
+            .get_latest_logs(&MAX_QUERY_LIMIT)
+            .unwrap_or_else(|_| Vec::new(&env));
 
         // 4. Fetch Withholding records (placeholder)
         let withholding_records = Vec::new(&env);

--- a/onchain/contracts/compliance_reporting/tests/test_compliance.rs
+++ b/onchain/contracts/compliance_reporting/tests/test_compliance.rs
@@ -92,7 +92,15 @@ fn test_log_record_before_init_rejected() {
     let addr = Address::generate(&env);
 
     let err = client
-        .try_log_record(&addr, &addr, &addr, &addr, &100, &ReportType::Payroll, &Bytes::new(&env))
+        .try_log_record(
+            &addr,
+            &addr,
+            &addr,
+            &addr,
+            &100,
+            &ReportType::Payroll,
+            &Bytes::new(&env),
+        )
         .unwrap_err()
         .unwrap();
     assert_eq!(err, ComplianceError::NotInitialized);
@@ -160,8 +168,13 @@ fn test_pause_blocks_log_record() {
 
     let err = client
         .try_log_record(
-            &employer, &employer, &employee, &token,
-            &100, &ReportType::Payroll, &Bytes::new(&env),
+            &employer,
+            &employer,
+            &employee,
+            &token,
+            &100,
+            &ReportType::Payroll,
+            &Bytes::new(&env),
         )
         .unwrap_err()
         .unwrap();
@@ -176,7 +189,15 @@ fn test_pause_does_not_block_reads() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 500, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        500,
+        &ReportType::Payroll,
+    );
 
     client.set_paused(&admin, &true);
 
@@ -198,7 +219,15 @@ fn test_unpause_restores_writes() {
     assert!(!client.is_paused());
 
     env.ledger().set_timestamp(1000);
-    let id = log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    let id = log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
     assert_eq!(id, 1);
 }
 
@@ -226,7 +255,15 @@ fn test_log_record_employer_as_publisher() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    let id = log_as_employer(&client, &env, &employer, &employee, &token, 5000, &ReportType::Payroll);
+    let id = log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        5000,
+        &ReportType::Payroll,
+    );
 
     assert_eq!(id, 1);
     assert_eq!(client.get_record_count(&employer), 1);
@@ -253,8 +290,13 @@ fn test_log_record_authorized_publisher() {
 
     env.ledger().set_timestamp(2000);
     let id = client.log_record(
-        &publisher, &employer, &employee, &token,
-        &1000, &ReportType::Tax, &Bytes::new(&env),
+        &publisher,
+        &employer,
+        &employee,
+        &token,
+        &1000,
+        &ReportType::Tax,
+        &Bytes::new(&env),
     );
 
     assert_eq!(id, 1);
@@ -273,8 +315,13 @@ fn test_log_record_unauthorized_publisher_rejected() {
 
     let err = client
         .try_log_record(
-            &attacker, &employer, &employee, &token,
-            &100, &ReportType::Payroll, &Bytes::new(&env),
+            &attacker,
+            &employer,
+            &employee,
+            &token,
+            &100,
+            &ReportType::Payroll,
+            &Bytes::new(&env),
         )
         .unwrap_err()
         .unwrap();
@@ -294,8 +341,13 @@ fn test_log_record_revoked_publisher_rejected() {
 
     let err = client
         .try_log_record(
-            &publisher, &employer, &employee, &token,
-            &100, &ReportType::Payroll, &Bytes::new(&env),
+            &publisher,
+            &employer,
+            &employee,
+            &token,
+            &100,
+            &ReportType::Payroll,
+            &Bytes::new(&env),
         )
         .unwrap_err()
         .unwrap();
@@ -311,8 +363,13 @@ fn test_log_record_zero_amount_rejected() {
 
     let err = client
         .try_log_record(
-            &employer, &employer, &employee, &token,
-            &0, &ReportType::Payroll, &Bytes::new(&env),
+            &employer,
+            &employer,
+            &employee,
+            &token,
+            &0,
+            &ReportType::Payroll,
+            &Bytes::new(&env),
         )
         .unwrap_err()
         .unwrap();
@@ -328,8 +385,13 @@ fn test_log_record_negative_amount_rejected() {
 
     let err = client
         .try_log_record(
-            &employer, &employer, &employee, &token,
-            &-1, &ReportType::Payroll, &Bytes::new(&env),
+            &employer,
+            &employer,
+            &employee,
+            &token,
+            &-1,
+            &ReportType::Payroll,
+            &Bytes::new(&env),
         )
         .unwrap_err()
         .unwrap();
@@ -345,7 +407,15 @@ fn test_log_record_monotonic_ids_per_employer() {
 
     env.ledger().set_timestamp(1000);
     for expected_id in 1u32..=5 {
-        let id = log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+        let id = log_as_employer(
+            &client,
+            &env,
+            &employer,
+            &employee,
+            &token,
+            100,
+            &ReportType::Payroll,
+        );
         assert_eq!(id, expected_id);
     }
     assert_eq!(client.get_record_count(&employer), 5);
@@ -360,9 +430,33 @@ fn test_log_record_global_seq_increments_across_employers() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer_a, &employee, &token, 100, &ReportType::Payroll);
-    log_as_employer(&client, &env, &employer_b, &employee, &token, 200, &ReportType::Tax);
-    log_as_employer(&client, &env, &employer_a, &employee, &token, 300, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer_a,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer_b,
+        &employee,
+        &token,
+        200,
+        &ReportType::Tax,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer_a,
+        &employee,
+        &token,
+        300,
+        &ReportType::Payroll,
+    );
 
     assert_eq!(client.get_global_seq(), 3);
     assert_eq!(client.get_record_count(&employer_a), 2);
@@ -399,8 +493,13 @@ fn test_log_record_with_metadata() {
 
     env.ledger().set_timestamp(1000);
     let id = client.log_record(
-        &employer, &employer, &employee, &token,
-        &999, &ReportType::Regulatory, &metadata,
+        &employer,
+        &employer,
+        &employee,
+        &token,
+        &999,
+        &ReportType::Regulatory,
+        &metadata,
     );
 
     let record = client.get_record(&employer, &id).unwrap();
@@ -427,6 +526,8 @@ fn test_generate_report_with_mocked_external_contracts() {
     // The implementation of generate_report is verified to exist and call configured contracts.
 }
 
+#[test]
+fn test_get_withholding_records_empty() {
     let (env, client, _) = setup();
     let employer = Address::generate(&env);
 
@@ -444,11 +545,35 @@ fn test_get_withholding_records_date_filtering() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
     env.ledger().set_timestamp(2000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 200, &ReportType::Tax);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        200,
+        &ReportType::Tax,
+    );
     env.ledger().set_timestamp(3000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 300, &ReportType::Regulatory);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        300,
+        &ReportType::Regulatory,
+    );
 
     // Only t=2000 falls in [1500, 2500].
     let report = client.get_withholding_records(&employer, &1500, &2500, &None, &50);
@@ -465,9 +590,25 @@ fn test_get_withholding_records_inclusive_boundaries() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
     env.ledger().set_timestamp(2000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 200, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        200,
+        &ReportType::Payroll,
+    );
 
     let report = client.get_withholding_records(&employer, &1000, &2000, &None, &50);
     assert_eq!(report.record_count, 2);
@@ -482,9 +623,33 @@ fn test_get_withholding_records_type_filtering() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Tax);
-    log_as_employer(&client, &env, &employer, &employee, &token, 500, &ReportType::Payroll);
-    log_as_employer(&client, &env, &employer, &employee, &token, 200, &ReportType::Tax);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Tax,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        500,
+        &ReportType::Payroll,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        200,
+        &ReportType::Tax,
+    );
 
     let report = client.get_withholding_records(&employer, &0, &2000, &Some(ReportType::Tax), &50);
     assert_eq!(report.record_count, 2);
@@ -502,9 +667,33 @@ fn test_get_withholding_records_all_types_when_no_filter() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
-    log_as_employer(&client, &env, &employer, &employee, &token, 200, &ReportType::Tax);
-    log_as_employer(&client, &env, &employer, &employee, &token, 300, &ReportType::Regulatory);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        200,
+        &ReportType::Tax,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        300,
+        &ReportType::Regulatory,
+    );
 
     let report = client.get_withholding_records(&employer, &0, &2000, &None, &50);
     assert_eq!(report.record_count, 3);
@@ -520,7 +709,15 @@ fn test_get_withholding_records_limit_caps_results() {
 
     env.ledger().set_timestamp(1000);
     for _ in 0..10 {
-        log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+        log_as_employer(
+            &client,
+            &env,
+            &employer,
+            &employee,
+            &token,
+            100,
+            &ReportType::Payroll,
+        );
     }
 
     let report = client.get_withholding_records(&employer, &0, &2000, &None, &3);
@@ -581,7 +778,15 @@ fn test_get_withholding_records_equal_start_end_date() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
 
     let report = client.get_withholding_records(&employer, &1000, &1000, &None, &10);
     assert_eq!(report.record_count, 1);
@@ -595,7 +800,15 @@ fn test_get_withholding_records_no_records_in_range() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(5000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
 
     let report = client.get_withholding_records(&employer, &0, &4999, &None, &10);
     assert_eq!(report.record_count, 0);
@@ -610,11 +823,35 @@ fn test_get_withholding_records_returns_newest_first() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
     env.ledger().set_timestamp(2000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 200, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        200,
+        &ReportType::Payroll,
+    );
     env.ledger().set_timestamp(3000);
-    log_as_employer(&client, &env, &employer, &employee, &token, 300, &ReportType::Payroll);
+    log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        300,
+        &ReportType::Payroll,
+    );
 
     let report = client.get_withholding_records(&employer, &0, &5000, &None, &10);
     assert_eq!(report.record_count, 3);
@@ -639,7 +876,15 @@ fn test_global_seq_never_resets() {
 
     env.ledger().set_timestamp(1000);
     for _ in 0..5 {
-        log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+        log_as_employer(
+            &client,
+            &env,
+            &employer,
+            &employee,
+            &token,
+            100,
+            &ReportType::Payroll,
+        );
     }
     assert_eq!(client.get_global_seq(), 5);
 }
@@ -653,7 +898,15 @@ fn test_record_ids_are_contiguous() {
 
     env.ledger().set_timestamp(1000);
     for i in 1u32..=5 {
-        let id = log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+        let id = log_as_employer(
+            &client,
+            &env,
+            &employer,
+            &employee,
+            &token,
+            100,
+            &ReportType::Payroll,
+        );
         assert_eq!(id, i, "Expected contiguous ID {i}");
     }
 }
@@ -666,7 +919,15 @@ fn test_record_timestamp_is_ledger_time() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(42_000);
-    let id = log_as_employer(&client, &env, &employer, &employee, &token, 100, &ReportType::Payroll);
+    let id = log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
 
     let record = client.get_record(&employer, &id).unwrap();
     assert_eq!(record.timestamp, 42_000);
@@ -680,7 +941,15 @@ fn test_records_are_immutable_after_write() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    let id = log_as_employer(&client, &env, &employer, &employee, &token, 777, &ReportType::Tax);
+    let id = log_as_employer(
+        &client,
+        &env,
+        &employer,
+        &employee,
+        &token,
+        777,
+        &ReportType::Tax,
+    );
 
     let r1 = client.get_record(&employer, &id).unwrap();
     let r2 = client.get_record(&employer, &id).unwrap();
@@ -701,9 +970,33 @@ fn test_employer_records_are_isolated() {
     let token = Address::generate(&env);
 
     env.ledger().set_timestamp(1000);
-    log_as_employer(&client, &env, &employer_a, &employee, &token, 100, &ReportType::Payroll);
-    log_as_employer(&client, &env, &employer_a, &employee, &token, 200, &ReportType::Payroll);
-    log_as_employer(&client, &env, &employer_b, &employee, &token, 999, &ReportType::Tax);
+    log_as_employer(
+        &client,
+        &env,
+        &employer_a,
+        &employee,
+        &token,
+        100,
+        &ReportType::Payroll,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer_a,
+        &employee,
+        &token,
+        200,
+        &ReportType::Payroll,
+    );
+    log_as_employer(
+        &client,
+        &env,
+        &employer_b,
+        &employee,
+        &token,
+        999,
+        &ReportType::Tax,
+    );
 
     assert_eq!(client.get_record_count(&employer_a), 2);
     assert_eq!(client.get_record_count(&employer_b), 1);
@@ -725,7 +1018,15 @@ fn test_large_batch_logging_and_report() {
 
     for i in 1u64..=50 {
         env.ledger().set_timestamp(i * 100);
-        log_as_employer(&client, &env, &employer, &employee, &token, 10, &ReportType::Payroll);
+        log_as_employer(
+            &client,
+            &env,
+            &employer,
+            &employee,
+            &token,
+            10,
+            &ReportType::Payroll,
+        );
     }
 
     assert_eq!(client.get_record_count(&employer), 50);

--- a/onchain/contracts/department_manager/src/lib.rs
+++ b/onchain/contracts/department_manager/src/lib.rs
@@ -230,7 +230,10 @@ impl DepartmentManagerContract {
                 .expect("Parent department not found");
             assert!(parent.org_id == org_id, "Parent must be in same org");
             // child depth = parent depth + 1; must not exceed MAX_DEPTH
-            assert!(Self::dept_depth(&env, pid) + 1 <= MAX_DEPTH, "Max hierarchy depth exceeded");
+            assert!(
+                Self::dept_depth(&env, pid) + 1 <= MAX_DEPTH,
+                "Max hierarchy depth exceeded"
+            );
         }
 
         let next_id: u128 = env
@@ -516,12 +519,7 @@ impl DepartmentManagerContract {
     ///
     /// # Events
     /// Publishes `("dept_mvd", dept_id)` on success.
-    pub fn update_department(
-        env: Env,
-        caller: Address,
-        dept_id: u128,
-        new_parent: Option<u128>,
-    ) {
+    pub fn update_department(env: Env, caller: Address, dept_id: u128, new_parent: Option<u128>) {
         caller.require_auth();
         Self::require_initialized(&env);
 
@@ -546,7 +544,10 @@ impl DepartmentManagerContract {
                 .expect("Parent department not found");
             assert!(parent.org_id == dept.org_id, "Parent must be in same org");
             // child depth = parent depth + 1; must not exceed MAX_DEPTH
-            assert!(Self::dept_depth(&env, pid) + 1 <= MAX_DEPTH, "Max hierarchy depth exceeded");
+            assert!(
+                Self::dept_depth(&env, pid) + 1 <= MAX_DEPTH,
+                "Max hierarchy depth exceeded"
+            );
             assert!(!Self::has_cycle(&env, dept_id, pid), "Cycle detected");
         }
 

--- a/onchain/contracts/department_manager/tests/test_department.rs
+++ b/onchain/contracts/department_manager/tests/test_department.rs
@@ -458,7 +458,10 @@ fn test_remove_one_leaves_others() {
     let remaining = client.get_department_employees(&dept_id);
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining.get(0), Some(emp2.clone()));
-    assert_eq!(client.get_employee_department(&emp2, &org_id), Some(dept_id));
+    assert_eq!(
+        client.get_employee_department(&emp2, &org_id),
+        Some(dept_id)
+    );
 }
 
 #[test]
@@ -804,10 +807,15 @@ fn prop_all_cycle_attempts_rejected() {
 
         // Map original IDs to new IDs
         let map_id = |id: u128| -> u128 {
-            if id == root { r }
-            else if id == n1 { x1 }
-            else if id == n2 { x2 }
-            else { x3 }
+            if id == root {
+                r
+            } else if id == n1 {
+                x1
+            } else if id == n2 {
+                x2
+            } else {
+                x3
+            }
         };
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/onchain/contracts/dispute_escalation/src/lib.rs
+++ b/onchain/contracts/dispute_escalation/src/lib.rs
@@ -372,7 +372,9 @@ impl DisputeEscalationContract {
 
         // Open a bounded admin-review window.
         let review_limit = storage::get_pending_review_time_limit(&env);
-        let review_deadline = now.checked_add(review_limit).ok_or(DisputeError::SlaDeadlineOverflow)?;
+        let review_deadline = now
+            .checked_add(review_limit)
+            .ok_or(DisputeError::SlaDeadlineOverflow)?;
 
         // `phase_started_at` records exactly when the SLA breach was observed.
         dispute.status = DisputeStatus::PendingReview;

--- a/onchain/contracts/dispute_escalation/tests/test_escalation.rs
+++ b/onchain/contracts/dispute_escalation/tests/test_escalation.rs
@@ -1359,7 +1359,6 @@ fn test_cannot_escalate_from_resolved_state() {
     assert_eq!(res, Err(Ok(DisputeError::AlreadyResolved)));
 }
 
-
 #[test]
 fn test_keeper_advance_stage_overflow_returns_distinct_error() {
     // When pending_review_time_limit is set to u64::MAX, now + limit overflows

--- a/onchain/contracts/employee_roles/tests/test_roles.rs
+++ b/onchain/contracts/employee_roles/tests/test_roles.rs
@@ -20,8 +20,14 @@ fn setup() -> (Env, Address, EmployeeRolesContractClient<'static>) {
 }
 
 /// Setup with owner, and employees holding Employee, Manager, and Admin roles.
-fn setup_with_roles(
-) -> (Env, Address, Address, Address, Address, EmployeeRolesContractClient<'static>) {
+fn setup_with_roles() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    EmployeeRolesContractClient<'static>,
+) {
     let (env, owner, client) = setup();
     let emp = Address::generate(&env);
     let mgr = Address::generate(&env);
@@ -146,7 +152,10 @@ fn test_employee_cannot_self_grant_admin() {
     client.assign_role(&owner, &emp, &BuiltInRole::Employee);
 
     let result = client.try_assign_role(&emp, &emp, &BuiltInRole::Admin);
-    assert!(result.is_err(), "Employee must not be able to self-grant Admin");
+    assert!(
+        result.is_err(),
+        "Employee must not be able to self-grant Admin"
+    );
 }
 
 #[test]
@@ -188,13 +197,9 @@ const ADMIN_ACTIONS: &[PayrollAction] = &[
 fn test_matrix_owner_can_perform_all_actions() {
     let (_env, owner, client) = setup();
 
-    for action in [
-        EMPLOYEE_ACTIONS,
-        MANAGER_ACTIONS,
-        ADMIN_ACTIONS,
-    ]
-    .into_iter()
-    .flatten()
+    for action in [EMPLOYEE_ACTIONS, MANAGER_ACTIONS, ADMIN_ACTIONS]
+        .into_iter()
+        .flatten()
     {
         assert!(
             client.can_perform(&owner, action),
@@ -321,7 +326,10 @@ fn test_require_capability_denies_employee_manager_action() {
     let (_env, _owner, emp, _mgr, _adm, client) = setup_with_roles();
 
     let result = client.try_require_capability(&emp, &PayrollAction::CreatePayrollRecord);
-    assert!(result.is_err(), "Employee must not have CreatePayrollRecord capability");
+    assert!(
+        result.is_err(),
+        "Employee must not have CreatePayrollRecord capability"
+    );
 }
 
 #[test]
@@ -329,7 +337,10 @@ fn test_require_capability_denies_employee_admin_action() {
     let (_env, _owner, emp, _mgr, _adm, client) = setup_with_roles();
 
     let result = client.try_require_capability(&emp, &PayrollAction::AssignRoles);
-    assert!(result.is_err(), "Employee must not have AssignRoles capability");
+    assert!(
+        result.is_err(),
+        "Employee must not have AssignRoles capability"
+    );
 }
 
 #[test]
@@ -345,7 +356,10 @@ fn test_require_capability_denies_manager_admin_action() {
     let (_env, _owner, _emp, mgr, _adm, client) = setup_with_roles();
 
     let result = client.try_require_capability(&mgr, &PayrollAction::EmergencyPause);
-    assert!(result.is_err(), "Manager must not have EmergencyPause capability");
+    assert!(
+        result.is_err(),
+        "Manager must not have EmergencyPause capability"
+    );
 }
 
 #[test]

--- a/onchain/contracts/expense_reimbursement/src/lib.rs
+++ b/onchain/contracts/expense_reimbursement/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, xdr::ToXdr, Address, Bytes, BytesN, Env,
-    IntoVal, String, Symbol, Val, Vec,
+    contract, contractimpl, contracttype, token, xdr::ToXdr, Address, Bytes, BytesN, Env, IntoVal,
+    String, Symbol, Val, Vec,
 };
 
 /// ExpenseReimbursementContract manages expense submissions with approval workflows
@@ -163,7 +163,8 @@ fn append_approval_audit_log(
     subject: &Address,
     approved_amount: i128,
 ) -> Option<u64> {
-    let maybe_audit_logger: Option<Address> = env.storage().persistent().get(&StorageKey::AuditLogger);
+    let maybe_audit_logger: Option<Address> =
+        env.storage().persistent().get(&StorageKey::AuditLogger);
     maybe_audit_logger.map(|audit_logger| {
         let mut args = Vec::<Val>::new(env);
         args.push_back(approver.clone().into_val(env));
@@ -171,11 +172,7 @@ fn append_approval_audit_log(
         args.push_back(Some(subject.clone()).into_val(env));
         args.push_back(Some(approved_amount).into_val(env));
 
-        env.invoke_contract::<u64>(
-            &audit_logger,
-            &Symbol::new(env, "append_log"),
-            args,
-        )
+        env.invoke_contract::<u64>(&audit_logger, &Symbol::new(env, "append_log"), args)
     })
 }
 
@@ -314,18 +311,24 @@ impl ExpenseReimbursementContract {
             .get(&StorageKey::Expense(expense_id))
             .expect("Expense not found");
 
-        assert!(expense.status == ExpenseStatus::Pending, "Expense not pending");
+        assert!(
+            expense.status == ExpenseStatus::Pending,
+            "Expense not pending"
+        );
 
         let token_client = token::Client::new(&env, &expense.token);
         token_client.transfer(&payer, &env.current_contract_address(), &amount);
 
         expense.escrow_amount += amount;
-        
+
         // Register the payer if none exists; else require same payer for refunds to be coherent
         if expense.payer.is_none() {
             expense.payer = Some(payer.clone());
         } else {
-            assert!(expense.payer.unwrap() == payer, "Only initial payer can add funds");
+            assert!(
+                expense.payer.unwrap() == payer,
+                "Only initial payer can add funds"
+            );
             expense.payer = Some(payer.clone());
         }
 
@@ -357,17 +360,19 @@ impl ExpenseReimbursementContract {
         assert!(expense.approver == approver, "Unauthorized approver");
         assert!(expense.status == ExpenseStatus::Pending, "Invalid status");
         assert!(approved_amount > 0, "Approved amount must be positive");
-        assert!(approved_amount <= expense.amount, "Cannot approve more than requested");
-        assert!(expense.escrow_amount >= approved_amount, "Insufficient escrowed funds");
+        assert!(
+            approved_amount <= expense.amount,
+            "Cannot approve more than requested"
+        );
+        assert!(
+            expense.escrow_amount >= approved_amount,
+            "Insufficient escrowed funds"
+        );
 
         expense.approved_amount = Some(approved_amount);
         expense.status = ExpenseStatus::Approved;
-        let audit_log_id = append_approval_audit_log(
-            &env,
-            &approver,
-            &expense.submitter,
-            approved_amount,
-        );
+        let audit_log_id =
+            append_approval_audit_log(&env, &approver, &expense.submitter, approved_amount);
         expense.audit_log_id = audit_log_id;
         env.storage()
             .persistent()
@@ -405,7 +410,11 @@ impl ExpenseReimbursementContract {
         if expense.escrow_amount > 0 {
             if let Some(payer) = expense.payer.clone() {
                 let token_client = token::Client::new(&env, &expense.token);
-                token_client.transfer(&env.current_contract_address(), &payer, &expense.escrow_amount);
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &payer,
+                    &expense.escrow_amount,
+                );
             }
         }
 
@@ -428,7 +437,7 @@ impl ExpenseReimbursementContract {
     /// Pay an approved expense to the employee. Any surplus escrow goes back to the payer.
     pub fn pay_expense(env: Env, expense_id: u128) {
         require_initialized(&env);
-        
+
         // Anyone can execute the token payout if it's approved
 
         let mut expense: Expense = env
@@ -451,9 +460,13 @@ impl ExpenseReimbursementContract {
             .set(&StorageKey::Expense(expense_id), &expense);
 
         let token_client = token::Client::new(&env, &expense.token);
-        
+
         // Payout to employee
-        token_client.transfer(&env.current_contract_address(), &expense.submitter, &amount_to_pay);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &expense.submitter,
+            &amount_to_pay,
+        );
 
         // Refund any unapproved surplus
         let surplus = escrow_before - amount_to_pay;
@@ -493,7 +506,11 @@ impl ExpenseReimbursementContract {
         if expense.escrow_amount > 0 {
             if let Some(payer) = expense.payer.clone() {
                 let token_client = token::Client::new(&env, &expense.token);
-                token_client.transfer(&env.current_contract_address(), &payer, &expense.escrow_amount);
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &payer,
+                    &expense.escrow_amount,
+                );
             }
         }
         expense.escrow_amount = 0;

--- a/onchain/contracts/expense_reimbursement/tests/test_expense.rs
+++ b/onchain/contracts/expense_reimbursement/tests/test_expense.rs
@@ -4,9 +4,7 @@ use expense_reimbursement::{
     ExpenseReimbursementContract, ExpenseReimbursementContractClient, ExpenseStatus,
 };
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, Env, String, Symbol,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -368,7 +366,7 @@ fn test_fund_expense() {
     let expense = client.get_expense(&expense_id).unwrap();
     assert_eq!(expense.escrow_amount, 500);
     assert_eq!(expense.payer, Some(payer.clone()));
-    
+
     // contract holds tokens
     assert_eq!(token_client.balance(&client.address), 500);
     assert_eq!(token_client.balance(&payer), 500);
@@ -590,7 +588,7 @@ fn test_reject_expense_refunds() {
 
     client.fund_expense(&payer, &expense_id, &500);
     assert_eq!(token_client.balance(&client.address), 500);
-    
+
     client.reject_expense(&approver, &expense_id);
 
     let expense = client.get_expense(&expense_id).unwrap();
@@ -635,7 +633,7 @@ fn test_pay_expense_full() {
 
     let expense = client.get_expense(&expense_id).unwrap();
     assert_eq!(expense.status, ExpenseStatus::Paid);
-    
+
     // Funds disbursed fully to submitter
     assert_eq!(token_client.balance(&submitter), 500);
     assert_eq!(token_client.balance(&payer), 500); // the remaining 500 out of initial 1_000

--- a/onchain/contracts/fee_collector/src/helpers.rs
+++ b/onchain/contracts/fee_collector/src/helpers.rs
@@ -89,10 +89,7 @@ pub(crate) fn compute_percentage_fee(gross_amount: i128, fee_bps: u32) -> i128 {
 }
 
 /// Computes a tiered fee based on the gross amount and a schedule of tiers.
-pub(crate) fn compute_tiered_fee(
-    gross_amount: i128,
-    schedule: soroban_sdk::Vec<FeeTier>,
-) -> i128 {
+pub(crate) fn compute_tiered_fee(gross_amount: i128, schedule: soroban_sdk::Vec<FeeTier>) -> i128 {
     if gross_amount == 0 || schedule.is_empty() {
         return 0;
     }

--- a/onchain/contracts/fee_collector/src/lib.rs
+++ b/onchain/contracts/fee_collector/src/lib.rs
@@ -156,10 +156,13 @@ impl FeeCollectorContract {
             .instance()
             .set(&StorageKey::TotalFeesCollected, &0i128);
         env.storage().instance().set(&StorageKey::Paused, &false);
-        env.storage().instance().set(&StorageKey::Initialized, &true);
         env.storage()
             .instance()
-            .set(&StorageKey::TieredSchedule, &soroban_sdk::Vec::<FeeTier>::new(&env));
+            .set(&StorageKey::Initialized, &true);
+        env.storage().instance().set(
+            &StorageKey::TieredSchedule,
+            &soroban_sdk::Vec::<FeeTier>::new(&env),
+        );
 
         // Establish initial TTL for the contract instance.
         bump_ttl(&env);

--- a/onchain/contracts/fee_collector/tests/test_fees.rs
+++ b/onchain/contracts/fee_collector/tests/test_fees.rs
@@ -937,7 +937,6 @@ fn test_payer_is_payment_recipient_still_pays_fee() {
     assert_eq!(tok.balance(&user), 990); // net returned to same address
 }
 
-
 // ─── calculate_fee no-auth verification ─────────────────────────────────
 
 #[test]

--- a/onchain/contracts/fee_collector/tests/test_tiered_fees.rs
+++ b/onchain/contracts/fee_collector/tests/test_tiered_fees.rs
@@ -14,17 +14,26 @@ fn test_tiered_fee_selection() {
 
     client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
 
-    // Setup schedule: 
+    // Setup schedule:
     // Tier 1: up to 1000 -> 500 bps (5%)
     // Tier 2: up to 5000 -> 250 bps (2.5%)
     // Tier 3: above 5000 -> 100 bps (1%)
     let mut schedule = Vec::new(&env);
-    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
-    schedule.push_back(FeeTier { limit: 5000, fee_bps: 250 });
-    schedule.push_back(FeeTier { limit: i128::MAX, fee_bps: 100 });
+    schedule.push_back(FeeTier {
+        limit: 1000,
+        fee_bps: 500,
+    });
+    schedule.push_back(FeeTier {
+        limit: 5000,
+        fee_bps: 250,
+    });
+    schedule.push_back(FeeTier {
+        limit: i128::MAX,
+        fee_bps: 100,
+    });
 
     client.update_tiered_schedule(&admin, &schedule);
-    
+
     // Switch to Tiered mode
     let config = client.get_config();
     client.update_fee_config(&admin, &config.fee_bps, &config.flat_fee, &FeeMode::Tiered);
@@ -94,7 +103,6 @@ fn test_update_tiered_schedule_unauthorized() {
     client.update_tiered_schedule(&attacker, &schedule);
 }
 
-
 #[test]
 #[should_panic(expected = "Tier limits must be strictly increasing and positive")]
 fn test_update_tiered_schedule_negative_limit_rejected() {
@@ -108,7 +116,10 @@ fn test_update_tiered_schedule_negative_limit_rejected() {
     client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
 
     let mut schedule = Vec::new(&env);
-    schedule.push_back(FeeTier { limit: -100, fee_bps: 500 });
+    schedule.push_back(FeeTier {
+        limit: -100,
+        fee_bps: 500,
+    });
 
     client.update_tiered_schedule(&admin, &schedule);
 }
@@ -126,7 +137,10 @@ fn test_update_tiered_schedule_zero_limit_rejected() {
     client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
 
     let mut schedule = Vec::new(&env);
-    schedule.push_back(FeeTier { limit: 0, fee_bps: 500 });
+    schedule.push_back(FeeTier {
+        limit: 0,
+        fee_bps: 500,
+    });
 
     client.update_tiered_schedule(&admin, &schedule);
 }
@@ -144,8 +158,14 @@ fn test_update_tiered_schedule_non_increasing_rejected() {
     client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
 
     let mut schedule = Vec::new(&env);
-    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
-    schedule.push_back(FeeTier { limit: 500, fee_bps: 250 }); // lower than previous
+    schedule.push_back(FeeTier {
+        limit: 1000,
+        fee_bps: 500,
+    });
+    schedule.push_back(FeeTier {
+        limit: 500,
+        fee_bps: 250,
+    }); // lower than previous
 
     client.update_tiered_schedule(&admin, &schedule);
 }
@@ -163,8 +183,14 @@ fn test_update_tiered_schedule_duplicate_limit_rejected() {
     client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
 
     let mut schedule = Vec::new(&env);
-    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
-    schedule.push_back(FeeTier { limit: 1000, fee_bps: 250 }); // same as previous
+    schedule.push_back(FeeTier {
+        limit: 1000,
+        fee_bps: 500,
+    });
+    schedule.push_back(FeeTier {
+        limit: 1000,
+        fee_bps: 250,
+    }); // same as previous
 
     client.update_tiered_schedule(&admin, &schedule);
 }
@@ -181,9 +207,18 @@ fn test_update_tiered_schedule_valid_limits_accepted() {
     client.initialize(&admin, &treasury, &0, &0, &FeeMode::Percentage);
 
     let mut schedule = Vec::new(&env);
-    schedule.push_back(FeeTier { limit: 1000, fee_bps: 500 });
-    schedule.push_back(FeeTier { limit: 5000, fee_bps: 250 });
-    schedule.push_back(FeeTier { limit: i128::MAX, fee_bps: 100 });
+    schedule.push_back(FeeTier {
+        limit: 1000,
+        fee_bps: 500,
+    });
+    schedule.push_back(FeeTier {
+        limit: 5000,
+        fee_bps: 250,
+    });
+    schedule.push_back(FeeTier {
+        limit: i128::MAX,
+        fee_bps: 100,
+    });
 
     client.update_tiered_schedule(&admin, &schedule);
 }

--- a/onchain/contracts/nft_payroll_badge/src/lib.rs
+++ b/onchain/contracts/nft_payroll_badge/src/lib.rs
@@ -374,7 +374,7 @@ impl NftPayrollBadge {
 
         let mut badge = read_badge(&env, badge_id)?;
         let current_time = env.ledger().timestamp();
-        
+
         if badge.expires_at != 0 && current_time >= badge.expires_at {
             return Err(BadgeError::BadgeExpired);
         }

--- a/onchain/contracts/nft_payroll_badge/tests/test_badge.rs
+++ b/onchain/contracts/nft_payroll_badge/tests/test_badge.rs
@@ -5,12 +5,14 @@ use soroban_sdk::{
     Address, Bytes, Env,
 };
 
-use nft_payroll_badge::{Badge, BadgeError, BadgeKind, BadgeState, NftPayrollBadge, NftPayrollBadgeClient};
+use nft_payroll_badge::{
+    Badge, BadgeError, BadgeKind, BadgeState, NftPayrollBadge, NftPayrollBadgeClient,
+};
 
 fn create_env() -> Env {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     // Set a non-zero timestamp. In Soroban tests, the default timestamp is 0.
     // Because our contract treats `expires_at == 0` as "never expires",
     // calling `expire()` when the ledger time is 0 creates a logical conflict.
@@ -275,7 +277,7 @@ fn metadata_update_and_freeze() {
     // Try update again -> error
     let res = client.try_update_metadata(&admin, &badge_id, &bytes_from_str(&env, "meta3"));
     assert_eq!(res, Err(Ok(BadgeError::MetadataFrozen)));
-    
+
     // Try freeze again -> error
     let res2 = client.try_freeze_metadata(&admin, &badge_id);
     assert_eq!(res2, Err(Ok(BadgeError::MetadataFrozen)));
@@ -327,11 +329,11 @@ fn explicit_expiry() {
     // Expire
     client.expire(&admin, &badge_id);
     assert_eq!(client.get_state(&badge_id), BadgeState::Expired);
-    
+
     // Repeated expire -> error
     let res = client.try_expire(&admin, &badge_id);
     assert_eq!(res, Err(Ok(BadgeError::BadgeExpired)));
-    
+
     // Transfer expired -> error
     let res_transfer = client.try_transfer(&employee, &badge_id, &admin);
     assert_eq!(res_transfer, Err(Ok(BadgeError::BadgeExpired)));
@@ -378,13 +380,13 @@ fn non_admin_update_revoke_fails() {
     // Employer is not admin, should fail to update/revoke/expire
     let res1 = client.try_update_metadata(&employer, &badge_id, &bytes_from_str(&env, "new"));
     assert!(res1.is_err());
-    
+
     let res2 = client.try_revoke(&employer, &badge_id);
     assert!(res2.is_err());
-    
+
     let res3 = client.try_expire(&employer, &badge_id);
     assert!(res3.is_err());
-    
+
     let res4 = client.try_freeze_metadata(&employer, &badge_id);
     assert!(res4.is_err());
 }

--- a/onchain/contracts/payment_history/src/lib.rs
+++ b/onchain/contracts/payment_history/src/lib.rs
@@ -293,11 +293,7 @@ impl PaymentHistoryContract {
             .storage()
             .persistent()
             .get(&StorageKey::PaymentByHash(payment_hash));
-        global_id.and_then(|id| {
-            env.storage()
-                .persistent()
-                .get(&StorageKey::Payment(id))
-        })
+        global_id.and_then(|id| env.storage().persistent().get(&StorageKey::Payment(id)))
     }
 
     /// Fetch a single payment record by its global ID.
@@ -366,7 +362,9 @@ impl PaymentHistoryContract {
         }
 
         let effective_limit = limit.min(MAX_PAGE_SIZE);
-        let end = start_index.saturating_add(effective_limit).min(count.saturating_add(1));
+        let end = start_index
+            .saturating_add(effective_limit)
+            .min(count.saturating_add(1));
 
         for i in start_index..end {
             let global_id: u128 = env
@@ -422,7 +420,9 @@ impl PaymentHistoryContract {
         }
 
         let effective_limit = limit.min(MAX_PAGE_SIZE);
-        let end = start_index.saturating_add(effective_limit).min(count.saturating_add(1));
+        let end = start_index
+            .saturating_add(effective_limit)
+            .min(count.saturating_add(1));
 
         for i in start_index..end {
             let global_id: u128 = env
@@ -478,7 +478,9 @@ impl PaymentHistoryContract {
         }
 
         let effective_limit = limit.min(MAX_PAGE_SIZE);
-        let end = start_index.saturating_add(effective_limit).min(count.saturating_add(1));
+        let end = start_index
+            .saturating_add(effective_limit)
+            .min(count.saturating_add(1));
 
         for i in start_index..end {
             let global_id: u128 = env

--- a/onchain/contracts/payment_history/src/storage.rs
+++ b/onchain/contracts/payment_history/src/storage.rs
@@ -93,7 +93,6 @@ pub enum StorageKey {
     PaymentByHash(BytesN<32>),
 
     // ── Agreement index ────────────────────────────────────────────────────
-
     /// Total number of payments recorded for this agreement.
     /// Doubles as the 1-based position of the most recently appended entry.
     AgreementPaymentCount(u128), // key: agreement_id
@@ -104,7 +103,6 @@ pub enum StorageKey {
     AgreementPayment(u128, u32), // key: (agreement_id, 1-based position)
 
     // ── Employer (from) index ──────────────────────────────────────────────
-
     /// Total number of payments originating from this employer address.
     EmployerPaymentCount(Address), // key: employer
 
@@ -114,7 +112,6 @@ pub enum StorageKey {
     EmployerPayment(Address, u32), // key: (employer, 1-based position)
 
     // ── Employee (to) index ────────────────────────────────────────────────
-
     /// Total number of payments received by this employee address.
     EmployeePaymentCount(Address), // key: employee
 

--- a/onchain/contracts/payment_history/tests/test_history.rs
+++ b/onchain/contracts/payment_history/tests/test_history.rs
@@ -190,9 +190,15 @@ fn test_record_payment_returns_sequential_ids() {
     let employer = Address::generate(&env);
     let employee = Address::generate(&env);
 
-    let id1 = record(&client, &env, 1, 1, &token, 100, &employer, &employee, 1_000);
-    let id2 = record(&client, &env, 1, 2, &token, 200, &employer, &employee, 2_000);
-    let id3 = record(&client, &env, 2, 3, &token, 300, &employer, &employee, 3_000);
+    let id1 = record(
+        &client, &env, 1, 1, &token, 100, &employer, &employee, 1_000,
+    );
+    let id2 = record(
+        &client, &env, 1, 2, &token, 200, &employer, &employee, 2_000,
+    );
+    let id3 = record(
+        &client, &env, 2, 3, &token, 300, &employer, &employee, 3_000,
+    );
 
     assert_eq!(id1, 1u128);
     assert_eq!(id2, 2u128);
@@ -213,8 +219,15 @@ fn test_record_payment_persists_all_fields() {
     let timestamp = 1_700_000_000u64;
     let hash = make_hash(&env, 0xAB);
 
-    let payment_id =
-        client.record_payment(&agreement_id, &hash, &token, &amount, &employer, &employee, &timestamp);
+    let payment_id = client.record_payment(
+        &agreement_id,
+        &hash,
+        &token,
+        &amount,
+        &employer,
+        &employee,
+        &timestamp,
+    );
 
     let rec = client
         .get_payment_by_id(&payment_id)
@@ -278,7 +291,9 @@ fn test_record_payment_updates_all_three_sequential_indices() {
     let employer = Address::generate(&env);
     let employee = Address::generate(&env);
 
-    record(&client, &env, 7, 1, &token, 100, &employer, &employee, 1_000);
+    record(
+        &client, &env, 7, 1, &token, 100, &employer, &employee, 1_000,
+    );
 
     assert_eq!(client.get_agreement_payment_count(&7u128), 1u32);
     assert_eq!(client.get_employer_payment_count(&employer), 1u32);
@@ -324,7 +339,9 @@ fn test_record_payment_duplicate_hash_is_idempotent() {
     assert_eq!(client.get_employer_payment_count(&employer), 1u32);
     assert_eq!(client.get_employee_payment_count(&employee), 1u32);
 
-    let by_hash = client.get_payment_by_hash(&hash).expect("record must exist");
+    let by_hash = client
+        .get_payment_by_hash(&hash)
+        .expect("record must exist");
     assert_eq!(by_hash.id, id1);
     assert_eq!(by_hash.amount, 1_000i128);
 
@@ -366,7 +383,10 @@ fn test_get_payment_by_hash_returns_correct_record() {
 
     let pid = client.record_payment(&5u128, &hash, &token, &777i128, &from, &to, &55_000u64);
     let rec = client.get_payment_by_hash(&hash);
-    assert!(rec.is_some(), "hash lookup must return Some for recorded payment");
+    assert!(
+        rec.is_some(),
+        "hash lookup must return Some for recorded payment"
+    );
     let rec = rec.unwrap();
     assert_eq!(rec.id, pid);
     assert_eq!(rec.payment_hash, hash);
@@ -402,7 +422,9 @@ fn test_hash_index_written_atomically() {
     let pid = client.record_payment(&1u128, &hash, &token, &100i128, &from, &to, &0u64);
 
     let by_id = client.get_payment_by_id(&pid).expect("must exist by ID");
-    let by_hash = client.get_payment_by_hash(&hash).expect("must exist by hash");
+    let by_hash = client
+        .get_payment_by_hash(&hash)
+        .expect("must exist by hash");
     assert_eq!(by_id, by_hash, "record by-id and by-hash must be identical");
 }
 
@@ -462,7 +484,10 @@ fn test_get_payment_by_id_zero_returns_none() {
     let (_id, client) = register_contract(&env);
     initialize_contract(&env, &client);
 
-    assert!(client.get_payment_by_id(&0u128).is_none(), "ID 0 is never assigned");
+    assert!(
+        client.get_payment_by_id(&0u128).is_none(),
+        "ID 0 is never assigned"
+    );
 }
 
 // ─── get_global_payment_count ─────────────────────────────────────────────────
@@ -486,7 +511,17 @@ fn test_global_count_tracks_all_agreements() {
     let to = Address::generate(&env);
 
     for i in 0..5u8 {
-        record(&client, &env, i as u128, i, &token, 10, &from, &to, i as u64 * 100);
+        record(
+            &client,
+            &env,
+            i as u128,
+            i,
+            &token,
+            10,
+            &from,
+            &to,
+            i as u64 * 100,
+        );
     }
     assert_eq!(client.get_global_payment_count(), 5u128);
 }
@@ -558,7 +593,17 @@ fn test_get_payments_by_agreement_full_pagination() {
     let agreement_id = 1u128;
 
     for i in 0..5u8 {
-        record(&client, &env, agreement_id, i, &token, i as i128 * 100, &from, &to, i as u64);
+        record(
+            &client,
+            &env,
+            agreement_id,
+            i,
+            &token,
+            i as i128 * 100,
+            &from,
+            &to,
+            i as u64,
+        );
     }
 
     let page1 = client.get_payments_by_agreement(&agreement_id, &1u32, &2u32);
@@ -588,7 +633,9 @@ fn test_get_payments_by_agreement_start_index_zero_returns_empty() {
     record(&client, &env, 1, 1, &token, 100, &from, &to, 0);
 
     assert_eq!(
-        client.get_payments_by_agreement(&1u128, &0u32, &10u32).len(),
+        client
+            .get_payments_by_agreement(&1u128, &0u32, &10u32)
+            .len(),
         0u32
     );
 }
@@ -605,7 +652,9 @@ fn test_get_payments_by_agreement_start_index_above_count_returns_empty() {
     record(&client, &env, 1, 1, &token, 100, &from, &to, 0);
 
     assert_eq!(
-        client.get_payments_by_agreement(&1u128, &2u32, &10u32).len(),
+        client
+            .get_payments_by_agreement(&1u128, &2u32, &10u32)
+            .len(),
         0u32
     );
 }
@@ -617,7 +666,9 @@ fn test_get_payments_by_agreement_empty_history_returns_empty() {
     initialize_contract(&env, &client);
 
     assert_eq!(
-        client.get_payments_by_agreement(&1u128, &1u32, &10u32).len(),
+        client
+            .get_payments_by_agreement(&1u128, &1u32, &10u32)
+            .len(),
         0u32
     );
 }
@@ -635,11 +686,25 @@ fn test_get_payments_by_agreement_limit_capped_at_max_page_size() {
     let total = MAX_PAGE_SIZE + 10;
 
     for i in 0..total as u8 {
-        record(&client, &env, agreement_id, i, &token, i as i128, &from, &to, i as u64);
+        record(
+            &client,
+            &env,
+            agreement_id,
+            i,
+            &token,
+            i as i128,
+            &from,
+            &to,
+            i as u64,
+        );
     }
 
     let page = client.get_payments_by_agreement(&agreement_id, &1u32, &(MAX_PAGE_SIZE + 50));
-    assert_eq!(page.len(), MAX_PAGE_SIZE, "limit must be capped at MAX_PAGE_SIZE");
+    assert_eq!(
+        page.len(),
+        MAX_PAGE_SIZE,
+        "limit must be capped at MAX_PAGE_SIZE"
+    );
 }
 
 #[test]
@@ -654,7 +719,17 @@ fn test_get_payments_by_agreement_exact_boundary_read() {
     let agreement_id = 1u128;
 
     for i in 0..3u8 {
-        record(&client, &env, agreement_id, i, &token, i as i128, &from, &to, i as u64);
+        record(
+            &client,
+            &env,
+            agreement_id,
+            i,
+            &token,
+            i as i128,
+            &from,
+            &to,
+            i as u64,
+        );
     }
 
     // start_index=3 (the last valid position), limit=10 must return exactly 1 record.
@@ -712,7 +787,17 @@ fn test_get_payments_by_employer_pagination() {
     let employee = Address::generate(&env);
 
     for i in 0..5u8 {
-        record(&client, &env, 1, i, &token, i as i128 * 10, &employer, &employee, i as u64);
+        record(
+            &client,
+            &env,
+            1,
+            i,
+            &token,
+            i as i128 * 10,
+            &employer,
+            &employee,
+            i as u64,
+        );
     }
 
     let page1 = client.get_payments_by_employer(&employer, &1u32, &2u32);
@@ -736,7 +821,10 @@ fn test_get_payments_by_employer_start_index_zero_returns_empty() {
     let to = Address::generate(&env);
     record(&client, &env, 1, 1, &token, 1, &from, &to, 0);
 
-    assert_eq!(client.get_payments_by_employer(&from, &0u32, &10u32).len(), 0u32);
+    assert_eq!(
+        client.get_payments_by_employer(&from, &0u32, &10u32).len(),
+        0u32
+    );
 }
 
 #[test]
@@ -750,7 +838,10 @@ fn test_get_payments_by_employer_start_index_above_count_returns_empty() {
     let to = Address::generate(&env);
     record(&client, &env, 1, 1, &token, 1, &from, &to, 0);
 
-    assert_eq!(client.get_payments_by_employer(&from, &2u32, &10u32).len(), 0u32);
+    assert_eq!(
+        client.get_payments_by_employer(&from, &2u32, &10u32).len(),
+        0u32
+    );
 }
 
 #[test]
@@ -760,7 +851,12 @@ fn test_get_payments_by_employer_empty_history_returns_empty() {
     initialize_contract(&env, &client);
 
     let employer = Address::generate(&env);
-    assert_eq!(client.get_payments_by_employer(&employer, &1u32, &10u32).len(), 0u32);
+    assert_eq!(
+        client
+            .get_payments_by_employer(&employer, &1u32, &10u32)
+            .len(),
+        0u32
+    );
 }
 
 // ─── Employee index ───────────────────────────────────────────────────────────
@@ -812,7 +908,17 @@ fn test_get_payments_by_employee_pagination() {
     let employee = Address::generate(&env);
 
     for i in 0..5u8 {
-        record(&client, &env, 1, i, &token, i as i128 * 10, &employer, &employee, i as u64);
+        record(
+            &client,
+            &env,
+            1,
+            i,
+            &token,
+            i as i128 * 10,
+            &employer,
+            &employee,
+            i as u64,
+        );
     }
 
     let page1 = client.get_payments_by_employee(&employee, &1u32, &3u32);
@@ -833,7 +939,10 @@ fn test_get_payments_by_employee_start_index_zero_returns_empty() {
     let to = Address::generate(&env);
     record(&client, &env, 1, 1, &token, 1, &from, &to, 0);
 
-    assert_eq!(client.get_payments_by_employee(&to, &0u32, &10u32).len(), 0u32);
+    assert_eq!(
+        client.get_payments_by_employee(&to, &0u32, &10u32).len(),
+        0u32
+    );
 }
 
 #[test]
@@ -847,7 +956,10 @@ fn test_get_payments_by_employee_start_index_above_count_returns_empty() {
     let to = Address::generate(&env);
     record(&client, &env, 1, 1, &token, 1, &from, &to, 0);
 
-    assert_eq!(client.get_payments_by_employee(&to, &2u32, &10u32).len(), 0u32);
+    assert_eq!(
+        client.get_payments_by_employee(&to, &2u32, &10u32).len(),
+        0u32
+    );
 }
 
 #[test]
@@ -857,7 +969,12 @@ fn test_get_payments_by_employee_empty_history_returns_empty() {
     initialize_contract(&env, &client);
 
     let employee = Address::generate(&env);
-    assert_eq!(client.get_payments_by_employee(&employee, &1u32, &10u32).len(), 0u32);
+    assert_eq!(
+        client
+            .get_payments_by_employee(&employee, &1u32, &10u32)
+            .len(),
+        0u32
+    );
 }
 
 // ─── Cross-index consistency ──────────────────────────────────────────────────
@@ -877,18 +994,38 @@ fn test_same_payment_visible_in_all_five_query_paths() {
     let amount = 1_234i128;
     let hash = make_hash(&env, 0x55);
 
-    let payment_id =
-        client.record_payment(&agreement_id, &hash, &token, &amount, &employer, &employee, &9_999u64);
+    let payment_id = client.record_payment(
+        &agreement_id,
+        &hash,
+        &token,
+        &amount,
+        &employer,
+        &employee,
+        &9_999u64,
+    );
 
-    let by_hash = client.get_payment_by_hash(&hash).expect("must exist by hash");
-    let by_id   = client.get_payment_by_id(&payment_id).expect("must exist by id");
-    let by_agg  = client.get_payments_by_agreement(&agreement_id, &1u32, &1u32).get(0).unwrap();
-    let by_empr = client.get_payments_by_employer(&employer, &1u32, &1u32).get(0).unwrap();
-    let by_empe = client.get_payments_by_employee(&employee, &1u32, &1u32).get(0).unwrap();
+    let by_hash = client
+        .get_payment_by_hash(&hash)
+        .expect("must exist by hash");
+    let by_id = client
+        .get_payment_by_id(&payment_id)
+        .expect("must exist by id");
+    let by_agg = client
+        .get_payments_by_agreement(&agreement_id, &1u32, &1u32)
+        .get(0)
+        .unwrap();
+    let by_empr = client
+        .get_payments_by_employer(&employer, &1u32, &1u32)
+        .get(0)
+        .unwrap();
+    let by_empe = client
+        .get_payments_by_employee(&employee, &1u32, &1u32)
+        .get(0)
+        .unwrap();
 
     assert_eq!(by_hash, by_id);
-    assert_eq!(by_id,   by_agg);
-    assert_eq!(by_agg,  by_empr);
+    assert_eq!(by_id, by_agg);
+    assert_eq!(by_agg, by_empr);
     assert_eq!(by_empr, by_empe);
     assert_eq!(by_id.payment_hash, hash);
     assert_eq!(by_id.amount, amount);
@@ -941,7 +1078,17 @@ fn test_index_counts_only_increase() {
     let agreement_id = 1u128;
 
     for i in 0..5u8 {
-        record(&client, &env, agreement_id, i, &token, i as i128, &from, &to, i as u64);
+        record(
+            &client,
+            &env,
+            agreement_id,
+            i,
+            &token,
+            i as i128,
+            &from,
+            &to,
+            i as u64,
+        );
         assert_eq!(
             client.get_agreement_payment_count(&agreement_id),
             (i + 1) as u32,
@@ -966,7 +1113,17 @@ fn test_large_history_boundary_reads() {
     let total: u32 = 20;
 
     for i in 0..total as u8 {
-        record(&client, &env, agreement_id, i, &token, i as i128, &from, &to, i as u64);
+        record(
+            &client,
+            &env,
+            agreement_id,
+            i,
+            &token,
+            i as i128,
+            &from,
+            &to,
+            i as u64,
+        );
     }
 
     assert_eq!(client.get_agreement_payment_count(&agreement_id), total);
@@ -1000,7 +1157,17 @@ fn test_multiple_agreements_large_history_independent() {
         record(&client, &env, 1, i, &token, i as i128, &from, &to, i as u64);
     }
     for i in 10..15u8 {
-        record(&client, &env, 2, i, &token, i as i128 * 10, &from, &to, (100 + i) as u64);
+        record(
+            &client,
+            &env,
+            2,
+            i,
+            &token,
+            i as i128 * 10,
+            &from,
+            &to,
+            (100 + i) as u64,
+        );
     }
 
     assert_eq!(client.get_agreement_payment_count(&1u128), 10u32);
@@ -1076,8 +1243,14 @@ fn test_event_based_reconciliation_across_payment_sources() {
     ];
 
     for (idx, fixture) in fixtures.iter().enumerate() {
-        assert!(!fixture.source.topic().is_empty(), "source topic must be defined");
-        assert!(fixture.source_event_id > 0, "source event id must be non-zero");
+        assert!(
+            !fixture.source.topic().is_empty(),
+            "source topic must be defined"
+        );
+        assert!(
+            fixture.source_event_id > 0,
+            "source event id must be non-zero"
+        );
 
         let id = reconcile_fixture(&client, &env, fixture);
         assert_eq!(id, (idx as u128) + 1);

--- a/onchain/contracts/payment_retry/src/lib.rs
+++ b/onchain/contracts/payment_retry/src/lib.rs
@@ -384,7 +384,11 @@ impl PaymentRetryContract {
     ) {
         require_initialized(&env);
         // Permissionless entry point, but we check if already exists
-        if env.storage().persistent().has(&StorageKey::Payment(payment_id.clone())) {
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKey::Payment(payment_id.clone()))
+        {
             return;
         }
 

--- a/onchain/contracts/payment_retry/tests/test_retry.rs
+++ b/onchain/contracts/payment_retry/tests/test_retry.rs
@@ -612,26 +612,17 @@ fn test_backoff_uses_last_interval_when_retry_count_exceeds_list() {
 
     // Retry 1: next_retry_at = 0 + 7 = 7
     client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        7
-    );
+    assert_eq!(client.get_payment(&payment_id).unwrap().next_retry_at, 7);
 
     // Retry 2: next_retry_at = 7 + 7 = 14
     env.ledger().with_mut(|li| li.timestamp = 7);
     client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        14
-    );
+    assert_eq!(client.get_payment(&payment_id).unwrap().next_retry_at, 14);
 
     // Retry 3: next_retry_at = 14 + 7 = 21
     env.ledger().with_mut(|li| li.timestamp = 14);
     client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        21
-    );
+    assert_eq!(client.get_payment(&payment_id).unwrap().next_retry_at, 21);
 }
 
 #[test]
@@ -662,10 +653,7 @@ fn test_backoff_uses_stepped_intervals() {
 
     // Retry 1 → interval[0] = 10
     client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        10
-    );
+    assert_eq!(client.get_payment(&payment_id).unwrap().next_retry_at, 10);
 
     // Retry 2 → interval[1] = 30
     env.ledger().with_mut(|li| li.timestamp = 10);

--- a/onchain/contracts/payment_splitter/src/lib.rs
+++ b/onchain/contracts/payment_splitter/src/lib.rs
@@ -97,10 +97,13 @@ impl PaymentSplitterContract {
 
         for i in 0..recipients.len() {
             let r = recipients.get_unchecked(i);
-            
+
             // 1. Uniqueness check
             for seen in 0..seen_addresses.len() {
-                assert!(seen_addresses.get_unchecked(seen) != r.recipient, "Duplicate recipient address");
+                assert!(
+                    seen_addresses.get_unchecked(seen) != r.recipient,
+                    "Duplicate recipient address"
+                );
             }
             seen_addresses.push_back(r.recipient.clone());
 
@@ -118,11 +121,17 @@ impl PaymentSplitterContract {
         }
 
         // 2. Mutual exclusivity check (Percent vs Fixed)
-        assert!(has_percent != has_fixed, "Split must be either all Percentage or all Fixed");
+        assert!(
+            has_percent != has_fixed,
+            "Split must be either all Percentage or all Fixed"
+        );
 
         // 3. Percentage sum validation
         if has_percent {
-            assert!(total_bps == 10000, "Percentage shares must sum to 10000 (100%)");
+            assert!(
+                total_bps == 10000,
+                "Percentage shares must sum to 10000 (100%)"
+            );
         }
 
         let next_id: u128 = env
@@ -233,7 +242,7 @@ impl PaymentSplitterContract {
                 .expect("Dust underflow");
             assert!(dust >= 0, "Negative dust detected");
 
-            // Mathematical bound: dust = sum(remainders) / 10000. 
+            // Mathematical bound: dust = sum(remainders) / 10000.
             // Since each remainder < 10000, sum(remainders) < 10000 * recipient_count.
             // Therefore, dust < recipient_count.
             assert!(
@@ -247,7 +256,12 @@ impl PaymentSplitterContract {
                 if (i as i128) >= dust {
                     break;
                 }
-                let best = Self::select_next_dust_recipient(&env, &def.recipients, &remainders, &awarded_dust);
+                let best = Self::select_next_dust_recipient(
+                    &env,
+                    &def.recipients,
+                    &remainders,
+                    &awarded_dust,
+                );
                 awarded_dust.push_back(best);
             }
 
@@ -311,7 +325,11 @@ impl PaymentSplitterContract {
             }
 
             if remainder == best_remainder
-                && Self::compare_addresses(env, &recipients.get_unchecked(i).recipient, &recipients.get_unchecked(best_index).recipient) < 0
+                && Self::compare_addresses(
+                    env,
+                    &recipients.get_unchecked(i).recipient,
+                    &recipients.get_unchecked(best_index).recipient,
+                ) < 0
             {
                 best_index = i;
             }

--- a/onchain/contracts/payment_splitter/tests/test_splitter.rs
+++ b/onchain/contracts/payment_splitter/tests/test_splitter.rs
@@ -56,7 +56,7 @@ fn test_create_split_percent_success() {
     let creator = Address::generate(&env);
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
     recipients.push_back(RecipientShare {
         recipient: a.clone(),
@@ -66,7 +66,7 @@ fn test_create_split_percent_success() {
         recipient: b.clone(),
         kind: ShareKind::Percent(4000),
     });
-    
+
     let id = client.create_split(&creator, &recipients);
     let def = client.get_split(&id);
     assert_eq!(def.recipients.len(), 2);
@@ -80,7 +80,7 @@ fn test_create_split_duplicate_recipient() {
     let (_, client) = setup(&env);
     let creator = Address::generate(&env);
     let a = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
     recipients.push_back(RecipientShare {
         recipient: a.clone(),
@@ -101,7 +101,7 @@ fn test_create_split_zero_percent() {
     let creator = Address::generate(&env);
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
     recipients.push_back(RecipientShare {
         recipient: a,
@@ -122,7 +122,7 @@ fn test_create_split_mixed_modes() {
     let creator = Address::generate(&env);
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
     recipients.push_back(RecipientShare {
         recipient: a,
@@ -140,29 +140,38 @@ fn test_compute_split_rounding_dust() {
     let env = create_env();
     let (_, client) = setup(&env);
     let creator = Address::generate(&env);
-    
+
     let a = Address::generate(&env);
     let b = Address::generate(&env);
     let c = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
     // 3333 + 3333 + 3334 = 10000
-    recipients.push_back(RecipientShare { recipient: a.clone(), kind: ShareKind::Percent(3333) });
-    recipients.push_back(RecipientShare { recipient: b.clone(), kind: ShareKind::Percent(3333) });
-    recipients.push_back(RecipientShare { recipient: c.clone(), kind: ShareKind::Percent(3334) });
-    
+    recipients.push_back(RecipientShare {
+        recipient: a.clone(),
+        kind: ShareKind::Percent(3333),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b.clone(),
+        kind: ShareKind::Percent(3333),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: c.clone(),
+        kind: ShareKind::Percent(3334),
+    });
+
     let id = client.create_split(&creator, &recipients);
-    
+
     // Total = 100
     // A: (3333 * 100) / 10000 = 33
     // B: (3333 * 100) / 10000 = 33
     // C: 100 - (33 + 33) = 34
     let out = client.compute_split(&id, &100);
-    
+
     assert_eq!(out.get(0).unwrap().1, 33);
     assert_eq!(out.get(1).unwrap().1, 33);
     assert_eq!(out.get(2).unwrap().1, 34);
-    
+
     let total_comp: i128 = out.iter().map(|x| x.1).sum();
     assert_eq!(total_comp, 100);
 }
@@ -172,16 +181,22 @@ fn test_compute_split_prime_number() {
     let env = create_env();
     let (_, client) = setup(&env);
     let creator = Address::generate(&env);
-    
+
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(6000) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(4000) });
-    
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Percent(6000),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Percent(4000),
+    });
+
     let id = client.create_split(&creator, &recipients);
-    
+
     // Total = 107 (prime)
     // A: (6000 * 107) / 10000 = 64.2 -> 64
     // B: 107 - 64 = 43
@@ -196,14 +211,20 @@ fn test_compute_split_one_stroop() {
     let env = create_env();
     let (_, client) = setup(&env);
     let creator = Address::generate(&env);
-    
+
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(5000) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(5000) });
-    
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Percent(5000),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Percent(5000),
+    });
+
     let id = client.create_split(&creator, &recipients);
     let out = client.compute_split(&id, &1);
 
@@ -228,16 +249,22 @@ fn test_fixed_split_validation() {
     let creator = Address::generate(&env);
     let a = Address::generate(&env);
     let b = Address::generate(&env);
-    
+
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Fixed(300) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Fixed(700) });
-    
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Fixed(300),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Fixed(700),
+    });
+
     let id = client.create_split(&creator, &recipients);
-    
+
     assert!(client.validate_split_for_amount(&id, &1000));
     assert!(!client.validate_split_for_amount(&id, &999));
-    
+
     let out = client.compute_split(&id, &1000);
     assert_eq!(out.get(0).unwrap().1, 300);
     assert_eq!(out.get(1).unwrap().1, 700);
@@ -253,8 +280,14 @@ fn test_compute_split_zero_amount_rejected() {
     let b = Address::generate(&env);
 
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(5000) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(5000) });
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Percent(5000),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Percent(5000),
+    });
 
     let id = client.create_split(&creator, &recipients);
     client.compute_split(&id, &0);
@@ -270,8 +303,14 @@ fn test_compute_split_negative_amount_rejected() {
     let b = Address::generate(&env);
 
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(5000) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(5000) });
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Percent(5000),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Percent(5000),
+    });
 
     let id = client.create_split(&creator, &recipients);
     client.compute_split(&id, &-1);
@@ -287,8 +326,14 @@ fn test_fixed_split_mismatched_total_rejected() {
     let b = Address::generate(&env);
 
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Fixed(300) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Fixed(700) });
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Fixed(300),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Fixed(700),
+    });
 
     let id = client.create_split(&creator, &recipients);
     client.compute_split(&id, &999);
@@ -303,12 +348,24 @@ fn test_dust_tie_breaker_ignores_input_order() {
     let b = Address::generate(&env);
 
     let mut first_order = Vec::new(&env);
-    first_order.push_back(RecipientShare { recipient: a.clone(), kind: ShareKind::Percent(5000) });
-    first_order.push_back(RecipientShare { recipient: b.clone(), kind: ShareKind::Percent(5000) });
+    first_order.push_back(RecipientShare {
+        recipient: a.clone(),
+        kind: ShareKind::Percent(5000),
+    });
+    first_order.push_back(RecipientShare {
+        recipient: b.clone(),
+        kind: ShareKind::Percent(5000),
+    });
 
     let mut reversed_order = Vec::new(&env);
-    reversed_order.push_back(RecipientShare { recipient: b.clone(), kind: ShareKind::Percent(5000) });
-    reversed_order.push_back(RecipientShare { recipient: a.clone(), kind: ShareKind::Percent(5000) });
+    reversed_order.push_back(RecipientShare {
+        recipient: b.clone(),
+        kind: ShareKind::Percent(5000),
+    });
+    reversed_order.push_back(RecipientShare {
+        recipient: a.clone(),
+        kind: ShareKind::Percent(5000),
+    });
 
     let first_id = client.create_split(&creator, &first_order);
     let second_id = client.create_split(&creator, &reversed_order);
@@ -329,7 +386,10 @@ fn test_dust_tie_breaker_ignores_input_order() {
 
     assert_eq!(first_a, second_a);
     assert_eq!(first_out.get(0).unwrap().1 + first_out.get(1).unwrap().1, 1);
-    assert_eq!(second_out.get(0).unwrap().1 + second_out.get(1).unwrap().1, 1);
+    assert_eq!(
+        second_out.get(0).unwrap().1 + second_out.get(1).unwrap().1,
+        1
+    );
 }
 
 #[test]
@@ -342,9 +402,18 @@ fn test_repeated_percent_splits_do_not_lose_or_create_value() {
     let c = Address::generate(&env);
 
     let mut recipients = Vec::new(&env);
-    recipients.push_back(RecipientShare { recipient: a, kind: ShareKind::Percent(3333) });
-    recipients.push_back(RecipientShare { recipient: b, kind: ShareKind::Percent(3333) });
-    recipients.push_back(RecipientShare { recipient: c, kind: ShareKind::Percent(3334) });
+    recipients.push_back(RecipientShare {
+        recipient: a,
+        kind: ShareKind::Percent(3333),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: b,
+        kind: ShareKind::Percent(3333),
+    });
+    recipients.push_back(RecipientShare {
+        recipient: c,
+        kind: ShareKind::Percent(3334),
+    });
 
     let id = client.create_split(&creator, &recipients);
 

--- a/onchain/contracts/payroll_escrow/src/tests/test_escrow.rs
+++ b/onchain/contracts/payroll_escrow/src/tests/test_escrow.rs
@@ -751,7 +751,10 @@ fn assert_escrow_conservation(
         outflow + remaining,
         "conservation violated: funded={total_funded} released={total_released} refunded={total_refunded} remaining={remaining}"
     );
-    assert!(outflow <= total_funded, "outflow must not exceed funded deposits");
+    assert!(
+        outflow <= total_funded,
+        "outflow must not exceed funded deposits"
+    );
 }
 
 #[test]

--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -547,13 +547,8 @@ impl PriceOracleContract {
 
         // Per-source submission rate limit.
         if cfg.min_submit_interval_secs > 0 {
-            let last_key =
-                DataKey::LastSubmission(source.clone(), base.clone(), quote.clone());
-            if let Some(last_ts) = env
-                .storage()
-                .temporary()
-                .get::<_, u64>(&last_key)
-            {
+            let last_key = DataKey::LastSubmission(source.clone(), base.clone(), quote.clone());
+            if let Some(last_ts) = env.storage().temporary().get::<_, u64>(&last_key) {
                 let elapsed = source_timestamp.saturating_sub(last_ts);
                 if elapsed < cfg.min_submit_interval_secs {
                     return Err(OracleError::SubmissionRateLimited);

--- a/onchain/contracts/price_oracle/tests/test_oracle.rs
+++ b/onchain/contracts/price_oracle/tests/test_oracle.rs
@@ -1,4 +1,4 @@
-﻿#![cfg(test)]
+#![cfg(test)]
 #![allow(deprecated)]
 
 use price_oracle::{OracleError, PriceOracleContract, PriceOracleContractClient};

--- a/onchain/contracts/rate_limiter/src/lib.rs
+++ b/onchain/contracts/rate_limiter/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! Per-address and global rate limiting contract using Token Bucket algorithm.
 //!
-//! Provides burst-friendly rate limiting with automatic token refills, 
+//! Provides burst-friendly rate limiting with automatic token refills,
 //! global throttling, and admin bypass to ensure security and fairness.
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
@@ -75,10 +75,18 @@ impl RateLimiter {
         assert!(!Self::is_initialized(&env), "already initialized");
 
         env.storage().persistent().set(&StorageKey::Admin, &admin);
-        env.storage().persistent().set(&StorageKey::DefaultBurst, &default_burst);
-        env.storage().persistent().set(&StorageKey::DefaultRefillRate, &default_refill_rate);
-        env.storage().persistent().set(&StorageKey::AdminBypass, &admin_bypass);
-        env.storage().persistent().set(&StorageKey::Initialized, &true);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::DefaultBurst, &default_burst);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::DefaultRefillRate, &default_refill_rate);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::AdminBypass, &admin_bypass);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Initialized, &true);
     }
 
     /// Configures the global rate limit.
@@ -90,9 +98,15 @@ impl RateLimiter {
     /// @param refill_rate Global tokens added per second.
     pub fn set_global_limit(env: Env, enabled: bool, burst: u32, refill_rate: u32) {
         Self::require_admin_auth(&env);
-        env.storage().persistent().set(&StorageKey::GlobalLimitEnabled, &enabled);
-        env.storage().persistent().set(&StorageKey::GlobalBurst, &burst);
-        env.storage().persistent().set(&StorageKey::GlobalRefillRate, &refill_rate);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::GlobalLimitEnabled, &enabled);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::GlobalBurst, &burst);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::GlobalRefillRate, &refill_rate);
     }
 
     /// Sets a per-address limit override.
@@ -103,7 +117,10 @@ impl RateLimiter {
     /// @param refill_rate Tokens added per second for this address.
     pub fn set_limit_for(env: Env, addr: Address, burst: u32, refill_rate: u32) {
         Self::require_admin_auth(&env);
-        env.storage().persistent().set(&StorageKey::Limit(addr), &LimitConfig { burst, refill_rate });
+        env.storage().persistent().set(
+            &StorageKey::Limit(addr),
+            &LimitConfig { burst, refill_rate },
+        );
     }
 
     /// Removes a per-address limit override.
@@ -124,7 +141,11 @@ impl RateLimiter {
         Self::require_initialized(&env);
 
         let admin: Address = env.storage().persistent().get(&StorageKey::Admin).unwrap();
-        let bypass: bool = env.storage().persistent().get(&StorageKey::AdminBypass).unwrap_or(true);
+        let bypass: bool = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::AdminBypass)
+            .unwrap_or(true);
 
         // Security assumption: Admin bypass prevents permanent lockout of governance controllers.
         if bypass && subject == admin {
@@ -132,15 +153,33 @@ impl RateLimiter {
         }
 
         // 1. Check Global Limit (if enabled)
-        if env.storage().persistent().get(&StorageKey::GlobalLimitEnabled).unwrap_or(false) {
-            let g_burst = env.storage().persistent().get(&StorageKey::GlobalBurst).unwrap_or(0);
-            let g_refill = env.storage().persistent().get(&StorageKey::GlobalRefillRate).unwrap_or(0);
+        if env
+            .storage()
+            .persistent()
+            .get(&StorageKey::GlobalLimitEnabled)
+            .unwrap_or(false)
+        {
+            let g_burst = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::GlobalBurst)
+                .unwrap_or(0);
+            let g_refill = env
+                .storage()
+                .persistent()
+                .get(&StorageKey::GlobalRefillRate)
+                .unwrap_or(0);
             Self::consume_bucket(&env, StorageKey::GlobalUsage, g_burst, g_refill);
         }
 
         // 2. Check Per-Address Limit
         let limit = Self::get_limit_config(&env, &subject);
-        Self::consume_bucket(&env, StorageKey::Usage(subject.clone()), limit.burst, limit.refill_rate)
+        Self::consume_bucket(
+            &env,
+            StorageKey::Usage(subject.clone()),
+            limit.burst,
+            limit.refill_rate,
+        )
     }
 
     /// Explicitly resets usage for an address.
@@ -156,7 +195,9 @@ impl RateLimiter {
     /// @dev Only callable by current admin.
     pub fn transfer_admin(env: Env, new_admin: Address) {
         Self::require_admin_auth(&env);
-        env.storage().persistent().set(&StorageKey::Admin, &new_admin);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Admin, &new_admin);
     }
 
     /// Gets current config for an address.
@@ -197,16 +238,28 @@ impl RateLimiter {
     }
 
     fn get_limit_config(env: &Env, addr: &Address) -> LimitConfig {
-        env.storage().persistent().get(&StorageKey::Limit(addr.clone())).unwrap_or_else(|| {
-            LimitConfig {
-                burst: env.storage().persistent().get(&StorageKey::DefaultBurst).unwrap_or(0),
-                refill_rate: env.storage().persistent().get(&StorageKey::DefaultRefillRate).unwrap_or(0),
-            }
-        })
+        env.storage()
+            .persistent()
+            .get(&StorageKey::Limit(addr.clone()))
+            .unwrap_or_else(|| LimitConfig {
+                burst: env
+                    .storage()
+                    .persistent()
+                    .get(&StorageKey::DefaultBurst)
+                    .unwrap_or(0),
+                refill_rate: env
+                    .storage()
+                    .persistent()
+                    .get(&StorageKey::DefaultRefillRate)
+                    .unwrap_or(0),
+            })
     }
 
     fn is_initialized(env: &Env) -> bool {
-        env.storage().persistent().get(&StorageKey::Initialized).unwrap_or(false)
+        env.storage()
+            .persistent()
+            .get(&StorageKey::Initialized)
+            .unwrap_or(false)
     }
 
     fn require_initialized(env: &Env) {
@@ -214,8 +267,11 @@ impl RateLimiter {
     }
 
     fn require_admin_auth(env: &Env) {
-        let admin: Address = env.storage().persistent().get(&StorageKey::Admin).expect("admin not set");
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::Admin)
+            .expect("admin not set");
         admin.require_auth();
     }
 }
-

--- a/onchain/contracts/rate_limiter/tests/test_rate_limit.rs
+++ b/onchain/contracts/rate_limiter/tests/test_rate_limit.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     Address, Env,
 };
 
-use rate_limiter::{RateLimiter, RateLimiterClient, LimitConfig};
+use rate_limiter::{LimitConfig, RateLimiter, RateLimiterClient};
 
 fn create_env() -> Env {
     let env = Env::default();
@@ -28,7 +28,7 @@ fn test_initialize_and_basic_quota() {
 
     client.initialize(&admin, &5u32, &1u32, &true);
     assert_eq!(client.get_admin(), Some(admin.clone()));
-    
+
     let config = client.get_limit_for(&user);
     assert_eq!(config.burst, 5);
     assert_eq!(config.refill_rate, 1);
@@ -47,7 +47,7 @@ fn test_token_bucket_refill_logic() {
 
     // Start at T=100
     env.ledger().with_mut(|li| li.timestamp = 100);
-    
+
     // Burst 2, Refill 1 per second
     client.initialize(&admin, &2u32, &1u32, &false);
 
@@ -83,7 +83,7 @@ fn test_global_limit_enforcement() {
 
     // User 1 consumes the global token
     client.check_and_consume(&user1);
-    
+
     // User 2 fails because global bucket is empty
     let result = client.try_check_and_consume(&user2);
     assert!(result.is_err());
@@ -101,7 +101,7 @@ fn test_admin_bypass_security() {
     // Admin is exempt
     assert_eq!(client.check_and_consume(&admin), u32::MAX);
     assert_eq!(client.check_and_consume(&admin), u32::MAX);
-    
+
     // User is blocked
     let user = Address::generate(&env);
     assert!(client.try_check_and_consume(&user).is_err());
@@ -115,7 +115,7 @@ fn test_per_address_overrides() {
     let user = Address::generate(&env);
 
     client.initialize(&admin, &1u32, &0u32, &false);
-    
+
     // User override
     client.set_limit_for(&user, &10u32, &5u32);
     let config = client.get_limit_for(&user);
@@ -123,7 +123,7 @@ fn test_per_address_overrides() {
     assert_eq!(config.refill_rate, 5);
 
     assert_eq!(client.check_and_consume(&user), 9);
-    
+
     // Clear override
     client.clear_limit_for(&user);
     let config_reset = client.get_limit_for(&user);
@@ -138,10 +138,10 @@ fn test_admin_usage_reset() {
     let user = Address::generate(&env);
 
     client.initialize(&admin, &1u32, &0u32, &false);
-    
+
     client.check_and_consume(&user);
     assert!(client.try_check_and_consume(&user).is_err());
-    
+
     // Admin resets user usage
     client.reset_usage(&user);
     assert_eq!(client.check_and_consume(&user), 0);
@@ -156,8 +156,7 @@ fn test_admin_transfer() {
 
     client.initialize(&admin1, &1u32, &1u32, &false);
     assert_eq!(client.get_admin(), Some(admin1.clone()));
-    
+
     client.transfer_admin(&admin2);
     assert_eq!(client.get_admin(), Some(admin2.clone()));
 }
-

--- a/onchain/contracts/rbac/src/lib.rs
+++ b/onchain/contracts/rbac/src/lib.rs
@@ -373,12 +373,8 @@ impl RbacContract {
         write_roles(&env, &old_owner, &old_roles);
 
         // Update owner record.
-        env.storage()
-            .persistent()
-            .set(&StorageKey::Owner, &caller);
-        env.storage()
-            .persistent()
-            .remove(&StorageKey::PendingOwner);
+        env.storage().persistent().set(&StorageKey::Owner, &caller);
+        env.storage().persistent().remove(&StorageKey::PendingOwner);
 
         env.events()
             .publish((symbol_short!("RBAC"), symbol_short!("owner")), &caller);

--- a/onchain/contracts/rbac/tests/test_rbac.rs
+++ b/onchain/contracts/rbac/tests/test_rbac.rs
@@ -112,7 +112,11 @@ fn test_duplicate_grant_is_noop() {
     client.grant_role(&admin, &user, &Role::Employee);
 
     let roles = client.get_roles(&user);
-    assert_eq!(roles.len(), 1, "Duplicate grant should not add a second entry");
+    assert_eq!(
+        roles.len(),
+        1,
+        "Duplicate grant should not add a second entry"
+    );
 }
 
 #[test]
@@ -264,10 +268,10 @@ fn test_role_inheritance_full_matrix() {
     // Employee   F       F         T         F
     // Arbiter    F       F         F         T
     let expected: [[bool; 4]; 4] = [
-        [true, true, true, true],     // Admin grants
-        [false, true, true, false],   // Employer grants
-        [false, false, true, false],  // Employee grants
-        [false, false, false, true],  // Arbiter grants
+        [true, true, true, true],    // Admin grants
+        [false, true, true, false],  // Employer grants
+        [false, false, true, false], // Employee grants
+        [false, false, false, true], // Arbiter grants
     ];
 
     for (gi, granted) in all_roles.iter().enumerate() {

--- a/onchain/contracts/slashing_penalty/src/lib.rs
+++ b/onchain/contracts/slashing_penalty/src/lib.rs
@@ -26,9 +26,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, contracterror,
-    Address, BytesN, Env, Map, Vec, Symbol, symbol_short,
-    token,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
+    Map, Symbol, Vec,
 };
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -44,16 +43,16 @@ const DEFAULT_QUORUM: u32 = 2;
 
 // ─── Storage Keys ─────────────────────────────────────────────────────────────
 
-const ADMIN: Symbol        = symbol_short!("ADMIN");
-const QUORUM: Symbol       = symbol_short!("QUORUM");
-const SLASHERS: Symbol     = symbol_short!("SLASHERS");
-const STAKES: Symbol       = symbol_short!("STAKES");
-const SLASH_REC: Symbol    = symbol_short!("SLASHREC");
-const USED_EV: Symbol      = symbol_short!("USEDEV");
-const ESCROW: Symbol       = symbol_short!("ESCROW");
-const TOKEN: Symbol        = symbol_short!("TOKEN");
-const CAPS: Symbol         = symbol_short!("CAPS");
-const SLASH_ACC: Symbol    = symbol_short!("SLASHACC");
+const ADMIN: Symbol = symbol_short!("ADMIN");
+const QUORUM: Symbol = symbol_short!("QUORUM");
+const SLASHERS: Symbol = symbol_short!("SLASHERS");
+const STAKES: Symbol = symbol_short!("STAKES");
+const SLASH_REC: Symbol = symbol_short!("SLASHREC");
+const USED_EV: Symbol = symbol_short!("USEDEV");
+const ESCROW: Symbol = symbol_short!("ESCROW");
+const TOKEN: Symbol = symbol_short!("TOKEN");
+const CAPS: Symbol = symbol_short!("CAPS");
+const SLASH_ACC: Symbol = symbol_short!("SLASHACC");
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -141,37 +140,37 @@ pub struct PenaltyAccumulator {
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum SlashError {
     /// Caller does not hold the slasher role.
-    Unauthorized        = 1,
+    Unauthorized = 1,
     /// Evidence hash has already been used.
-    DuplicateEvidence   = 2,
+    DuplicateEvidence = 2,
     /// Penalty exceeds the allowed maximum.
-    PenaltyTooHigh      = 3,
+    PenaltyTooHigh = 3,
     /// Offender has insufficient staked balance.
-    InsufficientStake   = 4,
+    InsufficientStake = 4,
     /// Appeal window has not yet closed.
-    AppealWindowOpen    = 5,
+    AppealWindowOpen = 5,
     /// Appeal window has already closed.
-    AppealWindowClosed  = 6,
+    AppealWindowClosed = 6,
     /// Slash record not found.
-    RecordNotFound      = 7,
+    RecordNotFound = 7,
     /// Slash is not in a state that allows this operation.
-    InvalidState        = 8,
+    InvalidState = 8,
     /// Quorum of attestors not yet reached.
-    QuorumNotMet        = 9,
+    QuorumNotMet = 9,
     /// Slasher already attested to this slash.
-    AlreadyAttested     = 10,
+    AlreadyAttested = 10,
     /// Penalty basis points cannot be zero.
-    ZeroPenalty         = 11,
+    ZeroPenalty = 11,
     /// Admin address already initialised.
-    AlreadyInitialized  = 12,
+    AlreadyInitialized = 12,
     /// Penalty cap configuration is invalid.
-    InvalidConfig       = 13,
+    InvalidConfig = 13,
     /// Period cap would be exceeded.
-    PeriodCapExceeded   = 14,
+    PeriodCapExceeded = 14,
     /// Lifetime cap would be exceeded.
     LifetimeCapExceeded = 15,
     /// Arithmetic overflow/underflow protection.
-    ArithmeticOverflow  = 16,
+    ArithmeticOverflow = 16,
 }
 
 // ─── Contract ─────────────────────────────────────────────────────────────────
@@ -181,7 +180,6 @@ pub struct SlashingPenaltyContract;
 
 #[contractimpl]
 impl SlashingPenaltyContract {
-
     // ── Initialisation ────────────────────────────────────────────────────────
 
     /// Initialise the contract. Can only be called once.
@@ -212,19 +210,36 @@ impl SlashingPenaltyContract {
         admin.require_auth();
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&TOKEN, &token);
-        env.storage().instance().set(&QUORUM, &quorum.max(DEFAULT_QUORUM));
-        env.storage().instance().set(&SLASHERS, &Vec::<Address>::new(&env));
-        env.storage().instance().set(&STAKES, &Map::<Address, i128>::new(&env));
-        env.storage().instance().set(&SLASH_REC, &Map::<BytesN<32>, SlashRecord>::new(&env));
-        env.storage().instance().set(&USED_EV, &Vec::<BytesN<32>>::new(&env));
-        env.storage().instance().set(&ESCROW, &Map::<BytesN<32>, i128>::new(&env));
-        env.storage().instance().set(&SLASH_ACC, &Map::<Address, PenaltyAccumulator>::new(&env));
-        env.storage().instance().set(&CAPS, &PenaltyCaps {
-            per_event_bps_cap,
-            per_period_amount_cap,
-            lifetime_amount_cap,
-            period_secs,
-        });
+        env.storage()
+            .instance()
+            .set(&QUORUM, &quorum.max(DEFAULT_QUORUM));
+        env.storage()
+            .instance()
+            .set(&SLASHERS, &Vec::<Address>::new(&env));
+        env.storage()
+            .instance()
+            .set(&STAKES, &Map::<Address, i128>::new(&env));
+        env.storage()
+            .instance()
+            .set(&SLASH_REC, &Map::<BytesN<32>, SlashRecord>::new(&env));
+        env.storage()
+            .instance()
+            .set(&USED_EV, &Vec::<BytesN<32>>::new(&env));
+        env.storage()
+            .instance()
+            .set(&ESCROW, &Map::<BytesN<32>, i128>::new(&env));
+        env.storage()
+            .instance()
+            .set(&SLASH_ACC, &Map::<Address, PenaltyAccumulator>::new(&env));
+        env.storage().instance().set(
+            &CAPS,
+            &PenaltyCaps {
+                per_event_bps_cap,
+                per_period_amount_cap,
+                lifetime_amount_cap,
+                period_secs,
+            },
+        );
         Ok(())
     }
 
@@ -243,12 +258,15 @@ impl SlashingPenaltyContract {
             lifetime_amount_cap,
             period_secs,
         )?;
-        env.storage().instance().set(&CAPS, &PenaltyCaps {
-            per_event_bps_cap,
-            per_period_amount_cap,
-            lifetime_amount_cap,
-            period_secs,
-        });
+        env.storage().instance().set(
+            &CAPS,
+            &PenaltyCaps {
+                per_event_bps_cap,
+                per_period_amount_cap,
+                lifetime_amount_cap,
+                period_secs,
+            },
+        );
         Ok(())
     }
 
@@ -433,10 +451,8 @@ impl SlashingPenaltyContract {
 
         env.storage().instance().set(&SLASH_REC, &records);
 
-        env.events().publish(
-            (symbol_short!("ATTESTED"), attestor),
-            evidence_hash.clone(),
-        );
+        env.events()
+            .publish((symbol_short!("ATTESTED"), attestor), evidence_hash.clone());
 
         Ok(())
     }
@@ -445,11 +461,17 @@ impl SlashingPenaltyContract {
 
     /// The offender raises an appeal during the appeal window.
     /// This does not automatically reverse the slash — admin must review.
-    pub fn raise_appeal(env: Env, offender: Address, evidence_hash: BytesN<32>) -> Result<(), SlashError> {
+    pub fn raise_appeal(
+        env: Env,
+        offender: Address,
+        evidence_hash: BytesN<32>,
+    ) -> Result<(), SlashError> {
         offender.require_auth();
         let records: Map<BytesN<32>, SlashRecord> =
             env.storage().instance().get(&SLASH_REC).unwrap();
-        let record = records.get(evidence_hash.clone()).ok_or(SlashError::RecordNotFound)?;
+        let record = records
+            .get(evidence_hash.clone())
+            .ok_or(SlashError::RecordNotFound)?;
 
         if record.status != SlashStatus::Pending {
             return Err(SlashError::InvalidState);
@@ -459,10 +481,8 @@ impl SlashingPenaltyContract {
             return Err(SlashError::AppealWindowClosed);
         }
 
-        env.events().publish(
-            (symbol_short!("APPEALED"), offender),
-            evidence_hash,
-        );
+        env.events()
+            .publish((symbol_short!("APPEALED"), offender), evidence_hash);
 
         Ok(())
     }
@@ -477,7 +497,9 @@ impl SlashingPenaltyContract {
 
         let mut records: Map<BytesN<32>, SlashRecord> =
             env.storage().instance().get(&SLASH_REC).unwrap();
-        let mut record = records.get(evidence_hash.clone()).ok_or(SlashError::RecordNotFound)?;
+        let mut record = records
+            .get(evidence_hash.clone())
+            .ok_or(SlashError::RecordNotFound)?;
 
         if record.status != SlashStatus::Pending {
             return Err(SlashError::InvalidState);
@@ -497,10 +519,8 @@ impl SlashingPenaltyContract {
         records.set(evidence_hash.clone(), record);
         env.storage().instance().set(&SLASH_REC, &records);
 
-        env.events().publish(
-            (symbol_short!("RESOLVED"), uphold),
-            evidence_hash,
-        );
+        env.events()
+            .publish((symbol_short!("RESOLVED"), uphold), evidence_hash);
 
         Ok(())
     }
@@ -510,7 +530,9 @@ impl SlashingPenaltyContract {
     pub fn execute_slash(env: Env, evidence_hash: BytesN<32>) -> Result<(), SlashError> {
         let mut records: Map<BytesN<32>, SlashRecord> =
             env.storage().instance().get(&SLASH_REC).unwrap();
-        let mut record = records.get(evidence_hash.clone()).ok_or(SlashError::RecordNotFound)?;
+        let mut record = records
+            .get(evidence_hash.clone())
+            .ok_or(SlashError::RecordNotFound)?;
 
         if record.status != SlashStatus::Pending {
             return Err(SlashError::InvalidState);
@@ -652,10 +674,15 @@ impl SlashingPenaltyContract {
         Ok(slash_amount)
     }
 
-    fn enforce_and_record_caps(env: &Env, offender: &Address, slash_amount: i128) -> Result<(), SlashError> {
+    fn enforce_and_record_caps(
+        env: &Env,
+        offender: &Address,
+        slash_amount: i128,
+    ) -> Result<(), SlashError> {
         let caps: PenaltyCaps = env.storage().instance().get(&CAPS).unwrap();
         let now = env.ledger().timestamp();
-        let mut accs: Map<Address, PenaltyAccumulator> = env.storage().instance().get(&SLASH_ACC).unwrap();
+        let mut accs: Map<Address, PenaltyAccumulator> =
+            env.storage().instance().get(&SLASH_ACC).unwrap();
 
         let mut acc = accs.get(offender.clone()).unwrap_or(PenaltyAccumulator {
             period_start_ts: now,
@@ -692,7 +719,8 @@ impl SlashingPenaltyContract {
     }
 
     fn decrease_accumulator(env: &Env, offender: &Address, amount: i128) -> Result<(), SlashError> {
-        let mut accs: Map<Address, PenaltyAccumulator> = env.storage().instance().get(&SLASH_ACC).unwrap();
+        let mut accs: Map<Address, PenaltyAccumulator> =
+            env.storage().instance().get(&SLASH_ACC).unwrap();
         let Some(mut acc) = accs.get(offender.clone()) else {
             return Ok(());
         };

--- a/onchain/contracts/slashing_penalty/tests/integration_test.rs
+++ b/onchain/contracts/slashing_penalty/tests/integration_test.rs
@@ -7,8 +7,7 @@ use soroban_sdk::{
 };
 
 use slashing_penalty::{
-    SlashingPenaltyContract, SlashingPenaltyContractClient,
-    Offense, SlashStatus, SlashError,
+    Offense, SlashError, SlashStatus, SlashingPenaltyContract, SlashingPenaltyContractClient,
 };
 
 // ─── Test Helpers ─────────────────────────────────────────────────────────────
@@ -35,18 +34,22 @@ impl TestEnv {
         let contract_id = env.register_contract(None, SlashingPenaltyContract);
         let client = SlashingPenaltyContractClient::new(&env, &contract_id);
 
-        let admin    = Address::generate(&env);
+        let admin = Address::generate(&env);
         let slasher1 = Address::generate(&env);
         let slasher2 = Address::generate(&env);
         let slasher3 = Address::generate(&env);
         let offender = Address::generate(&env);
         let token_admin = Address::generate(&env);
-        let token = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
         let token_sac = StellarAssetClient::new(&env, &token);
         token_sac.mint(&offender, &1_000_000i128);
 
         // Per-event cap: 50%, period cap: 6_000, lifetime cap: 9_000, period: 1 day.
-        client.initialize(&admin, &token, &2u32, &5_000u32, &6_000i128, &9_000i128, &86_400u64);
+        client.initialize(
+            &admin, &token, &2u32, &5_000u32, &6_000i128, &9_000i128, &86_400u64,
+        );
         client.add_slasher(&slasher1);
         client.add_slasher(&slasher2);
         client.add_slasher(&slasher3);
@@ -54,7 +57,16 @@ impl TestEnv {
         // Give offender an initial staked balance.
         client.stake(&offender, &10_000i128);
 
-        TestEnv { env, client, admin, slasher1, slasher2, slasher3, offender, token }
+        TestEnv {
+            env,
+            client,
+            admin,
+            slasher1,
+            slasher2,
+            slasher3,
+            offender,
+            token,
+        }
     }
 
     fn evidence_hash(&self, seed: u8) -> BytesN<32> {
@@ -85,13 +97,7 @@ fn test_initialize_sets_admin_and_quorum() {
 fn test_initialize_twice_fails() {
     let t = TestEnv::setup();
     let result = t.client.try_initialize(
-        &t.admin,
-        &t.token,
-        &2u32,
-        &5_000u32,
-        &6_000i128,
-        &9_000i128,
-        &86_400u64,
+        &t.admin, &t.token, &2u32, &5_000u32, &6_000i128, &9_000i128, &86_400u64,
     );
     assert_eq!(result, Err(Ok(SlashError::AlreadyInitialized)));
 }
@@ -259,10 +265,20 @@ fn test_duplicate_evidence_fails() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(6);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     let result = t.client.try_slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     assert_eq!(result, Err(Ok(SlashError::DuplicateEvidence)));
 }
@@ -291,7 +307,12 @@ fn test_attestation_requires_quorum_before_execute() {
 
     // Only one attestor — quorum is 2
     t.client.attest_slash(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
 
     t.advance_time(APPEAL_WINDOW + 1);
@@ -306,10 +327,20 @@ fn test_attestation_quorum_met_allows_execute() {
     let hash = t.evidence_hash(11);
 
     t.client.attest_slash(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     t.client.attest_slash(
-        &t.slasher2, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher2,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
 
     t.advance_time(APPEAL_WINDOW + 1);
@@ -325,10 +356,20 @@ fn test_double_attestation_by_same_slasher_fails() {
     let hash = t.evidence_hash(12);
 
     t.client.attest_slash(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     let result = t.client.try_attest_slash(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     assert_eq!(result, Err(Ok(SlashError::AlreadyAttested)));
 }
@@ -340,7 +381,12 @@ fn test_execute_before_appeal_window_fails() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(20);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     let result = t.client.try_execute_slash(&hash);
     assert_eq!(result, Err(Ok(SlashError::AppealWindowOpen)));
@@ -351,7 +397,12 @@ fn test_execute_after_appeal_window_succeeds() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(21);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     t.advance_time(APPEAL_WINDOW + 1);
     t.client.execute_slash(&hash);
@@ -364,7 +415,12 @@ fn test_raise_appeal_within_window() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(22);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &500u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &500u32,
+        &hash,
+        &0u64,
     );
     // Should not panic — event emitted
     t.client.raise_appeal(&t.offender, &hash);
@@ -375,7 +431,12 @@ fn test_raise_appeal_after_window_fails() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(23);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &500u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &500u32,
+        &hash,
+        &0u64,
     );
     t.advance_time(APPEAL_WINDOW + 1);
     let result = t.client.try_raise_appeal(&t.offender, &hash);
@@ -391,7 +452,12 @@ fn test_appeal_upheld_returns_funds() {
     let before = t.client.get_stake_balance(&t.offender);
 
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     assert_eq!(t.client.get_stake_balance(&t.offender), before - 1_000);
 
@@ -409,7 +475,12 @@ fn test_appeal_rejected_burns_funds() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(31);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::FraudProof, &2_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::FraudProof,
+        &2_000u32,
+        &hash,
+        &0u64,
     );
     t.client.raise_appeal(&t.offender, &hash);
     t.client.resolve_appeal(&hash, &false);
@@ -425,7 +496,12 @@ fn test_cannot_resolve_already_resolved_appeal() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(32);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash,
+        &0u64,
     );
     t.client.resolve_appeal(&hash, &true);
     let result = t.client.try_resolve_appeal(&hash, &false);
@@ -440,14 +516,24 @@ fn test_repeated_offenses_with_different_evidence_hashes() {
 
     // First offense: 10%
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &1_000u32, &t.evidence_hash(40), &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &1_000u32,
+        &t.evidence_hash(40),
+        &0u64,
     );
     assert_eq!(t.client.get_stake_balance(&t.offender), 9_000i128);
 
     // Second offense: another 10% of remaining stake
     // (stake is now 9_000; 10% = 900)
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &1_000u32, &t.evidence_hash(41), &1u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &1_000u32,
+        &t.evidence_hash(41),
+        &1u64,
     );
     assert_eq!(t.client.get_stake_balance(&t.offender), 8_100i128);
 }
@@ -458,16 +544,31 @@ fn test_repeated_penalties_saturate_period_cap() {
 
     // 30% of 10_000 = 3_000 (within period cap 6_000)
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::FraudProof, &3_000u32, &t.evidence_hash(42), &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::FraudProof,
+        &3_000u32,
+        &t.evidence_hash(42),
+        &0u64,
     );
     // 30% of 7_000 = 2_100 (cumulative 5_100, still within cap)
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::FraudProof, &3_000u32, &t.evidence_hash(43), &1u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::FraudProof,
+        &3_000u32,
+        &t.evidence_hash(43),
+        &1u64,
     );
 
     // 30% of 4_900 = 1_470 would exceed period cap (5_100 + 1_470 > 6_000)
     let result = t.client.try_slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::FraudProof, &3_000u32, &t.evidence_hash(44), &2u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::FraudProof,
+        &3_000u32,
+        &t.evidence_hash(44),
+        &2u64,
     );
     assert_eq!(result, Err(Ok(SlashError::PeriodCapExceeded)));
 }
@@ -479,38 +580,78 @@ fn test_boundary_conditions_at_caps() {
     // Exactly reach period cap: 60% of 10_000 is blocked by per-event cap,
     // so use two events to hit period cap exactly.
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &5_000u32, &t.evidence_hash(45), &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &5_000u32,
+        &t.evidence_hash(45),
+        &0u64,
     ); // 5_000
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &2_000u32, &t.evidence_hash(46), &1u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &2_000u32,
+        &t.evidence_hash(46),
+        &1u64,
     ); // 1_000
 
     // Now exactly at 6_000 period cap. Any additional positive slash in same period fails.
     let same_period = t.client.try_slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &100u32, &t.evidence_hash(47), &2u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &100u32,
+        &t.evidence_hash(47),
+        &2u64,
     );
     assert_eq!(same_period, Err(Ok(SlashError::PeriodCapExceeded)));
 
     // Advance into next period to test lifetime boundary at 9_000.
     t.advance_time(86_401);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &3_000u32, &t.evidence_hash(48), &3u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &3_000u32,
+        &t.evidence_hash(48),
+        &3u64,
     ); // 1_200 => cumulative 7_200
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &5_000u32, &t.evidence_hash(49), &4u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &5_000u32,
+        &t.evidence_hash(49),
+        &4u64,
     ); // 1_400 => cumulative 8_600
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &2_000u32, &t.evidence_hash(52), &5u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &2_000u32,
+        &t.evidence_hash(52),
+        &5u64,
     ); // 280 => cumulative 8_880
 
     // This slash is still below lifetime cap.
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &1_000u32, &t.evidence_hash(53), &6u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &1_000u32,
+        &t.evidence_hash(53),
+        &6u64,
     ); // 112 => cumulative 8_992
 
     // Next slash crosses lifetime cap (8_992 + 11 > 9_000)
     let over_lifetime = t.client.try_slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &100u32, &t.evidence_hash(60), &7u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &100u32,
+        &t.evidence_hash(60),
+        &7u64,
     );
     assert_eq!(over_lifetime, Err(Ok(SlashError::LifetimeCapExceeded)));
 }
@@ -523,14 +664,24 @@ fn test_minimal_balance_does_not_underflow_or_create_negative_accounting() {
 
     // 1 bps of 1 rounds to 0 -> rejected.
     let too_small = t.client.try_slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &1u32, &t.evidence_hash(54), &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &1u32,
+        &t.evidence_hash(54),
+        &0u64,
     );
     assert_eq!(too_small, Err(Ok(SlashError::ZeroPenalty)));
     assert_eq!(t.client.get_stake_balance(&t.offender), 1i128);
 
     // 100% slash is still bounded by per-event cap (50%), so set 5_000 bps.
     let ok = t.client.try_slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &5_000u32, &t.evidence_hash(55), &1u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &5_000u32,
+        &t.evidence_hash(55),
+        &1u64,
     );
     assert_eq!(ok, Err(Ok(SlashError::ZeroPenalty)));
     assert_eq!(t.client.get_stake_balance(&t.offender), 1i128);
@@ -548,14 +699,24 @@ fn test_simulated_concurrent_triggers_are_capped() {
         (59u8, &t.slasher1),
     ] {
         let _ = t.client.try_slash_with_evidence(
-            slasher, &t.offender, &Offense::FraudProof, &2_000u32, &t.evidence_hash(seed), &10u64,
+            slasher,
+            &t.offender,
+            &Offense::FraudProof,
+            &2_000u32,
+            &t.evidence_hash(seed),
+            &10u64,
         );
     }
 
     // First four are accepted: 2_000 + 1_600 + 1_280 + 1_024 = 5_904 < period cap.
     // Next trigger in the same burst would exceed period cap.
     let result = t.client.try_slash_with_evidence(
-        &t.slasher2, &t.offender, &Offense::FraudProof, &2_000u32, &t.evidence_hash(61), &10u64,
+        &t.slasher2,
+        &t.offender,
+        &Offense::FraudProof,
+        &2_000u32,
+        &t.evidence_hash(61),
+        &10u64,
     );
     assert_eq!(result, Err(Ok(SlashError::PeriodCapExceeded)));
 }
@@ -566,7 +727,12 @@ fn test_execute_then_re_slash_uses_new_hash() {
     let hash1 = t.evidence_hash(50);
 
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash1, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash1,
+        &0u64,
     );
     t.advance_time(APPEAL_WINDOW + 1);
     t.client.execute_slash(&hash1);
@@ -574,7 +740,12 @@ fn test_execute_then_re_slash_uses_new_hash() {
     // New offense with a different hash — should succeed
     let hash2 = t.evidence_hash(51);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::DoubleSigning, &1_000u32, &hash2, &1u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::DoubleSigning,
+        &1_000u32,
+        &hash2,
+        &1u64,
     );
     let record = t.client.get_slash_record(&hash2).unwrap();
     assert_eq!(record.status, SlashStatus::Pending);
@@ -599,7 +770,9 @@ fn test_execute_nonexistent_slash_fails() {
 #[test]
 fn test_appeal_nonexistent_slash_fails() {
     let t = TestEnv::setup();
-    let result = t.client.try_raise_appeal(&t.offender, &t.evidence_hash(101));
+    let result = t
+        .client
+        .try_raise_appeal(&t.offender, &t.evidence_hash(101));
     assert_eq!(result, Err(Ok(SlashError::RecordNotFound)));
 }
 
@@ -608,7 +781,12 @@ fn test_slash_exactly_at_appeal_deadline_still_open() {
     let t = TestEnv::setup();
     let hash = t.evidence_hash(60);
     t.client.slash_with_evidence(
-        &t.slasher1, &t.offender, &Offense::MissedDuty, &500u32, &hash, &0u64,
+        &t.slasher1,
+        &t.offender,
+        &Offense::MissedDuty,
+        &500u32,
+        &hash,
+        &0u64,
     );
     // Advance to exactly the deadline — window still open (>)
     t.advance_time(APPEAL_WINDOW);

--- a/onchain/contracts/stello_pay_contract/src/backup.rs
+++ b/onchain/contracts/stello_pay_contract/src/backup.rs
@@ -363,7 +363,8 @@ pub fn decrypt_backup(envelope: &[u8], passphrase: &[u8]) -> Result<StdVec<u8>, 
     let ciphertext = &envelope[pos..];
 
     let key_bytes = derive_key(passphrase, salt);
-    let cipher = Aes256Gcm::new_from_slice(&key_bytes).map_err(|_| BackupError::DecryptionFailed)?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key_bytes).map_err(|_| BackupError::DecryptionFailed)?;
     let mut nonce_arr = [0u8; NONCE_LEN];
     nonce_arr.copy_from_slice(nonce_bytes);
     let nonce = Nonce::from(nonce_arr);
@@ -394,7 +395,11 @@ pub fn backup_agreement(
 }
 
 /// Decrypt and deserialise an agreement backup envelope.
-pub fn restore_agreement(env: &Env, envelope: &[u8], passphrase: &[u8]) -> Result<Agreement, BackupError> {
+pub fn restore_agreement(
+    env: &Env,
+    envelope: &[u8],
+    passphrase: &[u8],
+) -> Result<Agreement, BackupError> {
     let plaintext = decrypt_backup(envelope, passphrase)?;
     deserialize_agreement(env, &plaintext)
 }

--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -111,7 +111,9 @@ impl PayrollContract {
 
     /// Gets the linked Rate Limiter contract address, if any.
     pub fn get_rate_limiter_contract(env: Env) -> Option<Address> {
-        env.storage().persistent().get(&StorageKey::RateLimiterContract)
+        env.storage()
+            .persistent()
+            .get(&StorageKey::RateLimiterContract)
     }
 
     /// @notice Upgrades the contract's WASM code to a new version.
@@ -340,12 +342,7 @@ impl PayrollContract {
     /// # Errors
     /// Panics with descriptive messages for: unknown agreement, wrong caller,
     /// non-positive amount, `Cancelled` or `Completed` status, arithmetic overflow.
-    pub fn fund_milestone_agreement(
-        env: Env,
-        agreement_id: u128,
-        from: Address,
-        amount: i128,
-    ) {
+    pub fn fund_milestone_agreement(env: Env, agreement_id: u128, from: Address, amount: i128) {
         payroll::fund_milestone_agreement(&env, agreement_id, from, amount);
     }
 
@@ -362,7 +359,6 @@ impl PayrollContract {
     pub fn add_milestone(env: Env, agreement_id: u128, amount: i128) {
         payroll::add_milestone(env, agreement_id, amount);
     }
-
 
     /// Approves a milestone for payment.
     ///

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -136,7 +136,11 @@ fn require_multisig_executed(
 }
 
 fn enforce_rate_limit(env: &Env, caller: &Address) -> Result<(), PayrollError> {
-    if let Some(rate_limiter_addr) = env.storage().persistent().get::<_, Address>(&StorageKey::RateLimiterContract) {
+    if let Some(rate_limiter_addr) = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&StorageKey::RateLimiterContract)
+    {
         let client = RateLimiterClient::new(env, &rate_limiter_addr);
         if client.try_check_and_consume(caller).is_err() {
             return Err(PayrollError::RateLimited);
@@ -272,17 +276,17 @@ pub fn fund_milestone_agreement(env: &Env, agreement_id: u128, from: Address, am
     let new_balance = current_balance
         .checked_add(amount)
         .expect("Escrow balance overflow");
-    env.storage()
-        .instance()
-        .set(&MilestoneKey::MilestoneEscrowBalance(agreement_id), &new_balance);
+    env.storage().instance().set(
+        &MilestoneKey::MilestoneEscrowBalance(agreement_id),
+        &new_balance,
+    );
 
     let token_address: Address = env
         .storage()
         .instance()
         .get(&MilestoneKey::Token(agreement_id))
         .expect("Token not found");
-    TokenClient::new(env, &token_address)
-        .transfer(&from, &env.current_contract_address(), &amount);
+    TokenClient::new(env, &token_address).transfer(&from, &env.current_contract_address(), &amount);
 
     emit_milestone_funded(
         env,
@@ -358,7 +362,10 @@ pub fn add_milestone(env: Env, agreement_id: u128, amount: i128) {
     #[cfg(debug_assertions)]
     {
         let total_sum = sum_all_milestones(&env, agreement_id);
-        assert!(total_sum == total + amount, "Total amount mismatch after adding milestone");
+        assert!(
+            total_sum == total + amount,
+            "Total amount mismatch after adding milestone"
+        );
     }
 
     MilestoneAdded {
@@ -607,8 +614,11 @@ pub fn claim_milestone(env: Env, agreement_id: u128, milestone_id: u32) {
         &escrow_balance.saturating_sub(amount),
     );
 
-    TokenClient::new(&env, &token_address)
-        .transfer(&env.current_contract_address(), &contributor, &amount);
+    TokenClient::new(&env, &token_address).transfer(
+        &env.current_contract_address(),
+        &contributor,
+        &amount,
+    );
 
     MilestoneClaimed {
         agreement_id,
@@ -802,7 +812,6 @@ pub fn batch_claim_milestones(
             amount_claimed: amount,
             error_code: 0,
         });
-
     }
 
     if all_milestones_claimed(env, agreement_id, count) {
@@ -1824,9 +1833,13 @@ pub fn set_exchange_rate(
                 let allowed_delta = (prev_rate
                     .checked_mul(max_dev_bps as i128)
                     .unwrap_or(i128::MAX))
-                    .checked_div(10_000i128)
-                    .unwrap_or(i128::MAX);
-                let diff = if rate > prev_rate { rate - prev_rate } else { prev_rate - rate };
+                .checked_div(10_000i128)
+                .unwrap_or(i128::MAX);
+                let diff = if rate > prev_rate {
+                    rate - prev_rate
+                } else {
+                    prev_rate - rate
+                };
                 if diff > allowed_delta {
                     return Err(PayrollError::ExchangeRateInvalid);
                 }
@@ -1993,7 +2006,10 @@ pub fn claim_payroll(
 
     // Invariant check: claimed_periods <= num_periods (if defined)
     if let Some(num_periods) = agreement.num_periods {
-        assert!(claimed_periods <= num_periods, "Invariant violation: claimed_periods > num_periods");
+        assert!(
+            claimed_periods <= num_periods,
+            "Invariant violation: claimed_periods > num_periods"
+        );
     }
 
     // Calculate periods to pay
@@ -2512,10 +2528,13 @@ pub fn batch_claim_payroll(
         // Must have unclaimed periods
         let claimed_periods =
             DataKey::get_employee_claimed_periods(env, agreement_id, employee_index);
-        
+
         // Invariant check: claimed_periods <= num_periods (if defined)
         if let Some(num_periods) = agreement.num_periods {
-            assert!(claimed_periods <= num_periods, "Invariant violation: claimed_periods > num_periods");
+            assert!(
+                claimed_periods <= num_periods,
+                "Invariant violation: claimed_periods > num_periods"
+            );
         }
 
         if total_elapsed_periods <= claimed_periods {
@@ -2738,7 +2757,10 @@ pub fn claim_time_based(env: &Env, agreement_id: u128) -> Result<(), PayrollErro
     }
 
     // Invariant check
-    assert!(claimed_periods <= num_periods, "Invariant violation: claimed_periods > num_periods");
+    assert!(
+        claimed_periods <= num_periods,
+        "Invariant violation: claimed_periods > num_periods"
+    );
 
     // Allow claims if:
     // 1. Agreement is Active, OR

--- a/onchain/contracts/stello_pay_contract/tests/backup_recovery_tests.rs
+++ b/onchain/contracts/stello_pay_contract/tests/backup_recovery_tests.rs
@@ -102,7 +102,10 @@ fn test_serialize_deserialize_payroll_agreement() {
     assert_eq!(recovered.created_at, original.created_at);
     assert_eq!(recovered.activated_at, original.activated_at);
     assert_eq!(recovered.cancelled_at, original.cancelled_at);
-    assert_eq!(recovered.grace_period_seconds, original.grace_period_seconds);
+    assert_eq!(
+        recovered.grace_period_seconds,
+        original.grace_period_seconds
+    );
     assert_eq!(recovered.dispute_status, original.dispute_status);
     assert_eq!(recovered.dispute_raised_at, original.dispute_raised_at);
     assert_eq!(recovered.amount_per_period, original.amount_per_period);
@@ -482,7 +485,10 @@ fn test_two_backups_produce_different_envelopes() {
     let envelope1 = backup_agreement(&env, &agreement, passphrase, &TEST_SALT, &TEST_NONCE);
     let envelope2 = backup_agreement(&env, &agreement, passphrase, &TEST_SALT_2, &TEST_NONCE_2);
 
-    assert_ne!(envelope1, envelope2, "different salt/nonce must produce distinct envelopes");
+    assert_ne!(
+        envelope1, envelope2,
+        "different salt/nonce must produce distinct envelopes"
+    );
 }
 
 #[test]

--- a/onchain/contracts/stello_pay_contract/tests/gas_benchmarks.rs
+++ b/onchain/contracts/stello_pay_contract/tests/gas_benchmarks.rs
@@ -427,5 +427,8 @@ fn gas_benchmark_edge_unauthorized_caller() {
         .try_claim_payroll(&impostor, &agreement_id, &0u32)
         .unwrap_err()
         .unwrap();
-    assert_eq!(err, stello_pay_contract::storage::PayrollError::Unauthorized);
+    assert_eq!(
+        err,
+        stello_pay_contract::storage::PayrollError::Unauthorized
+    );
 }

--- a/onchain/contracts/stello_pay_contract/tests/invariant_tests.rs
+++ b/onchain/contracts/stello_pay_contract/tests/invariant_tests.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, Vec,
+};
 use stello_pay_contract::storage::{AgreementMode, AgreementStatus, DataKey, Milestone};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
@@ -21,10 +24,15 @@ fn setup_contract(env: &Env) -> (Address, PayrollContractClient<'static>) {
 fn setup_token<'a>(
     env: &'a Env,
     admin: &Address,
-) -> (Address, soroban_sdk::token::Client<'a>, soroban_sdk::token::StellarAssetClient<'a>) {
+) -> (
+    Address,
+    soroban_sdk::token::Client<'a>,
+    soroban_sdk::token::StellarAssetClient<'a>,
+) {
     let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
     let token_client = soroban_sdk::token::Client::new(env, &token_contract.address());
-    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(env, &token_contract.address());
+    let token_admin_client =
+        soroban_sdk::token::StellarAssetClient::new(env, &token_contract.address());
     (token_contract.address(), token_client, token_admin_client)
 }
 
@@ -34,10 +42,10 @@ fn test_invariant_escrow_claimed_periods_limit() {
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let contributor = Address::generate(&env);
-    
+
     // Create escrow agreement with 2 periods
     let agreement_id = client.create_escrow_agreement(
         &employer,
@@ -47,22 +55,22 @@ fn test_invariant_escrow_claimed_periods_limit() {
         &3600u64,
         &2u32,
     );
-    
+
     // Fund contract
     token_admin_client.mint(&contract_id, &2000i128);
     env.as_contract(&contract_id, || {
         DataKey::set_agreement_escrow_balance(&env, agreement_id, &token_id, 2000i128);
     });
     client.activate_agreement(&agreement_id);
-    
+
     // Jump 1 hour - claim 1 period
     env.ledger().with_mut(|l| l.timestamp = 3600);
     client.claim_time_based(&agreement_id);
-    
+
     // Jump another hour - claim 2nd period
     env.ledger().with_mut(|l| l.timestamp = 7200);
     client.claim_time_based(&agreement_id);
-    
+
     // Verification: agreement is completed
     let agreement = client.get_agreement(&agreement_id).unwrap();
     assert_eq!(agreement.status, AgreementStatus::Completed);
@@ -75,14 +83,14 @@ fn test_invariant_milestone_balance_insufficient() {
     let (_contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, _token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let contributor = Address::generate(&env);
-    
+
     let agreement_id = client.create_milestone_agreement(&employer, &contributor, &token_id);
     client.add_milestone(&agreement_id, &1000i128);
     client.add_milestone(&agreement_id, &2000i128);
-    
+
     // Total unclaimed = 3000. Contract balance = 0.
     // Approving a milestone should trigger the invariant check.
     client.approve_milestone(&agreement_id, &1u32);
@@ -94,53 +102,53 @@ fn test_invariant_milestone_balance_sufficient() {
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let contributor = Address::generate(&env);
-    
+
     let agreement_id = client.create_milestone_agreement(&employer, &contributor, &token_id);
     client.add_milestone(&agreement_id, &1000i128);
-    
+
     // Fund contract
     token_admin_client.mint(&employer, &1000i128);
     client.fund_milestone_agreement(&agreement_id, &employer, &1000i128);
-    
+
     // Should succeed
     client.approve_milestone(&agreement_id, &1u32);
 }
 
 #[test]
-#[should_panic(expected = "Invariant violation: funded escrow balance < sum of unclaimed milestones")]
+#[should_panic(
+    expected = "Invariant violation: funded escrow balance < sum of unclaimed milestones"
+)]
 fn test_invariant_milestone_claim_insufficient_balance() {
     let env = create_test_env();
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let contributor = Address::generate(&env);
-    
+
     let agreement_id = client.create_milestone_agreement(&employer, &contributor, &token_id);
     client.add_milestone(&agreement_id, &1000i128);
-    
+
     // Fund contract
     token_admin_client.mint(&employer, &1000i128);
     client.fund_milestone_agreement(&agreement_id, &employer, &1000i128);
     client.approve_milestone(&agreement_id, &1u32);
-    
+
     // Now someone steals the funds from the contract (mocked by manual balance update)
     env.as_contract(&contract_id, || {
         use stello_pay_contract::storage::MilestoneKey;
-        env.storage().instance().set(
-            &MilestoneKey::MilestoneEscrowBalance(agreement_id),
-            &0i128,
-        );
+        env.storage()
+            .instance()
+            .set(&MilestoneKey::MilestoneEscrowBalance(agreement_id), &0i128);
     });
-    
+
     // Claim should fail due to invariant
     client.claim_milestone(&agreement_id, &1u32);
 }
-
 
 /// **Conservation invariant: Total escrow must equal paid + remaining at all times**
 ///
@@ -152,14 +160,14 @@ fn test_invariant_escrow_conservation_across_lifecycle() {
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let contributor = Address::generate(&env);
-    
+
     let amount_per_period = 500i128;
     let num_periods = 4u32;
     let total_amount = amount_per_period * (num_periods as i128);
-    
+
     // Create agreement
     let agreement_id = client.create_escrow_agreement(
         &employer,
@@ -169,14 +177,14 @@ fn test_invariant_escrow_conservation_across_lifecycle() {
         &3600u64,
         &num_periods,
     );
-    
+
     // Fund and activate
     token_admin_client.mint(&contract_id, &total_amount);
     env.as_contract(&contract_id, || {
         DataKey::set_agreement_escrow_balance(&env, agreement_id, &token_id, total_amount);
     });
     client.activate_agreement(&agreement_id);
-    
+
     // Helper: Assert conservation at every step
     let assert_conservation = || {
         env.as_contract(&contract_id, || {
@@ -186,13 +194,15 @@ fn test_invariant_escrow_conservation_across_lifecycle() {
                 remaining + paid,
                 total_amount,
                 "Conservation violated: remaining={}, paid={}, total={}",
-                remaining, paid, total_amount
+                remaining,
+                paid,
+                total_amount
             );
         });
     };
-    
+
     assert_conservation();
-    
+
     // Claim each period and verify conservation
     for i in 1..=num_periods {
         env.ledger().with_mut(|l| l.timestamp = 3600 * (i as u64));
@@ -211,26 +221,26 @@ fn test_invariant_payroll_multi_employee_conservation() {
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let employee1 = Address::generate(&env);
     let employee2 = Address::generate(&env);
     let employee3 = Address::generate(&env);
-    
+
     let agreement_id = client.create_payroll_agreement(&employer, &token_id, &604800);
-    
+
     let salary1 = 1000i128;
     let salary2 = 1500i128;
     let salary3 = 2000i128;
     let total_salary = salary1 + salary2 + salary3;
-    
+
     client.add_employee_to_agreement(&agreement_id, &employee1, &salary1);
     client.add_employee_to_agreement(&agreement_id, &employee2, &salary2);
     client.add_employee_to_agreement(&agreement_id, &employee3, &salary3);
-    
+
     let initial_escrow = total_salary * 10;
     token_admin_client.mint(&contract_id, &initial_escrow);
-    
+
     // Setup DataKey storage
     env.as_contract(&contract_id, || {
         DataKey::set_agreement_activation_time(&env, agreement_id, env.ledger().timestamp());
@@ -248,9 +258,9 @@ fn test_invariant_payroll_multi_employee_conservation() {
         DataKey::set_employee_salary(&env, agreement_id, 2, salary3);
         DataKey::set_employee_claimed_periods(&env, agreement_id, 2, 0);
     });
-    
+
     client.activate_agreement(&agreement_id);
-    
+
     let assert_conservation = || {
         env.as_contract(&contract_id, || {
             let remaining = DataKey::get_agreement_escrow_balance(&env, agreement_id, &token_id);
@@ -259,21 +269,23 @@ fn test_invariant_payroll_multi_employee_conservation() {
                 remaining + paid,
                 initial_escrow,
                 "Conservation violated: {}  + {} != {}",
-                remaining, paid, initial_escrow
+                remaining,
+                paid,
+                initial_escrow
             );
         });
     };
-    
+
     // Claim for different employees across periods
     for _ in 0..3 {
         env.ledger().with_mut(|l| l.timestamp += 86400);
-        
+
         client.try_claim_payroll(&employee1, &agreement_id, &0).ok();
         assert_conservation();
-        
+
         client.try_claim_payroll(&employee2, &agreement_id, &1).ok();
         assert_conservation();
-        
+
         client.try_claim_payroll(&employee3, &agreement_id, &2).ok();
         assert_conservation();
     }
@@ -289,69 +301,67 @@ fn test_invariant_dispute_resolution_bounds() {
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let arbiter = Address::generate(&env);
     let employee1 = Address::generate(&env);
     let employee2 = Address::generate(&env);
     let employee3 = Address::generate(&env);
-    
+
     client.set_arbiter(&employer, &arbiter);
-    
+
     let agreement_id = client.create_payroll_agreement(&employer, &token_id, &604800);
-    
+
     client.add_employee_to_agreement(&agreement_id, &employee1, &100);
     client.add_employee_to_agreement(&agreement_id, &employee2, &100);
     client.add_employee_to_agreement(&agreement_id, &employee3, &100);
-    
+
     // Use an amount that creates integer division dust (1000 / 3 = 333.33...)
     let escrow_balance = 1000i128;
     token_admin_client.mint(&contract_id, &escrow_balance);
-    
+
     env.as_contract(&contract_id, || {
         DataKey::set_agreement_escrow_balance(&env, agreement_id, &token_id, escrow_balance);
     });
-    
+
     client.activate_agreement(&agreement_id);
-    
+
     // Raise dispute
     client.raise_dispute(&employer, &agreement_id);
-    
+
     // Resolve: 700 to employees, 300 to employer
     let employee_payout = 700i128;
     let employer_refund = 300i128;
-    
+
     let initial_total = employee_payout + employer_refund;
     assert_eq!(initial_total, escrow_balance);
-    
+
     // Track balances before
     let emp1_before = token_client.balance(&employee1);
     let emp2_before = token_client.balance(&employee2);
     let emp3_before = token_client.balance(&employee3);
     let employer_before = token_client.balance(&employer);
-    
+
     client.resolve_dispute(&arbiter, &agreement_id, &employee_payout, &employer_refund);
-    
+
     // Verify total distributed equals escrow (no creation or loss of funds)
     let emp1_after = token_client.balance(&employee1);
     let emp2_after = token_client.balance(&employee2);
     let emp3_after = token_client.balance(&employee3);
     let employer_after = token_client.balance(&employer);
-    
-    let total_distributed = 
-        (emp1_after - emp1_before) +
-        (emp2_after - emp2_before) +
-        (emp3_after - emp3_before) +
-        (employer_after - employer_before);
-    
+
+    let total_distributed = (emp1_after - emp1_before)
+        + (emp2_after - emp2_before)
+        + (emp3_after - emp3_before)
+        + (employer_after - employer_before);
+
     // **Invariant: Total distributed must equal initial escrow**
     assert_eq!(
-        total_distributed,
-        escrow_balance,
+        total_distributed, escrow_balance,
         "Total distributed ({}) != escrow balance ({})",
         total_distributed, escrow_balance
     );
-    
+
     // Verify minimal remaining dust
     env.as_contract(&contract_id, || {
         let remaining = DataKey::get_agreement_escrow_balance(&env, agreement_id, &token_id);
@@ -374,17 +384,17 @@ fn test_invariant_claimed_periods_monotonic_bounded() {
     let (contract_id, client) = setup_contract(&env);
     let token_admin = Address::generate(&env);
     let (token_id, _token_client, token_admin_client) = setup_token(&env, &token_admin);
-    
+
     let employer = Address::generate(&env);
     let employee = Address::generate(&env);
-    
+
     let agreement_id = client.create_payroll_agreement(&employer, &token_id, &604800);
     client.add_employee_to_agreement(&agreement_id, &employee, &1000);
-    
+
     let max_periods = 5u32;
     let escrow = 1000 * (max_periods as i128);
     token_admin_client.mint(&contract_id, &escrow);
-    
+
     env.as_contract(&contract_id, || {
         DataKey::set_agreement_activation_time(&env, agreement_id, env.ledger().timestamp());
         DataKey::set_agreement_period_duration(&env, agreement_id, 3600);
@@ -395,33 +405,35 @@ fn test_invariant_claimed_periods_monotonic_bounded() {
         DataKey::set_employee_salary(&env, agreement_id, 0, 1000);
         DataKey::set_employee_claimed_periods(&env, agreement_id, 0, 0);
     });
-    
+
     client.activate_agreement(&agreement_id);
-    
+
     let mut prev_claimed = 0u32;
-    
+
     // Attempt to claim beyond max_periods
     for _ in 0..max_periods + 3 {
         env.ledger().with_mut(|l| l.timestamp += 3600);
         client.try_claim_payroll(&employee, &agreement_id, &0).ok();
-        
+
         env.as_contract(&contract_id, || {
             let claimed = DataKey::get_employee_claimed_periods(&env, agreement_id, 0);
-            
+
             // **Invariant 1: Monotonic**
             assert!(
                 claimed >= prev_claimed,
                 "claimed_periods decreased: {} < {}",
-                claimed, prev_claimed
+                claimed,
+                prev_claimed
             );
-            
+
             // **Invariant 2: Bounded**
             assert!(
                 claimed <= max_periods,
                 "claimed_periods ({}) exceeded max ({})",
-                claimed, max_periods
+                claimed,
+                max_periods
             );
-            
+
             prev_claimed = claimed;
         });
     }

--- a/onchain/contracts/stello_pay_contract/tests/price_oracle_integration_tests.rs
+++ b/onchain/contracts/stello_pay_contract/tests/price_oracle_integration_tests.rs
@@ -175,8 +175,7 @@ fn seed_payroll_agreement(
     escrow_amount: i128,
 ) -> u128 {
     let grace_period: u64 = 7 * 24 * 3600;
-    let agreement_id =
-        payroll_client.create_payroll_agreement(employer, base_token, &grace_period);
+    let agreement_id = payroll_client.create_payroll_agreement(employer, base_token, &grace_period);
     payroll_client.add_employee_to_agreement(&agreement_id, employee, &salary_per_period);
     payroll_client.activate_agreement(&agreement_id);
 
@@ -229,7 +228,10 @@ fn test_oracle_push_propagates_rate_and_claim_converts_correctly() {
 
     // Verify the rate landed in the payroll contract.
     let converted = payroll_client.convert_currency(&base, &quote, &1_000i128);
-    assert_eq!(converted, 2_000, "1_000 base × 2.0 should equal 2_000 quote");
+    assert_eq!(
+        converted, 2_000,
+        "1_000 base × 2.0 should equal 2_000 quote"
+    );
 
     // Set up a payroll agreement denominated in base, funded in quote.
     let employer = Address::generate(&env);
@@ -311,9 +313,7 @@ fn test_claim_in_token_without_oracle_rate_returns_exchange_rate_not_found() {
     let _ = payroll_id;
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
     let quote_admin = Address::generate(&env);
     let quote = env
         .register_stellar_asset_contract_v2(quote_admin)
@@ -343,8 +343,7 @@ fn test_claim_in_token_without_oracle_rate_returns_exchange_rate_not_found() {
     // Advance one period — but NO rate has been set.
     env.ledger().with_mut(|li| li.timestamp += period_seconds);
 
-    let result =
-        payroll_client.try_claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
+    let result = payroll_client.try_claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
 
     assert_eq!(
         result,
@@ -400,10 +399,7 @@ fn test_oracle_rejects_stale_price_and_payroll_rate_unchanged() {
     let result = oracle_client.try_push_price(&source, &base, &quote, &stale_rate, &1_000u64);
 
     // Oracle must reject the stale submission.
-    assert!(
-        result.is_err(),
-        "Oracle must reject stale price submission"
-    );
+    assert!(result.is_err(), "Oracle must reject stale price submission");
 
     // Payroll rate must remain at the initial value.
     assert_eq!(
@@ -425,8 +421,7 @@ fn test_oracle_rejects_future_timestamp() {
         full_setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
-    let result =
-        oracle_client.try_push_price(&source, &base, &quote, &(2 * FX_SCALE), &1_001u64);
+    let result = oracle_client.try_push_price(&source, &base, &quote, &(2 * FX_SCALE), &1_001u64);
 
     assert!(result.is_err(), "Future timestamp must be rejected");
 
@@ -460,7 +455,10 @@ fn test_oracle_rejects_rate_below_min_and_payroll_unchanged() {
     assert!(result.is_err(), "Rate below min must be rejected");
 
     let result2 = payroll_client.try_convert_currency(&base, &quote, &1_000i128);
-    assert!(result2.is_err(), "No rate should exist after out-of-bounds rejection");
+    assert!(
+        result2.is_err(),
+        "No rate should exist after out-of-bounds rejection"
+    );
 
     let _ = payroll_owner;
 }
@@ -476,12 +474,14 @@ fn test_oracle_rejects_rate_above_max_and_payroll_unchanged() {
 
     env.ledger().with_mut(|li| li.timestamp = 1_000);
     // MAX_RATE = 10_000_000; submit 10_000_001.
-    let result =
-        oracle_client.try_push_price(&source, &base, &quote, &10_000_001i128, &1_000u64);
+    let result = oracle_client.try_push_price(&source, &base, &quote, &10_000_001i128, &1_000u64);
     assert!(result.is_err(), "Rate above max must be rejected");
 
     let result2 = payroll_client.try_convert_currency(&base, &quote, &1_000i128);
-    assert!(result2.is_err(), "No rate should exist after out-of-bounds rejection");
+    assert!(
+        result2.is_err(),
+        "No rate should exist after out-of-bounds rejection"
+    );
 
     let _ = payroll_owner;
 }
@@ -500,7 +500,10 @@ fn test_oracle_rejects_zero_rate() {
     assert!(result.is_err(), "Zero rate must be rejected");
 
     let result2 = payroll_client.try_convert_currency(&base, &quote, &1_000i128);
-    assert!(result2.is_err(), "No rate should exist after zero-rate rejection");
+    assert!(
+        result2.is_err(),
+        "No rate should exist after zero-rate rejection"
+    );
 
     let _ = payroll_owner;
 }
@@ -556,8 +559,7 @@ fn test_quorum_n2_requires_two_sources_before_rate_propagates() {
 
     let converted = payroll_client.convert_currency(&base, &quote, &1_000i128);
     assert_eq!(
-        converted,
-        3_000,
+        converted, 3_000,
         "Rate must propagate after quorum is reached"
     );
 }
@@ -599,7 +601,10 @@ fn test_quorum_duplicate_vote_rejected() {
 
     // Rate must still not have propagated.
     let result2 = payroll_client.try_convert_currency(&base, &quote, &1_000i128);
-    assert!(result2.is_err(), "Rate must not propagate after duplicate vote");
+    assert!(
+        result2.is_err(),
+        "Rate must not propagate after duplicate vote"
+    );
 }
 
 // ============================================================================
@@ -620,7 +625,10 @@ fn test_disabled_oracle_pair_cannot_update_payroll_rate() {
     let initial_rate: i128 = 2 * FX_SCALE;
     env.ledger().with_mut(|li| li.timestamp = 1_000);
     oracle_client.push_price(&source, &base, &quote, &initial_rate, &1_000u64);
-    assert_eq!(payroll_client.convert_currency(&base, &quote, &1_000i128), 2_000);
+    assert_eq!(
+        payroll_client.convert_currency(&base, &quote, &1_000i128),
+        2_000
+    );
 
     // Disable the pair.
     oracle_client.disable_pair(&oracle_owner, &base, &quote);
@@ -683,9 +691,7 @@ fn test_rate_update_propagates_to_subsequent_claims() {
     oracle_client.add_source(&oracle_owner, &source);
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
     let quote_admin = Address::generate(&env);
     let quote = env
         .register_stellar_asset_contract_v2(quote_admin)
@@ -775,9 +781,7 @@ fn test_claim_in_same_token_does_not_require_fx_rate() {
     let _ = (payroll_id, payroll_owner);
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
 
     let employer = Address::generate(&env);
     let employee = Address::generate(&env);
@@ -832,9 +836,7 @@ fn test_overflow_in_conversion_returns_exchange_rate_overflow() {
     let _ = payroll_id;
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
     let quote_admin = Address::generate(&env);
     let quote = env
         .register_stellar_asset_contract_v2(quote_admin)
@@ -868,8 +870,7 @@ fn test_overflow_in_conversion_returns_exchange_rate_overflow() {
 
     env.ledger().with_mut(|li| li.timestamp += period_seconds);
 
-    let result =
-        payroll_client.try_claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
+    let result = payroll_client.try_claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
 
     assert_eq!(
         result,
@@ -898,9 +899,7 @@ fn test_multi_period_claim_converts_accumulated_salary() {
     let _ = payroll_id;
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
     let quote_admin = Address::generate(&env);
     let quote = env
         .register_stellar_asset_contract_v2(quote_admin)
@@ -931,7 +930,8 @@ fn test_multi_period_claim_converts_accumulated_salary() {
     quote_asset_client.mint(&payroll_client.address, &escrow_amount);
 
     // Advance 3 full periods.
-    env.ledger().with_mut(|li| li.timestamp += 3 * period_seconds);
+    env.ledger()
+        .with_mut(|li| li.timestamp += 3 * period_seconds);
 
     payroll_client.claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
 
@@ -1043,7 +1043,10 @@ fn test_monotonic_oracle_update_does_not_overwrite_newer_rate_in_payroll() {
     // Push a fresh rate at t=2_000.
     env.ledger().with_mut(|li| li.timestamp = 2_000);
     oracle_client.push_price(&source, &base, &quote, &(3 * FX_SCALE), &2_000u64);
-    assert_eq!(payroll_client.convert_currency(&base, &quote, &1_000i128), 3_000);
+    assert_eq!(
+        payroll_client.convert_currency(&base, &quote, &1_000i128),
+        3_000
+    );
 
     // Attempt to push an older rate (t=1_500) — must be silently ignored.
     env.ledger().with_mut(|li| li.timestamp = 2_100);
@@ -1072,9 +1075,7 @@ fn test_pair_direction_isolation_in_payroll() {
     let _ = payroll_id;
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
     let quote_admin = Address::generate(&env);
     let quote = env
         .register_stellar_asset_contract_v2(quote_admin)
@@ -1084,7 +1085,10 @@ fn test_pair_direction_isolation_in_payroll() {
     payroll_client.set_exchange_rate(&payroll_owner, &base, &quote, &(2 * FX_SCALE));
 
     // (base → quote) works.
-    assert_eq!(payroll_client.convert_currency(&base, &quote, &1_000i128), 2_000);
+    assert_eq!(
+        payroll_client.convert_currency(&base, &quote, &1_000i128),
+        2_000
+    );
 
     // (quote → base) must fail — no rate configured.
     let result = payroll_client.try_convert_currency(&quote, &base, &1_000i128);
@@ -1109,9 +1113,7 @@ fn test_insufficient_payout_escrow_returns_error() {
     let _ = payroll_id;
 
     let base_admin = Address::generate(&env);
-    let base = env
-        .register_stellar_asset_contract_v2(base_admin)
-        .address();
+    let base = env.register_stellar_asset_contract_v2(base_admin).address();
     let quote_admin = Address::generate(&env);
     let quote = env
         .register_stellar_asset_contract_v2(quote_admin)
@@ -1144,8 +1146,7 @@ fn test_insufficient_payout_escrow_returns_error() {
 
     env.ledger().with_mut(|li| li.timestamp += period_seconds);
 
-    let result =
-        payroll_client.try_claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
+    let result = payroll_client.try_claim_payroll_in_token(&employee, &agreement_id, &0u32, &quote);
 
     assert_eq!(
         result,
@@ -1154,7 +1155,11 @@ fn test_insufficient_payout_escrow_returns_error() {
     );
 
     let quote_token = soroban_sdk::token::Client::new(&env, &quote);
-    assert_eq!(quote_token.balance(&employee), 0, "No tokens transferred on failure");
+    assert_eq!(
+        quote_token.balance(&employee),
+        0,
+        "No tokens transferred on failure"
+    );
     assert_eq!(
         payroll_client.get_employee_claimed_periods(&agreement_id, &0u32),
         0,

--- a/onchain/contracts/stello_pay_contract/tests/test_boundary_conditions.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_boundary_conditions.rs
@@ -806,7 +806,7 @@ fn test_claim_milestone_id_zero_panics() {
 
     let agreement_id = client.create_milestone_agreement(&employer, &contributor, &token);
     client.add_milestone(&agreement_id, &1000i128);
-    
+
     // Fund contract to satisfy invariant during approval
     token_client.mint(&_contract_id, &1000i128);
     client.approve_milestone(&agreement_id, &1u32);

--- a/onchain/contracts/stello_pay_contract/tests/test_dispute_integration.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_dispute_integration.rs
@@ -19,7 +19,11 @@ fn stellar_token<'a>(
     admin: &Address,
 ) -> (Address, token::Client<'a>, token::StellarAssetClient<'a>) {
     let t = e.register_stellar_asset_contract_v2(admin.clone());
-    (t.address(), token::Client::new(e, &t.address()), token::StellarAssetClient::new(e, &t.address()))
+    (
+        t.address(),
+        token::Client::new(e, &t.address()),
+        token::StellarAssetClient::new(e, &t.address()),
+    )
 }
 
 /// Payroll mode: arbiter split distributes pay_employee equally among employees.

--- a/onchain/contracts/stello_pay_contract/tests/test_disputes.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_disputes.rs
@@ -1,9 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{
-    testutils::Address as _,
-    token, Address, Env,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
 use stello_pay_contract::storage::{DisputeStatus, PayrollError};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
@@ -42,7 +39,7 @@ fn test_full_dispute_flow_resolved_by_arbiter() {
     let contributor = Address::generate(&env);
 
     payroll_client.set_arbiter(&employer, &arbiter);
-    
+
     // 1. Create Escrow
     let amount_per_period = 1000_i128;
     let agreement_id = payroll_client.create_escrow_agreement(
@@ -70,7 +67,7 @@ fn test_full_dispute_flow_resolved_by_arbiter() {
     // Verify state changed to Resolved
     let final_status = payroll_client.get_dispute_status(&agreement_id);
     assert_eq!(final_status, DisputeStatus::Resolved);
-    
+
     assert_eq!(token_client.balance(&contributor), 400);
     assert_eq!(token_client.balance(&employer), 600);
 }
@@ -86,10 +83,11 @@ fn test_raise_dispute_wrong_caller() {
     let contributor = Address::generate(&env);
     let token = Address::generate(&env);
 
-    let agreement_id = payroll_client.create_escrow_agreement(&employer, &contributor, &token, &1000, &86400, &1);
+    let agreement_id =
+        payroll_client.create_escrow_agreement(&employer, &contributor, &token, &1000, &86400, &1);
 
     let malicious_actor = Address::generate(&env);
-    
+
     // Should fail with NotParty error
     let result = payroll_client.try_raise_dispute(&malicious_actor, &agreement_id);
     assert_eq!(result, Err(Ok(PayrollError::NotParty)));
@@ -108,8 +106,9 @@ fn test_resolve_dispute_invalid_amounts() {
     let token = Address::generate(&env);
 
     payroll_client.set_arbiter(&employer, &arbiter);
-    
-    let agreement_id = payroll_client.create_escrow_agreement(&employer, &contributor, &token, &1000, &86400, &1);
+
+    let agreement_id =
+        payroll_client.create_escrow_agreement(&employer, &contributor, &token, &1000, &86400, &1);
     payroll_client.raise_dispute(&employer, &agreement_id);
 
     // Amounts sum to 1100, but escrow is only 1000
@@ -132,7 +131,7 @@ fn test_multi_employee_payout_split() {
     let employee2 = Address::generate(&env);
 
     payroll_client.set_arbiter(&employer, &arbiter);
-    
+
     let agreement_id = payroll_client.create_payroll_agreement(&employer, &token_address, &86400);
     payroll_client.add_employee_to_agreement(&agreement_id, &employee1, &100);
     payroll_client.add_employee_to_agreement(&agreement_id, &employee2, &100);
@@ -143,7 +142,10 @@ fn test_multi_employee_payout_split() {
     // Arbiter resolves, employee pool gets 150, employer gets 50
     payroll_client.resolve_dispute(&arbiter, &agreement_id, &150_i128, &50_i128);
 
-    assert_eq!(payroll_client.get_dispute_status(&agreement_id), DisputeStatus::Resolved);
+    assert_eq!(
+        payroll_client.get_dispute_status(&agreement_id),
+        DisputeStatus::Resolved
+    );
     // Pay is split equally among employees (150 / 2 = 75)
     assert_eq!(token_client.balance(&employee1), 75);
     assert_eq!(token_client.balance(&employee2), 75);

--- a/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{
     Address, Env, Vec,
 };
 
-use stello_pay_contract::storage::{DataKey, PayrollError};
 use stello_pay_contract::storage::ExchangeRateInfo;
+use stello_pay_contract::storage::{DataKey, PayrollError};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
 /// Create a fresh test environment with a deployed payroll contract, owner,

--- a/onchain/contracts/stello_pay_contract/tests/test_payment_failures.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_payment_failures.rs
@@ -941,10 +941,8 @@ fn test_batch_milestone_duplicate_invalid_id_processed_once() {
     let agreement_id = client.create_milestone_agreement(&employer, &contributor, &token);
     client.add_milestone(&agreement_id, &500);
 
-    let batch = client.batch_claim_milestones(
-        &agreement_id,
-        &Vec::from_array(&env, [99u32, 99u32, 1u32]),
-    );
+    let batch =
+        client.batch_claim_milestones(&agreement_id, &Vec::from_array(&env, [99u32, 99u32, 1u32]));
 
     assert_eq!(batch.successful_claims, 0);
     assert_eq!(batch.failed_claims, 3);

--- a/onchain/contracts/stello_pay_contract/tests/test_rate_limiter_integration.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_rate_limiter_integration.rs
@@ -25,7 +25,15 @@ fn setup_token(env: &Env) -> (Address, Address) {
     (token, admin)
 }
 
-fn setup(env: &Env) -> (Address, PayrollContractClient<'static>, RateLimiterClient<'static>, Address, Address) {
+fn setup(
+    env: &Env,
+) -> (
+    Address,
+    PayrollContractClient<'static>,
+    RateLimiterClient<'static>,
+    Address,
+    Address,
+) {
     let payroll_id = env.register_contract(None, PayrollContract);
     let payroll_client = PayrollContractClient::new(env, &payroll_id);
     let owner = addr(env);
@@ -33,7 +41,7 @@ fn setup(env: &Env) -> (Address, PayrollContractClient<'static>, RateLimiterClie
 
     let rl_id = env.register_contract(None, RateLimiter);
     let rl_client = RateLimiterClient::new(env, &rl_id);
-    
+
     // Initialize rate limiter: 2 token burst, 0 refill
     rl_client.initialize(&owner, &2, &0, &false);
 
@@ -48,10 +56,10 @@ fn test_rate_limited_claim() {
     let env = create_test_env();
     let (payroll_id, client, rl_client, owner, _) = setup(&env);
     let (token, _token_admin) = setup_token(&env);
-    
+
     let employer = addr(&env);
     let employee = addr(&env);
-    
+
     // Create payroll
     let agreement_id = client.create_payroll_agreement(&employer, &token, &3600);
     client.add_employee_to_agreement(&agreement_id, &employee, &1000);
@@ -59,17 +67,35 @@ fn test_rate_limited_claim() {
 
     // Setup DataKey storage for claiming
     env.as_contract(&payroll_id, || {
-        stello_pay_contract::storage::DataKey::set_agreement_activation_time(&env, agreement_id, env.ledger().timestamp());
-        stello_pay_contract::storage::DataKey::set_agreement_period_duration(&env, agreement_id, 3600);
+        stello_pay_contract::storage::DataKey::set_agreement_activation_time(
+            &env,
+            agreement_id,
+            env.ledger().timestamp(),
+        );
+        stello_pay_contract::storage::DataKey::set_agreement_period_duration(
+            &env,
+            agreement_id,
+            3600,
+        );
         stello_pay_contract::storage::DataKey::set_agreement_token(&env, agreement_id, &token);
-        
+
         stello_pay_contract::storage::DataKey::set_employee(&env, agreement_id, 0, &employee);
         stello_pay_contract::storage::DataKey::set_employee_salary(&env, agreement_id, 0, 1000);
-        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(&env, agreement_id, 0, 0);
-        
+        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(
+            &env,
+            agreement_id,
+            0,
+            0,
+        );
+
         stello_pay_contract::storage::DataKey::set_employee_count(&env, agreement_id, 1);
-        
-        stello_pay_contract::storage::DataKey::set_agreement_escrow_balance(&env, agreement_id, &token, 10000000);
+
+        stello_pay_contract::storage::DataKey::set_agreement_escrow_balance(
+            &env,
+            agreement_id,
+            &token,
+            10000000,
+        );
     });
 
     // Fund it
@@ -79,22 +105,24 @@ fn test_rate_limited_claim() {
     // Advance time by 3 periods (simulate 1 period = 30 days roughly, though period defaults to month if not escrow)
 
     // Wait, payroll agreement periods logic: 30 days is default period if not escrow
-    env.ledger().with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
+    env.ledger()
+        .with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
 
-    
     // First claim should succeed (consumes 1 rate limit token)
     let res1 = client.try_claim_payroll(&employee, &agreement_id, &0);
     assert_eq!(res1, Ok(Ok(())));
-    
+
     // Advance time again to accrue more payroll
-    env.ledger().with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
+    env.ledger()
+        .with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
 
     // Second claim should succeed (consumes 2nd rate limit token)
     let res2 = client.try_claim_payroll(&employee, &agreement_id, &0);
     assert_eq!(res2, Ok(Ok(())));
 
     // Advance time again to accrue more payroll
-    env.ledger().with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
+    env.ledger()
+        .with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
 
     // Third claim should fail (0 rate limit tokens left)
     let res3 = client.try_claim_payroll(&employee, &agreement_id, &0);
@@ -106,12 +134,12 @@ fn test_batch_claim_rate_limited() {
     let env = create_test_env();
     let (payroll_id, client, _, _owner, _) = setup(&env);
     let (token, _token_admin) = setup_token(&env);
-    
+
     let employer = addr(&env);
     let employee1 = addr(&env);
     let employee2 = addr(&env);
     let employee3 = addr(&env);
-    
+
     // Create payroll
     let agreement_id = client.create_payroll_agreement(&employer, &token, &3600);
     client.add_employee_to_agreement(&agreement_id, &employee1, &1000);
@@ -121,25 +149,53 @@ fn test_batch_claim_rate_limited() {
 
     // Setup DataKey storage for claiming
     env.as_contract(&payroll_id, || {
-        stello_pay_contract::storage::DataKey::set_agreement_activation_time(&env, agreement_id, env.ledger().timestamp());
-        stello_pay_contract::storage::DataKey::set_agreement_period_duration(&env, agreement_id, 3600);
+        stello_pay_contract::storage::DataKey::set_agreement_activation_time(
+            &env,
+            agreement_id,
+            env.ledger().timestamp(),
+        );
+        stello_pay_contract::storage::DataKey::set_agreement_period_duration(
+            &env,
+            agreement_id,
+            3600,
+        );
         stello_pay_contract::storage::DataKey::set_agreement_token(&env, agreement_id, &token);
-        
+
         stello_pay_contract::storage::DataKey::set_employee(&env, agreement_id, 0, &employee1);
         stello_pay_contract::storage::DataKey::set_employee_salary(&env, agreement_id, 0, 1000);
-        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(&env, agreement_id, 0, 0);
+        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(
+            &env,
+            agreement_id,
+            0,
+            0,
+        );
 
         stello_pay_contract::storage::DataKey::set_employee(&env, agreement_id, 1, &employee2);
         stello_pay_contract::storage::DataKey::set_employee_salary(&env, agreement_id, 1, 1000);
-        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(&env, agreement_id, 1, 0);
+        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(
+            &env,
+            agreement_id,
+            1,
+            0,
+        );
 
         stello_pay_contract::storage::DataKey::set_employee(&env, agreement_id, 2, &employee3);
         stello_pay_contract::storage::DataKey::set_employee_salary(&env, agreement_id, 2, 1000);
-        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(&env, agreement_id, 2, 0);
-        
+        stello_pay_contract::storage::DataKey::set_employee_claimed_periods(
+            &env,
+            agreement_id,
+            2,
+            0,
+        );
+
         stello_pay_contract::storage::DataKey::set_employee_count(&env, agreement_id, 3);
-        
-        stello_pay_contract::storage::DataKey::set_agreement_escrow_balance(&env, agreement_id, &token, 1000000);
+
+        stello_pay_contract::storage::DataKey::set_agreement_escrow_balance(
+            &env,
+            agreement_id,
+            &token,
+            1000000,
+        );
     });
 
     // Fund it
@@ -147,17 +203,28 @@ fn test_batch_claim_rate_limited() {
     TokenClient::new(&env, &token).transfer(&employer, &client.address, &3000000);
 
     // Fast forward
-    env.ledger().with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
-    
+    env.ledger()
+        .with_mut(|li| li.timestamp = li.timestamp + 30 * 24 * 3600);
+
     let mut indices = Vec::new(&env);
     indices.push_back(0);
 
     // Claim 1
-    assert_eq!(client.try_batch_claim_payroll(&employee1, &agreement_id, &indices).is_ok(), true);
-    
+    assert_eq!(
+        client
+            .try_batch_claim_payroll(&employee1, &agreement_id, &indices)
+            .is_ok(),
+        true
+    );
+
     // Claim 2
-    assert_eq!(client.try_batch_claim_payroll(&employee1, &agreement_id, &indices).is_ok(), true);
-    
+    assert_eq!(
+        client
+            .try_batch_claim_payroll(&employee1, &agreement_id, &indices)
+            .is_ok(),
+        true
+    );
+
     // Claim 3 -> limited
     let res3 = client.try_batch_claim_payroll(&employee1, &agreement_id, &indices);
     assert_eq!(res3, Err(Ok(PayrollError::RateLimited)));

--- a/onchain/contracts/stello_pay_contract/tests/test_time_based_claims.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_time_based_claims.rs
@@ -46,15 +46,14 @@ fn create_funded_time_based_agreement(
     amount_per_period: i128,
     num_periods: u32,
 ) -> u128 {
-    let agreement_id = client
-        .create_escrow_agreement(
-            employer,
-            contributor,
-            token,
-            &amount_per_period,
-            &PERIOD_SECONDS,
-            &num_periods,
-        );
+    let agreement_id = client.create_escrow_agreement(
+        employer,
+        contributor,
+        token,
+        &amount_per_period,
+        &PERIOD_SECONDS,
+        &num_periods,
+    );
     let total = amount_per_period * i128::from(num_periods);
 
     StellarAssetClient::new(env, token).mint(&client.address, &total);

--- a/onchain/contracts/template_versioning/src/lib.rs
+++ b/onchain/contracts/template_versioning/src/lib.rs
@@ -89,7 +89,11 @@ impl TemplateVersioning {
     }
 
     /// Register a named template; returns a stable `template_id`. The authenticated `owner` may later publish versions.
-    pub fn register_template(env: Env, owner: Address, name: String) -> Result<u64, VersioningError> {
+    pub fn register_template(
+        env: Env,
+        owner: Address,
+        name: String,
+    ) -> Result<u64, VersioningError> {
         owner.require_auth();
         Self::require_initialized(&env)?;
         if name.is_empty() {
@@ -160,7 +164,8 @@ impl TemplateVersioning {
             return Err(VersioningError::Unauthorized);
         }
         let key = DataKey::TemplateVersion(template_id, version);
-        let mut rec: TemplateVersionRecord = storage.get(&key).ok_or(VersioningError::VersionNotFound)?;
+        let mut rec: TemplateVersionRecord =
+            storage.get(&key).ok_or(VersioningError::VersionNotFound)?;
         rec.deprecated = true;
         storage.set(&key, &rec);
         Ok(())

--- a/onchain/contracts/template_versioning/tests/test_versioning.rs
+++ b/onchain/contracts/template_versioning/tests/test_versioning.rs
@@ -2,7 +2,9 @@ use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     Address, BytesN, Env, String,
 };
-use template_versioning::{AgreementBinding, TemplateVersionRecord, TemplateVersioning, TemplateVersioningClient};
+use template_versioning::{
+    AgreementBinding, TemplateVersionRecord, TemplateVersioning, TemplateVersioningClient,
+};
 
 fn ledger_ts(env: &Env, ts: u64) {
     env.ledger().set(LedgerInfo {
@@ -33,10 +35,7 @@ fn template_version_lifecycle() {
     client.initialize(&admin);
 
     let tid = client
-        .try_register_template(
-            &employer,
-            &String::from_str(&env, "Standard payroll"),
-        )
+        .try_register_template(&employer, &String::from_str(&env, "Standard payroll"))
         .unwrap()
         .unwrap();
 
@@ -66,29 +65,15 @@ fn template_version_lifecycle() {
         .unwrap();
     assert_eq!(v2, 2);
 
-    assert_eq!(
-        client.try_latest_version(&tid).unwrap().unwrap(),
-        2
-    );
+    assert_eq!(client.try_latest_version(&tid).unwrap().unwrap(), 2);
 
-    let r1: TemplateVersionRecord = client
-        .try_get_version(&tid, &1)
-        .unwrap()
-        .unwrap();
+    let r1: TemplateVersionRecord = client.try_get_version(&tid, &1).unwrap().unwrap();
     assert_eq!(r1.schema_hash, h1);
-    let r2: TemplateVersionRecord = client
-        .try_get_version(&tid, &2)
-        .unwrap()
-        .unwrap();
+    let r2: TemplateVersionRecord = client.try_get_version(&tid, &2).unwrap().unwrap();
     assert_eq!(r2.version, 2);
 
     let aid = client
-        .try_create_agreement(
-            &employer,
-            &tid,
-            &1,
-            &String::from_str(&env, "Q1-2025"),
-        )
+        .try_create_agreement(&employer, &tid, &1, &String::from_str(&env, "Q1-2025"))
         .unwrap()
         .unwrap();
     let ag: AgreementBinding = client.try_get_agreement(&aid).unwrap().unwrap();
@@ -99,30 +84,15 @@ fn template_version_lifecycle() {
         .try_deprecate_version(&employer, &tid, &1)
         .unwrap()
         .unwrap();
-    let dep: TemplateVersionRecord = client
-        .try_get_version(&tid, &1)
-        .unwrap()
-        .unwrap();
+    let dep: TemplateVersionRecord = client.try_get_version(&tid, &1).unwrap().unwrap();
     assert!(dep.deprecated);
 
-    assert!(
-        client
-            .try_create_agreement(
-                &employer,
-                &tid,
-                &1,
-                &String::from_str(&env, "should fail"),
-            )
-            .is_err()
-    );
+    assert!(client
+        .try_create_agreement(&employer, &tid, &1, &String::from_str(&env, "should fail"),)
+        .is_err());
 
     let aid2 = client
-        .try_create_agreement(
-            &employer,
-            &tid,
-            &2,
-            &String::from_str(&env, "Q2-2025"),
-        )
+        .try_create_agreement(&employer, &tid, &2, &String::from_str(&env, "Q2-2025"))
         .unwrap()
         .unwrap();
     let ag2 = client.try_get_agreement(&aid2).unwrap().unwrap();
@@ -143,23 +113,12 @@ fn non_owner_cannot_publish() {
 
     client.initialize(&admin);
     let tid = client
-        .try_register_template(
-            &employer,
-            &String::from_str(&env, "T"),
-        )
+        .try_register_template(&employer, &String::from_str(&env, "T"))
         .unwrap()
         .unwrap();
 
     let h = BytesN::from_array(&env, &[9u8; 32]);
-    assert!(
-        client
-            .try_publish_template_version(
-                &attacker,
-                &tid,
-                &h,
-                &String::from_str(&env, "x"),
-                &false,
-            )
-            .is_err()
-    );
+    assert!(client
+        .try_publish_template_version(&attacker, &tid, &h, &String::from_str(&env, "x"), &false,)
+        .is_err());
 }

--- a/onchain/contracts/token_vesting/tests/test_vesting.rs
+++ b/onchain/contracts/token_vesting/tests/test_vesting.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env, IntoVal, Symbol, Vec, vec,
+    vec, Address, Env, IntoVal, Symbol, Vec,
 };
 
 use token_vesting::{
@@ -1288,8 +1288,8 @@ fn cliff_plus_linear_full_spectrum() {
     );
 
     let cases = [
-        (0, 0),    // before start + cliff
-        (10, 0),   // after start, before cliff
+        (0, 0),  // before start + cliff
+        (10, 0), // after start, before cliff
         (20, 0),
         (30, 300), // exactly at cliff -> 1000 * 30/100 = 300
         (40, 400),

--- a/onchain/integration_tests/tests/test_dispute_escalation_integration.rs
+++ b/onchain/integration_tests/tests/test_dispute_escalation_integration.rs
@@ -38,10 +38,7 @@ fn test_escalation_appeal_full_flow() {
     let id = 201u128;
 
     client.file_dispute(&user, &id);
-    assert_eq!(
-        client.get_dispute(&id).unwrap().status,
-        DisputeStatus::Open
-    );
+    assert_eq!(client.get_dispute(&id).unwrap().status, DisputeStatus::Open);
 
     client.escalate_dispute(&user, &id);
     let d = client.get_dispute(&id).unwrap();

--- a/onchain/integration_tests/tests/test_expense_audit_logger_integration.rs
+++ b/onchain/integration_tests/tests/test_expense_audit_logger_integration.rs
@@ -15,7 +15,7 @@ use soroban_sdk::{
     Address, Env, String, Symbol,
 };
 
-use audit_logger::{AuditLoggerContract, AuditLoggerContractClient, AuditLogEntry};
+use audit_logger::{AuditLogEntry, AuditLoggerContract, AuditLoggerContractClient};
 use expense_reimbursement::{
     ExpenseReimbursementContract, ExpenseReimbursementContractClient, ExpenseStatus,
 };
@@ -114,7 +114,8 @@ fn test_expense_approval_records_audit_log() {
     let audit_log_id = expense.audit_log_id.expect("audit_log_id should be Some");
     assert!(audit_log_id > 0, "audit_log_id should be positive");
 
-    let log_entry = audit_client.get_log(&audit_log_id)
+    let log_entry = audit_client
+        .get_log(&audit_log_id)
         .expect("Audit log entry should exist");
     assert_eq!(log_entry.actor, approver);
     assert_eq!(log_entry.action, Symbol::new(&env, "expense_approved"));
@@ -154,7 +155,10 @@ fn test_expense_rejection_does_not_create_audit_log() {
     expense_client.reject_expense(&approver, &eid);
     let expense = expense_client.get_expense(&eid).unwrap();
     assert_eq!(expense.status, ExpenseStatus::Rejected);
-    assert_eq!(expense.audit_log_id, None, "Rejected expense should not have audit_log_id");
+    assert_eq!(
+        expense.audit_log_id, None,
+        "Rejected expense should not have audit_log_id"
+    );
 }
 
 /// Verifies that approving without audit logger configured still works (no crash).
@@ -190,5 +194,8 @@ fn test_expense_approval_without_audit_logger() {
     expense_client.approve_expense(&approver, &eid, &500);
     let expense = expense_client.get_expense(&eid).unwrap();
     assert_eq!(expense.status, ExpenseStatus::Approved);
-    assert_eq!(expense.audit_log_id, None, "No audit logger means no audit_log_id");
+    assert_eq!(
+        expense.audit_log_id, None,
+        "No audit logger means no audit_log_id"
+    );
 }

--- a/onchain/integration_tests/tests/test_rbac_employee_roles_integration.rs
+++ b/onchain/integration_tests/tests/test_rbac_employee_roles_integration.rs
@@ -1,11 +1,10 @@
 #![cfg(test)]
 
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
-use employee_roles::{EmployeeRolesContract, EmployeeRolesContractClient, BuiltInRole, PayrollAction};
+use employee_roles::{
+    BuiltInRole, EmployeeRolesContract, EmployeeRolesContractClient, PayrollAction,
+};
 use rbac::{RbacContract, RbacContractClient, Role};
 
 /// Creates a test environment with all auths mocked.
@@ -39,17 +38,24 @@ fn deploy_employee_roles(env: &Env) -> (Address, EmployeeRolesContractClient<'_>
 }
 
 // Refined helpers for better control
-fn setup(env: &Env) -> (RbacContractClient<'_>, EmployeeRolesContractClient<'_>, Address, Address) {
+fn setup(
+    env: &Env,
+) -> (
+    RbacContractClient<'_>,
+    EmployeeRolesContractClient<'_>,
+    Address,
+    Address,
+) {
     let rbac_id = env.register_contract(None, RbacContract);
     let rbac_client = RbacContractClient::new(env, &rbac_id);
     let rbac_owner = addr(env);
     rbac_client.initialize(&rbac_owner);
-    
+
     let er_id = env.register_contract(None, EmployeeRolesContract);
     let er_client = EmployeeRolesContractClient::new(env, &er_id);
     let er_owner = addr(env);
     er_client.initialize(&er_owner);
-    
+
     (rbac_client, er_client, rbac_owner, er_owner)
 }
 
@@ -57,40 +63,40 @@ fn setup(env: &Env) -> (RbacContractClient<'_>, EmployeeRolesContractClient<'_>,
 fn test_rbac_integration_immediate_effect() {
     let env = env();
     let (rbac_client, er_client, rbac_owner, er_owner) = setup(&env);
-    
+
     let user = addr(&env);
-    
+
     // Link ER to RBAC
     er_client.set_rbac_address(&rbac_client.address);
-    
+
     // Initially, user has no roles
     assert!(!er_client.can_perform(&user, &PayrollAction::ClaimOwnPayroll));
     assert!(!er_client.can_perform(&user, &PayrollAction::CreatePayrollRecord));
     assert!(!er_client.can_perform(&user, &PayrollAction::AssignRoles));
-    
+
     // 1. Grant Employee in RBAC
     rbac_client.grant_role(&rbac_owner, &user, &Role::Employee);
-    
+
     // Verify immediate effect in EmployeeRoles
     assert!(er_client.can_perform(&user, &PayrollAction::ClaimOwnPayroll));
     assert!(!er_client.can_perform(&user, &PayrollAction::CreatePayrollRecord));
-    
+
     // 2. Grant Employer in RBAC (implies Employee)
     let user2 = addr(&env);
     rbac_client.grant_role(&rbac_owner, &user2, &Role::Employer);
-    
+
     assert!(er_client.can_perform(&user2, &PayrollAction::ClaimOwnPayroll));
     assert!(er_client.can_perform(&user2, &PayrollAction::CreatePayrollRecord));
     assert!(!er_client.can_perform(&user2, &PayrollAction::AssignRoles));
-    
+
     // 3. Grant Admin in RBAC (implies all)
     let user3 = addr(&env);
     rbac_client.grant_role(&rbac_owner, &user3, &Role::Admin);
-    
+
     assert!(er_client.can_perform(&user3, &PayrollAction::ClaimOwnPayroll));
     assert!(er_client.can_perform(&user3, &PayrollAction::CreatePayrollRecord));
     assert!(er_client.can_perform(&user3, &PayrollAction::AssignRoles));
-    
+
     // 4. Revoke role in RBAC
     rbac_client.revoke_role(&rbac_owner, &user, &Role::Employee);
     assert!(!er_client.can_perform(&user, &PayrollAction::ClaimOwnPayroll));
@@ -101,16 +107,16 @@ fn test_rbac_hierarchy_inheritance() {
     let env = env();
     let (rbac_client, er_client, rbac_owner, _er_owner) = setup(&env);
     let user = addr(&env);
-    
+
     er_client.set_rbac_address(&rbac_client.address);
-    
+
     // Admin in RBAC should satisfy all checks in EmployeeRoles
     rbac_client.grant_role(&rbac_owner, &user, &Role::Admin);
-    
+
     assert!(er_client.has_role_at_least(&user, &BuiltInRole::Employee));
     assert!(er_client.has_role_at_least(&user, &BuiltInRole::Manager));
     assert!(er_client.has_role_at_least(&user, &BuiltInRole::Admin));
-    
+
     assert!(er_client.can_perform(&user, &PayrollAction::ClaimOwnPayroll));
     assert!(er_client.can_perform(&user, &PayrollAction::CreatePayrollRecord));
     assert!(er_client.can_perform(&user, &PayrollAction::AssignRoles));
@@ -121,12 +127,12 @@ fn test_local_role_override() {
     let env = env();
     let (rbac_client, er_client, _rbac_owner, er_owner) = setup(&env);
     let user = addr(&env);
-    
+
     er_client.set_rbac_address(&rbac_client.address);
-    
+
     // User has no role in RBAC, but has role locally in ER
     er_client.assign_role(&er_owner, &user, &BuiltInRole::Manager);
-    
+
     assert!(er_client.can_perform(&user, &PayrollAction::CreatePayrollRecord));
     assert!(er_client.has_role(&user, &BuiltInRole::Manager));
 }
@@ -136,12 +142,12 @@ fn test_unlinked_behavior() {
     let env = env();
     let (rbac_client, er_client, rbac_owner, _er_owner) = setup(&env);
     let user = addr(&env);
-    
+
     // RBAC has the role, but ER is NOT linked yet
     rbac_client.grant_role(&rbac_owner, &user, &Role::Admin);
-    
+
     assert!(!er_client.can_perform(&user, &PayrollAction::ClaimOwnPayroll));
-    
+
     // Now link it
     er_client.set_rbac_address(&rbac_client.address);
     assert!(er_client.can_perform(&user, &PayrollAction::ClaimOwnPayroll));

--- a/onchain/integration_tests/tests/test_salary_adjustment_payroll_integration.rs
+++ b/onchain/integration_tests/tests/test_salary_adjustment_payroll_integration.rs
@@ -15,9 +15,7 @@ use soroban_sdk::{
     Address, Env,
 };
 
-use salary_adjustment::{
-    SalaryAdjustmentContract, SalaryAdjustmentContractClient,
-};
+use salary_adjustment::{SalaryAdjustmentContract, SalaryAdjustmentContractClient};
 use stello_pay_contract::storage::DataKey;
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
@@ -173,8 +171,14 @@ fn test_salary_adjustment_apply_updates_payroll_salary() {
     payroll_client.claim_payroll(&employee, &agreement_id, &0);
 
     // 3 periods at INITIAL_SALARY (3,000) + 1 period at NEW_SALARY (2,500) = 5,500
-    assert_eq!(balance(&env, &tok, &employee), INITIAL_SALARY * 3 + NEW_SALARY * 1);
-    assert_eq!(payroll_client.get_employee_claimed_periods(&agreement_id, &0), 4);
+    assert_eq!(
+        balance(&env, &tok, &employee),
+        INITIAL_SALARY * 3 + NEW_SALARY * 1
+    );
+    assert_eq!(
+        payroll_client.get_employee_claimed_periods(&agreement_id, &0),
+        4
+    );
 }
 
 /// Verifies that a decrease adjustment is also reflected in the payroll claim.
@@ -221,8 +225,12 @@ fn test_salary_decrease_affects_payroll_claim() {
     let decreased: i128 = 500;
     let effective_date = env.ledger().timestamp() + ONE_DAY;
     let adjustment_id = salary_client.create_adjustment(
-        &employer, &employee, &approver,
-        &INITIAL_SALARY, &decreased, &effective_date,
+        &employer,
+        &employee,
+        &approver,
+        &INITIAL_SALARY,
+        &decreased,
+        &effective_date,
     );
     salary_client.approve_adjustment(&approver, &adjustment_id);
     advance(&env, ONE_DAY * 2);
@@ -236,7 +244,10 @@ fn test_salary_decrease_affects_payroll_claim() {
     payroll_client.claim_payroll(&employee, &agreement_id, &0);
 
     // 2 periods at 1,000 + 1 period at 500 = 2,500
-    assert_eq!(balance(&env, &tok, &employee), INITIAL_SALARY * 2 + decreased * 1);
+    assert_eq!(
+        balance(&env, &tok, &employee),
+        INITIAL_SALARY * 2 + decreased * 1
+    );
 }
 
 /// Verifies that get_employee_salary returns None before any adjustment is applied.

--- a/onchain/integration_tests/tests/test_workflows.rs
+++ b/onchain/integration_tests/tests/test_workflows.rs
@@ -1529,14 +1529,21 @@ fn test_cross_contract_workflow_payroll_escrow_dispute_bonus_history_conservatio
     let incentive_id =
         bonus_client.create_one_time_bonus(&employer, &employee_b, &approver, &tok, &250, &1_000);
     bonus_client.approve_incentive(&approver, &incentive_id);
-    assert_eq!(bonus_client.claim_incentive(&employee_b, &incentive_id), 250);
+    assert_eq!(
+        bonus_client.claim_incentive(&employee_b, &incentive_id),
+        250
+    );
 
     // Mirror the payroll dispute into the escalation module so the integration
     // test covers the off-chain coordination sequence as well as token effects.
     payroll_client.raise_dispute(&employee_b, &agreement_id);
     dispute_client.file_dispute(&employee_b, &agreement_id);
     dispute_client.escalate_dispute(&employee_b, &agreement_id);
-    dispute_client.resolve_dispute(&dispute_admin, &agreement_id, &DisputeOutcome::UpholdPayment);
+    dispute_client.resolve_dispute(
+        &dispute_admin,
+        &agreement_id,
+        &DisputeOutcome::UpholdPayment,
+    );
     payroll_client.resolve_dispute(&arbiter, &agreement_id, &600, &400);
 
     record_payment_as_payroll(
@@ -1576,7 +1583,10 @@ fn test_cross_contract_workflow_payroll_escrow_dispute_bonus_history_conservatio
         env.ledger().timestamp(),
     );
 
-    assert_eq!(payroll_client.get_dispute_status(&agreement_id), DisputeStatus::Resolved);
+    assert_eq!(
+        payroll_client.get_dispute_status(&agreement_id),
+        DisputeStatus::Resolved
+    );
     assert_eq!(
         payroll_client.get_agreement(&agreement_id).unwrap().status,
         AgreementStatus::Completed
@@ -1651,11 +1661,8 @@ fn test_cross_contract_workflow_failure_injection_preserves_state() {
     );
     escrow_client.fund_agreement(&employer, &agreement_id, &employer, &600);
 
-    let unauthorized_admin = dispute_client.try_set_level_time_limit(
-        &outsider,
-        &EscalationLevel::Level1,
-        &60,
-    );
+    let unauthorized_admin =
+        dispute_client.try_set_level_time_limit(&outsider, &EscalationLevel::Level1, &60);
     assert_eq!(
         unauthorized_admin,
         Err(Ok(EscalationError::Unauthorized.into()))

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+# Keep formatting compatible with stable rustfmt in CI.
+edition = "2021"
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Unix"
+use_small_heuristics = "Default"


### PR DESCRIPTION
## Summary
- add repository-root `rustfmt.toml` and `clippy.toml` so the onchain workspace inherits explicit formatting and lint thresholds
- add `cargo fmt --all --check` to the automated Contracts CI workflow and mirror it in the manual `ci.yml` workflow
- document formatting/lint conventions in `docs/ci.md`
- run rustfmt across the current workspace and add the missing test wrapper needed for rustfmt to parse `compliance_reporting` tests

Closes #499

## Verification
- `cd onchain && cargo fmt --all --check`
- `git diff --check`

## Existing validation blockers on current main
- `cd onchain && cargo clippy --workspace --all-targets` currently fails in existing `fee_collector` / `compliance_reporting` compile paths before this formatting gate can be treated as a lint baseline.
- `cd onchain && cargo test -p stello_pay_contract --verbose` currently fails in `price_oracle_integration_tests` because several `configure_pair` calls supply 9 args to a 10-arg API.
