### PR TITLE
fix(cli): add read-only Soroban query

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -111,6 +111,20 @@ Example:
 stellopay-cli info --contract-id CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE
 ```
 
+#### Webhooks
+
+Webhook inspection commands use the CLI's read-only Soroban query path. These
+commands do not require a secret key and never sign or submit transactions:
+
+```bash
+stellopay-cli webhook list --owner <OWNER_ADDRESS> --contract-id <CONTRACT_ID>
+stellopay-cli webhook get --webhook-id 1 --contract-id <CONTRACT_ID>
+stellopay-cli webhook stats --contract-id <CONTRACT_ID>
+```
+
+Webhook mutation commands such as `register`, `update`, `delete`, and `test`
+still use the signed invoke path because they submit contract transactions.
+
 #### Status
 
 Show CLI status and check system dependencies:

--- a/tools/cli/src/commands.rs
+++ b/tools/cli/src/commands.rs
@@ -1,14 +1,14 @@
 use anyhow::Result;
-use log::{info, warn, error};
+use log::{error, info, warn};
 use std::path::PathBuf;
 use stellopay_cli::Config;
 // use crate::Config;
-use stellopay_cli::{require_admin,require_not_paused,TokenClient,Error, WebhookCommands};
+use stellopay_cli::{require_admin, require_not_paused, Error, TokenClient, WebhookCommands};
 // use crate::token;
 //use soroban_sdk::contractclient::Client as SorobanHttpClient;
 //use anyhow::{Result,anyhow};
 //use soroban_client::rpc::Client as SorobonClient;
-use crate::utils::SorobanHttpClient;
+use crate::utils::{validate_stellar_address, SorobanHttpClient};
 
 pub async fn deploy_command(
     network: String,
@@ -17,82 +17,102 @@ pub async fn deploy_command(
     config: &Config,
 ) -> Result<()> {
     info!("Deploying contract to network: {}", network);
-    
+
+    if !validate_stellar_address(&owner) {
+        error!("Invalid owner address: {}", owner);
+        return Err(anyhow::anyhow!("Invalid owner address"));
+    }
+
     // Determine WASM file path
     let wasm_path = wasm.unwrap_or_else(|| {
         PathBuf::from("../../onchain/target/wasm32v1-none/release/stello_pay_contract.wasm")
     });
-    
+
     if !wasm_path.exists() {
         error!("WASM file not found: {:?}", wasm_path);
-        return Err(anyhow::anyhow!("WASM file not found. Please build the contract first."));
+        return Err(anyhow::anyhow!(
+            "WASM file not found. Please build the contract first."
+        ));
     }
-    
+
     // Check if soroban CLI is available
     let soroban_check = std::process::Command::new("soroban")
         .arg("--version")
         .output();
-    
+
     if soroban_check.is_err() {
         error!("Soroban CLI not found. Please install it first:");
         error!("cargo install --locked soroban-cli");
         return Err(anyhow::anyhow!("Soroban CLI not found"));
     }
-    
+
     println!("Deploying contract with the following parameters:");
     println!("  Network: {}", network);
     println!("  Owner: {}", owner);
     println!("  WASM file: {:?}", wasm_path);
     println!("  RPC URL: {}", config.network.rpc_url);
     println!();
-    
+
     // Build the deployment command
     let mut cmd = std::process::Command::new("soroban");
     cmd.args([
-        "contract", "deploy",
-        "--wasm", wasm_path.to_str().unwrap(),
-        "--rpc-url", &config.network.rpc_url,
-        "--network", &network,
+        "contract",
+        "deploy",
+        "--wasm",
+        wasm_path.to_str().unwrap(),
+        "--rpc-url",
+        &config.network.rpc_url,
+        "--network",
+        &network,
     ]);
-    
+
     println!("Running deployment command...");
     println!("Command: {:?}", cmd);
-    
+
     let output = cmd.output()?;
-    
+
     if !output.status.success() {
         error!("Contract deployment failed:");
         error!("stderr: {}", String::from_utf8_lossy(&output.stderr));
         error!("stdout: {}", String::from_utf8_lossy(&output.stdout));
         return Err(anyhow::anyhow!("Contract deployment failed"));
     }
-    
+
     let contract_id = String::from_utf8(output.stdout)?.trim().to_string();
     info!("Contract deployed successfully: {}", contract_id);
-    
+
     println!("✅ Contract deployed successfully!");
     println!("Contract ID: {}", contract_id);
-    
+
     // Initialize contract
     let init_output = std::process::Command::new("soroban")
         .args([
-            "contract", "invoke",
-            "--id", &contract_id,
-            "--rpc-url", &config.network.rpc_url,
-            "--network", &network,
-            "--", "initialize",
-            "--owner", &owner,
+            "contract",
+            "invoke",
+            "--id",
+            &contract_id,
+            "--rpc-url",
+            &config.network.rpc_url,
+            "--network",
+            &network,
+            "--",
+            "initialize",
+            "--owner",
+            &owner,
         ])
         .output()?;
-    
+
     if !init_output.status.success() {
-        error!("Contract initialization failed: {}", String::from_utf8_lossy(&init_output.stderr));
+        error!(
+            "Contract initialization failed: {}",
+            String::from_utf8_lossy(&init_output.stderr)
+        );
         return Err(anyhow::anyhow!("Contract initialization failed"));
     }
-    
+
     info!("Contract initialized successfully");
     println!("✅ Contract initialized with owner: {}", owner);
-    
+
     Ok(())
 }
 
@@ -100,23 +120,29 @@ pub async fn info_command(contract_id: Option<String>, config: &Config) -> Resul
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Getting contract information for: {}", contract_id);
-    
+
     println!("Contract Information:");
     println!("  Contract ID: {}", contract_id);
     println!("  Network RPC: {}", config.network.rpc_url);
-    println!("  Network Passphrase: {}", config.network.network_passphrase);
-    
+    println!(
+        "  Network Passphrase: {}",
+        config.network.network_passphrase
+    );
+
     // Try to get contract info using soroban CLI
     let output = std::process::Command::new("soroban")
         .args([
-            "contract", "inspect",
-            "--id", &contract_id,
-            "--rpc-url", &config.network.rpc_url,
+            "contract",
+            "inspect",
+            "--id",
+            &contract_id,
+            "--rpc-url",
+            &config.network.rpc_url,
         ])
         .output();
-    
+
     match output {
         Ok(output) if output.status.success() => {
             println!("\nContract Details:");
@@ -130,7 +156,7 @@ pub async fn info_command(contract_id: Option<String>, config: &Config) -> Resul
             warn!("Could not run soroban CLI: {}", e);
         }
     }
-    
+
     Ok(())
 }
 
@@ -138,18 +164,30 @@ pub async fn status_command(config: &Config) -> Result<()> {
     println!("StellopayCore CLI Status");
     println!("========================");
     println!();
-    
+
     // Check configuration
     println!("Configuration:");
     println!("  Network RPC: {}", config.network.rpc_url);
-    println!("  Network Passphrase: {}", config.network.network_passphrase);
-    println!("  Default Contract ID: {}", 
-        config.contract.default_contract_id.as_deref().unwrap_or("Not set"));
+    println!(
+        "  Network Passphrase: {}",
+        config.network.network_passphrase
+    );
+    println!(
+        "  Default Contract ID: {}",
+        config
+            .contract
+            .default_contract_id
+            .as_deref()
+            .unwrap_or("Not set")
+    );
     println!();
-    
+
     // Check if soroban CLI is available
     print!("Soroban CLI: ");
-    match std::process::Command::new("soroban").arg("--version").output() {
+    match std::process::Command::new("soroban")
+        .arg("--version")
+        .output()
+    {
         Ok(output) if output.status.success() => {
             let version = String::from_utf8_lossy(&output.stdout);
             println!("✅ Available ({})", version.trim());
@@ -162,41 +200,46 @@ pub async fn status_command(config: &Config) -> Result<()> {
             println!("   Install with: cargo install --locked soroban-cli");
         }
     }
-    
+
     // Check if contract WASM exists
-    let wasm_path = PathBuf::from("../../onchain/target/wasm32v1-none/release/stello_pay_contract.wasm");
+    let wasm_path =
+        PathBuf::from("../../onchain/target/wasm32v1-none/release/stello_pay_contract.wasm");
     print!("Contract WASM: ");
     if wasm_path.exists() {
         println!("✅ Built");
     } else {
         println!("❌ Not found");
-        println!("   Build with: cd onchain/contracts/stello_pay_contract && soroban contract build");
+        println!(
+            "   Build with: cd onchain/contracts/stello_pay_contract && soroban contract build"
+        );
     }
-    
+
     println!();
     println!("Ready to use StellopayCore CLI!");
-    
+
     Ok(())
 }
 
 pub async fn emergency_withdraw(
-    config:&Config,
-    dummy_context:&str,
+    config: &Config,
+    dummy_context: &str,
     contract_id: &str,
     token: &str,
     recipient: &str,
     amount: i128,
     verbose: bool,
-) -> Result<(), Error>{
+) -> Result<(), Error> {
     //verbose output
-    if verbose{
-        println!("Withdrawing {} of token {} to {}",amount,token,recipient);
+    if verbose {
+        println!("Withdrawing {} of token {} to {}", amount, token, recipient);
     }
-   
+
     //get secret key from config
-    let signer=config.auth.secret_key
-    .clone()
-    .ok_or_else( || anyhow::anyhow!("Missing secret key"))?;
+    let signer = config
+        .auth
+        .secret_key
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Missing secret key"))?;
     //ensuring caller is admin
     require_admin(&dummy_context)?;
 
@@ -204,62 +247,86 @@ pub async fn emergency_withdraw(
     require_not_paused(&dummy_context)?;
 
     //validating amount is non-zero
-    if amount<=0{
-        return Err(Error::ZeroAmount)
+    if amount <= 0 {
+        return Err(Error::ZeroAmount);
     }
-     //preparing soroban contract call
-    let contract_client=SorobanHttpClient::new(&config.network.rpc_url);
+    //preparing soroban contract call
+    let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
     //performing token transfer
-    let token_client=TokenClient::new(&config.network.rpc_url,token);
-    token_client.transfer(
-        &recipient,
-        amount,
-    );
+    let token_client = TokenClient::new(&config.network.rpc_url, token);
+    let _ = token_client.transfer(&recipient, amount);
     //emitting event for transparency
     // env.events().publish(
     //     (symbol_short!("emergency_withdraw"),recipient.clone()),
     //     amount,
     // );
     //calling the contract function
-    contract_client.invoke(
-        contract_id,
-        "emergency_withdraw",
-        vec![
-            ("token",token),
-            ("recipient",recipient),
-            ("amount",&amount.to_string()),
-        ],
-        &signer,
-    ).await?;
+    contract_client
+        .invoke(
+            contract_id,
+            "emergency_withdraw",
+            vec![
+                ("token", token),
+                ("recipient", recipient),
+                ("amount", &amount.to_string()),
+            ],
+            &signer,
+        )
+        .await?;
     Ok(())
 }
 
-pub async fn webhook_command(
-    command: WebhookCommands,
-    config: &Config,
-) -> Result<()> {
+pub async fn webhook_command(command: WebhookCommands, config: &Config) -> Result<()> {
     match command {
-        WebhookCommands::Register { name, description, url, events, secret, contract_id } => {
-            webhook_register_command(name, description, url, events, secret, contract_id, config).await
+        WebhookCommands::Register {
+            name,
+            description,
+            url,
+            events,
+            secret,
+            contract_id,
+        } => {
+            webhook_register_command(name, description, url, events, secret, contract_id, config)
+                .await
         }
-        WebhookCommands::Update { webhook_id, name, description, url, events, active, contract_id } => {
-            webhook_update_command(webhook_id, name, description, url, events, active, contract_id, config).await
+        WebhookCommands::Update {
+            webhook_id,
+            name,
+            description,
+            url,
+            events,
+            active,
+            contract_id,
+        } => {
+            webhook_update_command(
+                webhook_id,
+                name,
+                description,
+                url,
+                events,
+                active,
+                contract_id,
+                config,
+            )
+            .await
         }
-        WebhookCommands::Delete { webhook_id, contract_id } => {
-            webhook_delete_command(webhook_id, contract_id, config).await
-        }
+        WebhookCommands::Delete {
+            webhook_id,
+            contract_id,
+        } => webhook_delete_command(webhook_id, contract_id, config).await,
         WebhookCommands::List { owner, contract_id } => {
             webhook_list_command(owner, contract_id, config).await
         }
-        WebhookCommands::Get { webhook_id, contract_id } => {
-            webhook_get_command(webhook_id, contract_id, config).await
-        }
-        WebhookCommands::Stats { contract_id } => {
-            webhook_stats_command(contract_id, config).await
-        }
-        WebhookCommands::Test { webhook_id, event_type, contract_id } => {
-            webhook_test_command(webhook_id, event_type, contract_id, config).await
-        }
+        WebhookCommands::Get {
+            webhook_id,
+            contract_id,
+        } => webhook_get_command(webhook_id, contract_id, config).await,
+        WebhookCommands::Stats { contract_id } => webhook_stats_command(contract_id, config).await,
+        WebhookCommands::Test {
+            webhook_id,
+            event_type,
+            contract_id,
+        } => webhook_test_command(webhook_id, event_type, contract_id, config).await,
     }
 }
 
@@ -275,19 +342,19 @@ pub async fn webhook_register_command(
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Registering webhook: {}", name);
-    
+
     println!("Registering Webhook:");
     println!("  Name: {}", name);
     println!("  Description: {}", description);
     println!("  URL: {}", url);
     println!("  Events: {}", events);
     println!("  Contract ID: {}", contract_id);
-    
+
     // Parse events
     let event_list: Vec<&str> = events.split(',').map(|s| s.trim()).collect();
-    
+
     // Create webhook registration data structure
     let registration_data = serde_json::json!({
         "name": name,
@@ -307,25 +374,27 @@ pub async fn webhook_register_command(
             "require_tls": true
         }
     });
-    
+
     // Call contract to register webhook
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    let signer = config.auth.secret_key
+    let signer = config
+        .auth
+        .secret_key
         .clone()
         .ok_or_else(|| anyhow::anyhow!("Missing secret key"))?;
-    
-    let result = contract_client.invoke(
-        &contract_id,
-        "register_webhook",
-        vec![
-            ("registration", &registration_data.to_string()),
-        ],
-        &signer,
-    ).await?;
-    
+
+    let result = contract_client
+        .invoke(
+            &contract_id,
+            "register_webhook",
+            vec![("registration", &registration_data.to_string())],
+            &signer,
+        )
+        .await?;
+
     println!("✅ Webhook registered successfully!");
     println!("Webhook ID: {}", result);
-    
+
     Ok(())
 }
 
@@ -342,56 +411,72 @@ pub async fn webhook_update_command(
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Updating webhook: {}", webhook_id);
-    
+
     println!("Updating Webhook {}:", webhook_id);
-    
+
     // Create update data structure
     let mut update_data = serde_json::Map::new();
-    
+
     if let Some(name) = name {
-        update_data.insert("name".to_string(), serde_json::Value::String(name));
         println!("  Name: {}", name);
+        update_data.insert("name".to_string(), serde_json::Value::String(name));
     }
     if let Some(description) = description {
-        update_data.insert("description".to_string(), serde_json::Value::String(description));
         println!("  Description: {}", description);
+        update_data.insert(
+            "description".to_string(),
+            serde_json::Value::String(description),
+        );
     }
     if let Some(url) = url {
-        update_data.insert("url".to_string(), serde_json::Value::String(url));
         println!("  URL: {}", url);
+        update_data.insert("url".to_string(), serde_json::Value::String(url));
     }
     if let Some(events) = events {
         let event_list: Vec<&str> = events.split(',').map(|s| s.trim()).collect();
-        update_data.insert("events".to_string(), serde_json::Value::Array(
-            event_list.iter().map(|e| serde_json::Value::String(e.to_string())).collect()
-        ));
+        update_data.insert(
+            "events".to_string(),
+            serde_json::Value::Array(
+                event_list
+                    .iter()
+                    .map(|e| serde_json::Value::String(e.to_string()))
+                    .collect(),
+            ),
+        );
         println!("  Events: {}", events);
     }
     if let Some(active) = active {
         update_data.insert("is_active".to_string(), serde_json::Value::Bool(active));
         println!("  Active: {}", active);
     }
-    
+
     // Call contract to update webhook
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    let signer = config.auth.secret_key
+    let signer = config
+        .auth
+        .secret_key
         .clone()
         .ok_or_else(|| anyhow::anyhow!("Missing secret key"))?;
-    
-    contract_client.invoke(
-        &contract_id,
-        "update_webhook",
-        vec![
-            ("webhook_id", &webhook_id.to_string()),
-            ("update", &serde_json::Value::Object(update_data).to_string()),
-        ],
-        &signer,
-    ).await?;
-    
+
+    contract_client
+        .invoke(
+            &contract_id,
+            "update_webhook",
+            vec![
+                ("webhook_id", &webhook_id.to_string()),
+                (
+                    "update",
+                    &serde_json::Value::Object(update_data).to_string(),
+                ),
+            ],
+            &signer,
+        )
+        .await?;
+
     println!("✅ Webhook updated successfully!");
-    
+
     Ok(())
 }
 
@@ -403,28 +488,30 @@ pub async fn webhook_delete_command(
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Deleting webhook: {}", webhook_id);
-    
+
     println!("Deleting Webhook {}:", webhook_id);
-    
+
     // Call contract to delete webhook
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    let signer = config.auth.secret_key
+    let signer = config
+        .auth
+        .secret_key
         .clone()
         .ok_or_else(|| anyhow::anyhow!("Missing secret key"))?;
-    
-    contract_client.invoke(
-        &contract_id,
-        "delete_webhook",
-        vec![
-            ("webhook_id", &webhook_id.to_string()),
-        ],
-        &signer,
-    ).await?;
-    
+
+    contract_client
+        .invoke(
+            &contract_id,
+            "delete_webhook",
+            vec![("webhook_id", &webhook_id.to_string())],
+            &signer,
+        )
+        .await?;
+
     println!("✅ Webhook deleted successfully!");
-    
+
     Ok(())
 }
 
@@ -436,24 +523,20 @@ pub async fn webhook_list_command(
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Listing webhooks for owner: {}", owner);
-    
+
     println!("Webhooks for Owner: {}", owner);
-    
+
     // Call contract to list webhooks
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    
-    let result = contract_client.query(
-        &contract_id,
-        "list_owner_webhooks",
-        vec![
-            ("owner", &owner),
-        ],
-    ).await?;
-    
-    println!("Webhook IDs: {}", result);
-    
+
+    let result = contract_client
+        .query(&contract_id, "list_owner_webhooks", vec![("owner", &owner)])
+        .await?;
+
+    println!("Webhook IDs: {}", serde_json::to_string_pretty(&result)?);
+
     Ok(())
 }
 
@@ -465,51 +548,49 @@ pub async fn webhook_get_command(
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Getting webhook: {}", webhook_id);
-    
+
     println!("Webhook Information:");
     println!("  Webhook ID: {}", webhook_id);
-    
+
     // Call contract to get webhook
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    
-    let result = contract_client.query(
-        &contract_id,
-        "get_webhook",
-        vec![
-            ("webhook_id", &webhook_id.to_string()),
-        ],
-    ).await?;
-    
-    println!("Webhook Details: {}", result);
-    
+
+    let result = contract_client
+        .query(
+            &contract_id,
+            "get_webhook",
+            vec![("webhook_id", &webhook_id.to_string())],
+        )
+        .await?;
+
+    println!(
+        "Webhook Details: {}",
+        serde_json::to_string_pretty(&result)?
+    );
+
     Ok(())
 }
 
-pub async fn webhook_stats_command(
-    contract_id: Option<String>,
-    config: &Config,
-) -> Result<()> {
+pub async fn webhook_stats_command(contract_id: Option<String>, config: &Config) -> Result<()> {
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Getting webhook statistics");
-    
+
     println!("Webhook Statistics:");
-    
+
     // Call contract to get webhook stats
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    
-    let result = contract_client.query(
-        &contract_id,
-        "get_webhook_stats",
-        vec![],
-    ).await?;
-    
-    println!("Statistics: {}", result);
-    
+
+    let result = contract_client
+        .query(&contract_id, "get_webhook_stats", vec![])
+        .await?;
+
+    println!("Statistics: {}", serde_json::to_string_pretty(&result)?);
+
     Ok(())
 }
 
@@ -522,31 +603,35 @@ pub async fn webhook_test_command(
     let contract_id = contract_id
         .or_else(|| config.contract.default_contract_id.clone())
         .ok_or_else(|| anyhow::anyhow!("No contract ID provided"))?;
-    
+
     info!("Testing webhook: {} with event: {}", webhook_id, event_type);
-    
+
     println!("Testing Webhook:");
     println!("  Webhook ID: {}", webhook_id);
     println!("  Event Type: {}", event_type);
-    
+
     // Call contract to test webhook
     let contract_client = SorobanHttpClient::new(&config.network.rpc_url);
-    let signer = config.auth.secret_key
+    let signer = config
+        .auth
+        .secret_key
         .clone()
         .ok_or_else(|| anyhow::anyhow!("Missing secret key"))?;
-    
-    let result = contract_client.invoke(
-        &contract_id,
-        "test_webhook",
-        vec![
-            ("webhook_id", &webhook_id.to_string()),
-            ("event_type", &event_type),
-        ],
-        &signer,
-    ).await?;
-    
+
+    let result = contract_client
+        .invoke(
+            &contract_id,
+            "test_webhook",
+            vec![
+                ("webhook_id", &webhook_id.to_string()),
+                ("event_type", &event_type),
+            ],
+            &signer,
+        )
+        .await?;
+
     println!("✅ Webhook test completed!");
     println!("Result: {}", result);
-    
+
     Ok(())
 }

--- a/tools/cli/src/config.rs
+++ b/tools/cli/src/config.rs
@@ -1,29 +1,30 @@
-use stellopay_cli::Config;
 use anyhow::Result;
 use std::path::Path;
+use stellopay_cli::Config;
 use tokio::fs;
 
 pub async fn load_config(config_path: &Path) -> Result<Config> {
     // Expand tilde in path
     let expanded_path = if config_path.starts_with("~") {
-        let home_dir = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
+        let home_dir =
+            dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
         let path_str = config_path.to_string_lossy();
         let without_tilde = &path_str[1..]; // Remove the ~
         home_dir.join(without_tilde.trim_start_matches('/'))
     } else {
         config_path.to_path_buf()
     };
-    
+
     if !expanded_path.exists() {
         // Create default config if it doesn't exist
         let default_config = Config::default();
         create_config_file(&expanded_path, &default_config).await?;
         return Ok(default_config);
     }
-    
+
     let config_content = fs::read_to_string(&expanded_path).await?;
     let config: Config = toml::from_str(&config_content)?;
-    
+
     Ok(config)
 }
 
@@ -32,12 +33,12 @@ async fn create_config_file(path: &Path, config: &Config) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    
+
     let config_content = toml::to_string_pretty(config)?;
     fs::write(path, config_content).await?;
-    
+
     println!("Created default config file at: {}", path.display());
-    
+
     Ok(())
 }
 
@@ -46,11 +47,11 @@ pub fn get_secret_key(config: &Config) -> Result<String> {
     if let Ok(key) = std::env::var("STELLOPAY_SECRET_KEY") {
         return Ok(key);
     }
-    
+
     // Check config file
     if let Some(secret_key) = &config.auth.secret_key {
         return Ok(secret_key.clone());
     }
-    
+
     Err(anyhow::anyhow!("No secret key found. Set STELLOPAY_SECRET_KEY environment variable or add it to config file"))
 }

--- a/tools/cli/src/lib.rs
+++ b/tools/cli/src/lib.rs
@@ -48,15 +48,15 @@ pub enum Commands {
     /// Show CLI status
     Status,
     /// Emergency Command
-    EmergencyWithdraw{
+    EmergencyWithdraw {
         #[arg(long)]
-        contract_id:Option<String>,
+        contract_id: Option<String>,
         #[arg(long)]
-        token:String,
+        token: String,
         #[arg(long)]
-        recipient:String,
+        recipient: String,
         #[arg(long)]
-        amount:i128,
+        amount: i128,
     },
     /// Webhook management commands
     Webhook {
@@ -251,8 +251,8 @@ pub struct GasMetrics {
     pub total: u64,
 }
 //error enum
-#[derive(Debug,thiserror::Error)]
-pub enum Error{
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
     #[error("Zero amount is not allowed")]
     ZeroAmount,
     #[error("Missing secret key")]
@@ -302,23 +302,22 @@ impl Default for Config {
     }
 }
 //admin and pause checks
-pub fn require_admin(_context:&str)->Result<(),Error>{
+pub fn require_admin(_context: &str) -> Result<(), Error> {
     //dummy implementation
     Ok(())
 }
-pub fn require_not_paused(_context:&str)->Result<(),Error>{
+pub fn require_not_paused(_context: &str) -> Result<(), Error> {
     //dummy implementation
     Ok(())
 }
 //token client
 pub struct TokenClient;
-impl TokenClient{
-    pub fn new(_rpc_url:&str,_token_address:&str)->Self{
+impl TokenClient {
+    pub fn new(_rpc_url: &str, _token_address: &str) -> Self {
         TokenClient
     }
-    pub fn transfer(&self,_to:&str,_amount:i128)->Result<(),Error>{
+    pub fn transfer(&self, _to: &str, _amount: i128) -> Result<(), Error> {
         //dummy implementation
         Ok(())
     }
-
 }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -5,22 +5,22 @@ mod commands;
 mod config;
 mod utils;
 
+use anyhow::anyhow;
 use commands::*;
 use config::*;
-use stellopay_cli::{Cli, Commands, WebhookCommands};
-use anyhow::anyhow;
+use stellopay_cli::{Cli, Commands};
 
 #[tokio::main]
-async fn main() ->anyhow::Result<()> {
+async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    
+
     // Set up logging
     if cli.verbose {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
     } else {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     }
-    
+
     // Load configuration
     let config = match load_config(&cli.config).await {
         Ok(config) => config,
@@ -29,34 +29,30 @@ async fn main() ->anyhow::Result<()> {
             process::exit(1);
         }
     };
-    
+
     // Execute command
     let result = match cli.command {
-        Commands::Deploy { network, owner, wasm } => {
-            deploy_command(network, owner, wasm, &config).await
-        }
-        Commands::Info { contract_id } => {
-            info_command(contract_id, &config).await
-        }
-        Commands::Status => {
-            status_command(&config).await
-        }
-        Commands::Webhook { command } => {
-            webhook_command(command, &config).await
-        }
-        Commands::EmergencyWithdraw{
+        Commands::Deploy {
+            network,
+            owner,
+            wasm,
+        } => deploy_command(network, owner, wasm, &config).await,
+        Commands::Info { contract_id } => info_command(contract_id, &config).await,
+        Commands::Status => status_command(&config).await,
+        Commands::Webhook { command } => webhook_command(command, &config).await,
+        Commands::EmergencyWithdraw {
             contract_id,
             token,
             recipient,
             amount,
-        }=>{
+        } => {
             // //Loading config
-            let dummy_env="cli-context";
+            let dummy_env = "cli-context";
             // let config=load_config(&cli.config)?;
             // //resolving contract ID from arg or config
-            let contract_id_str=contract_id
-            .as_deref()
-            .ok_or_else(|| anyhow!("Missing contract ID"))?;
+            let contract_id_str = contract_id
+                .as_deref()
+                .ok_or_else(|| anyhow!("Missing contract ID"))?;
 
             //calling logic function
             emergency_withdraw(
@@ -67,11 +63,12 @@ async fn main() ->anyhow::Result<()> {
                 &recipient,
                 amount,
                 cli.verbose,
-            ).await?;
+            )
+            .await?;
             Ok(())
         }
     };
-    
+
     match result {
         Ok(()) => {}
         Err(e) => {

--- a/tools/cli/src/utils.rs
+++ b/tools/cli/src/utils.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_json::Value;
+use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Employee {
@@ -61,7 +62,10 @@ pub fn format_amount(amount: i128, decimals: u32) -> String {
             fractional,
             width = decimals as usize
         );
-        formatted.trim_end_matches('0').trim_end_matches('.').to_string()
+        formatted
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
     }
 }
 
@@ -316,45 +320,153 @@ mod tests {
         assert_eq!(truncate_address("SHORT", 4), "SHORT");
     }
 }
-pub struct SorobanHttpClient{
-    base_url:String,
-    client:reqwest::Client,
+pub struct SorobanHttpClient {
+    base_url: String,
+    client: Client,
 }
-impl SorobanHttpClient{
-    pub fn new(base_url: &str)->Self{
-        Self{
-            base_url:base_url.to_string(),
-            client:reqwest::Client::new(),
+
+impl SorobanHttpClient {
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client: Client::new(),
         }
     }
-    pub async fn get_ledger_info(&self)->Result<String>{
-        let url=format!("{}/ledger",self.base_url);
-        let res=self.client.get(&url).send().await?;
-        let body =res.text().await?;
+
+    pub async fn get_ledger_info(&self) -> Result<String> {
+        let url = format!("{}/ledger", self.base_url);
+        let res = self.client.get(&url).send().await?;
+        let body = res.text().await?;
         Ok(body)
     }
+
+    /// Simulate a read-only contract call without signing or submitting a transaction.
+    ///
+    /// This method is intentionally separate from `invoke`: it sends only the
+    /// contract id, method, and arguments to the RPC query endpoint and never
+    /// accepts a signer or secret key.
+    pub async fn query(
+        &self,
+        contract_id: &str,
+        method: &str,
+        args: Vec<(&str, &str)>,
+    ) -> Result<Value> {
+        let url = format!("{}/query", self.base_url);
+        let payload = self.query_payload(contract_id, method, args);
+        let response = self.client.post(&url).json(&payload).send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            return Err(anyhow::anyhow!(
+                "Soroban query failed with status {}: {}",
+                status,
+                body
+            ));
+        }
+
+        let value: Value = serde_json::from_str(&body)
+            .map_err(|e| anyhow::anyhow!("Malformed Soroban query response: {}", e))?;
+
+        if let Some(error) = value.get("error") {
+            return Err(anyhow::anyhow!("Soroban query RPC error: {}", error));
+        }
+
+        Ok(value.get("result").cloned().unwrap_or(value))
+    }
+
+    fn query_payload(&self, contract_id: &str, method: &str, args: Vec<(&str, &str)>) -> Value {
+        json!({
+            "contract_id": contract_id,
+            "method": method,
+            "args": args.iter().map(|(k, v)| json!({ (*k): v })).collect::<Vec<_>>(),
+            "read_only": true,
+        })
+    }
+
     pub async fn invoke(
         &self,
-        contract_id:&str,
-        method:&str,
-        args:Vec<(&str,&str)>,
-        signer:&str,
+        contract_id: &str,
+        method: &str,
+        args: Vec<(&str, &str)>,
+        signer: &str,
     ) -> Result<String> {
-        let url=format!("{}/invoke",self.base_url.trim_end_matches('/'));
-        println!("Invoking Soroban at: {}",url);
-        let payload=json!({
-            "contract_id":contract_id,
-            "method":method,
-            "args":args.iter().map(|(k,v)| json!({(*k):v})).collect::<Vec<_>>(),
-            "signer":signer,
+        let url = format!("{}/invoke", self.base_url);
+        println!("Invoking Soroban at: {}", url);
+        let payload = json!({
+            "contract_id": contract_id,
+            "method": method,
+            "args": args.iter().map(|(k, v)| json!({ (*k): v })).collect::<Vec<_>>(),
+            "signer": signer,
         });
-        let response=self
-            .client
-            .post(&url)
-            .json(&payload)
-            .send()
-            .await?;
-        let body=response.text().await?;
+        let response = self.client.post(&url).json(&payload).send().await?;
+        let body = response.text().await?;
         Ok(body)
+    }
+}
+
+#[cfg(test)]
+mod soroban_http_client_tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn serve_once(status: &str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let status = status.to_string();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        format!("http://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn query_returns_typed_result() {
+        let base_url = serve_once("200 OK", r#"{"jsonrpc":"2.0","result":{"ids":[1,2]}}"#);
+        let client = SorobanHttpClient::new(&base_url);
+
+        let result = client
+            .query(
+                "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+                "list",
+                vec![("owner", "G")],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result["ids"][0], 1);
+        assert_eq!(result["ids"][1], 2);
+    }
+
+    #[tokio::test]
+    async fn query_rejects_rpc_error() {
+        let base_url = serve_once(
+            "200 OK",
+            r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"simulation failed"}}"#,
+        );
+        let client = SorobanHttpClient::new(&base_url);
+
+        let error = client
+            .query(
+                "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+                "stats",
+                vec![],
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("Soroban query RPC error"));
+        assert!(error.contains("simulation failed"));
     }
 }

--- a/tools/cli/tests/integration_tests.rs
+++ b/tools/cli/tests/integration_tests.rs
@@ -7,9 +7,9 @@ use tempfile::TempDir;
 fn test_cli_help() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
     cmd.arg("--help");
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("CLI tool for StellopayCore contract management"));
+    cmd.assert().success().stdout(predicate::str::contains(
+        "CLI tool for StellopayCore contract management",
+    ));
 }
 
 #[test]
@@ -36,13 +36,16 @@ fn test_cli_info_with_contract_id() {
     cmd.arg("info")
         .arg("--contract-id")
         .arg("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE");
-    
+
     // This might fail depending on network connectivity, but should at least attempt to connect
     let output = cmd.output().unwrap();
-    assert!(output.status.success() || String::from_utf8_lossy(&output.stderr).contains("Failed to get contract details"));
+    assert!(
+        output.status.success()
+            || String::from_utf8_lossy(&output.stderr).contains("Failed to get contract details")
+    );
 }
 
-#[test] 
+#[test]
 fn test_deploy_without_owner() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
     cmd.arg("deploy");
@@ -55,17 +58,17 @@ fn test_deploy_without_owner() {
 fn test_config_file_creation() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("test_config.toml");
-    
+
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
     cmd.arg("--config")
         .arg(config_path.to_str().unwrap())
         .arg("status");
-    
+
     cmd.assert().success();
-    
+
     // Check that config file was created
     assert!(config_path.exists());
-    
+
     // Check config file content
     let config_content = std::fs::read_to_string(&config_path).unwrap();
     assert!(config_content.contains("rpc_url"));
@@ -75,13 +78,11 @@ fn test_config_file_creation() {
 #[test]
 fn test_deploy_with_invalid_owner() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
-    cmd.arg("deploy")
-        .arg("--owner")
-        .arg("invalid_address");
-    
+    cmd.arg("deploy").arg("--owner").arg("invalid_address");
+
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("Contract deployment failed"));
+        .stderr(predicate::str::contains("Invalid owner address"));
 }
 
 #[test]
@@ -90,7 +91,7 @@ fn test_deploy_with_missing_wasm() {
     cmd.arg("deploy")
         .arg("--owner")
         .arg("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
-    
+
     // Should fail due to missing WASM file or other deployment issues
     let output = cmd.output().unwrap();
     assert!(!output.status.success());
@@ -100,7 +101,7 @@ fn test_deploy_with_missing_wasm() {
 fn test_invalid_command() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
     cmd.arg("invalid_command");
-    
+
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("unrecognized subcommand"));
@@ -110,7 +111,7 @@ fn test_invalid_command() {
 fn test_version_flag() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
     cmd.arg("--version");
-    
+
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("stellopay-cli"));
@@ -120,7 +121,7 @@ fn test_version_flag() {
 fn test_config_with_custom_network() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("custom_config.toml");
-    
+
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
     cmd.arg("--config")
         .arg(config_path.to_str().unwrap())
@@ -129,7 +130,7 @@ fn test_config_with_custom_network() {
         .arg("futurenet")
         .arg("--owner")
         .arg("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
-    
+
     // Should fail due to missing WASM or other issues, but config should be created
     let _output = cmd.output().unwrap();
     assert!(config_path.exists());
@@ -141,38 +142,45 @@ fn test_info_with_invalid_contract_id() {
     cmd.arg("info")
         .arg("--contract-id")
         .arg("invalid_contract_id");
-    
+
     let output = cmd.output().unwrap();
     // The CLI currently doesn't validate contract ID format but logs warnings
     assert!(output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("Failed to get contract details"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to get contract details")
+            || stderr.contains("Could not run soroban CLI"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 #[test]
 fn test_concurrent_config_access() {
-    use std::thread;
     use std::sync::Arc;
-    
+    use std::thread;
+
     let temp_dir = Arc::new(TempDir::new().unwrap());
     let config_path = temp_dir.path().join("concurrent_config.toml");
-    
-    let handles: Vec<_> = (0..3).map(|i| {
-        let config_path = config_path.clone();
-        thread::spawn(move || {
-            let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
-            cmd.arg("--config")
-                .arg(config_path.to_str().unwrap())
-                .arg("status");
-            
-            let output = cmd.output().unwrap();
-            assert!(output.status.success(), "Thread {} failed", i);
+
+    let handles: Vec<_> = (0..3)
+        .map(|i| {
+            let config_path = config_path.clone();
+            thread::spawn(move || {
+                let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
+                cmd.arg("--config")
+                    .arg(config_path.to_str().unwrap())
+                    .arg("status");
+
+                let output = cmd.output().unwrap();
+                assert!(output.status.success(), "Thread {} failed", i);
+            })
         })
-    }).collect();
-    
+        .collect();
+
     for handle in handles {
         handle.join().unwrap();
     }
-    
+
     // Config should exist after all threads complete
     assert!(config_path.exists());
 }
@@ -180,9 +188,8 @@ fn test_concurrent_config_access() {
 #[test]
 fn test_cli_with_verbose_flag() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
-    cmd.arg("--verbose")
-        .arg("status");
-    
+    cmd.arg("--verbose").arg("status");
+
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("StellopayCore CLI Status"));
@@ -191,9 +198,8 @@ fn test_cli_with_verbose_flag() {
 #[test]
 fn test_cli_with_short_verbose_flag() {
     let mut cmd = Command::cargo_bin("stellopay-cli").unwrap();
-    cmd.arg("-v")
-        .arg("status");
-    
+    cmd.arg("-v").arg("status");
+
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("StellopayCore CLI Status"));


### PR DESCRIPTION
## Summary
- add documented `SorobanHttpClient::query` for read-only contract calls without a signer or transaction submission
- wire webhook list/get/stats commands to the typed JSON query result and pretty-print responses
- stabilize CLI validation/tests around owner validation and local Soroban CLI availability
- document read-only webhook inspection commands in the CLI README

Closes #496

## Verification
- `cd tools/cli && cargo build`
- `cd tools/cli && cargo test`
- `git diff --check`

## Security notes
- `query` does not accept a secret key, signer, or transaction submission data; signed mutation commands continue to use `invoke`.
