### PR TITLE
feat(payroll): emit per-entry failure events in batch_claim_payroll and batch_claim_milestones (#505)

### DIFF
--- a/docs/events-schema.json
+++ b/docs/events-schema.json
@@ -10,7 +10,11 @@
     },
     "AgreementMode": {
       "type": "integer",
-      "enum": [0, 1, 2],
+      "enum": [
+        0,
+        1,
+        2
+      ],
       "description": "0: Escrow, 1: Payroll, 2: Milestone"
     }
   },
@@ -18,154 +22,314 @@
     {
       "title": "MilestoneAdded",
       "properties": {
-        "event": { "const": "MilestoneAdded" },
-        "agreement_id": { "type": "string" },
-        "milestone_id": { "type": "integer" },
-        "amount": { "type": "string" }
+        "event": {
+          "const": "MilestoneAdded"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "milestone_id": {
+          "type": "integer"
+        },
+        "amount": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "MilestoneApproved",
       "properties": {
-        "event": { "const": "MilestoneApproved" },
-        "agreement_id": { "type": "string" },
-        "milestone_id": { "type": "integer" }
+        "event": {
+          "const": "MilestoneApproved"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "milestone_id": {
+          "type": "integer"
+        }
       }
     },
     {
       "title": "MilestoneClaimed",
       "properties": {
-        "event": { "const": "MilestoneClaimed" },
-        "agreement_id": { "type": "string" },
-        "milestone_id": { "type": "integer" },
-        "amount": { "type": "string" },
-        "to": { "$ref": "#/definitions/Address" }
+        "event": {
+          "const": "MilestoneClaimed"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "milestone_id": {
+          "type": "integer"
+        },
+        "amount": {
+          "type": "string"
+        },
+        "to": {
+          "$ref": "#/definitions/Address"
+        }
       }
     },
     {
       "title": "AgreementCreated",
       "properties": {
-        "event": { "const": "AgreementCreated" },
-        "agreement_id": { "type": "string" },
-        "employer": { "$ref": "#/definitions/Address" },
-        "mode": { "$ref": "#/definitions/AgreementMode" }
+        "event": {
+          "const": "AgreementCreated"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "employer": {
+          "$ref": "#/definitions/Address"
+        },
+        "mode": {
+          "$ref": "#/definitions/AgreementMode"
+        }
       }
     },
     {
       "title": "AgreementActivated",
       "properties": {
-        "event": { "const": "AgreementActivated" },
-        "agreement_id": { "type": "string" }
+        "event": {
+          "const": "AgreementActivated"
+        },
+        "agreement_id": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "EmployeeAdded",
       "properties": {
-        "event": { "const": "EmployeeAdded" },
-        "agreement_id": { "type": "string" },
-        "employee": { "$ref": "#/definitions/Address" },
-        "salary_per_period": { "type": "string" }
+        "event": {
+          "const": "EmployeeAdded"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "employee": {
+          "$ref": "#/definitions/Address"
+        },
+        "salary_per_period": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "PayrollClaimed",
       "properties": {
-        "event": { "const": "PayrollClaimed" },
-        "agreement_id": { "type": "string" },
-        "employee": { "$ref": "#/definitions/Address" },
-        "amount": { "type": "string" }
+        "event": {
+          "const": "PayrollClaimed"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "employee": {
+          "$ref": "#/definitions/Address"
+        },
+        "amount": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "AgreementPaused",
       "properties": {
-        "event": { "const": "AgreementPaused" },
-        "agreement_id": { "type": "string" }
+        "event": {
+          "const": "AgreementPaused"
+        },
+        "agreement_id": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "AgreementResumed",
       "properties": {
-        "event": { "const": "AgreementResumed" },
-        "agreement_id": { "type": "string" }
+        "event": {
+          "const": "AgreementResumed"
+        },
+        "agreement_id": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "PaymentSent",
       "properties": {
-        "event": { "const": "PaymentSent" },
-        "agreement_id": { "type": "string" },
-        "from": { "$ref": "#/definitions/Address" },
-        "to": { "$ref": "#/definitions/Address" },
-        "amount": { "type": "string" },
-        "token": { "$ref": "#/definitions/Address" }
+        "event": {
+          "const": "PaymentSent"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "from": {
+          "$ref": "#/definitions/Address"
+        },
+        "to": {
+          "$ref": "#/definitions/Address"
+        },
+        "amount": {
+          "type": "string"
+        },
+        "token": {
+          "$ref": "#/definitions/Address"
+        }
       }
     },
     {
       "title": "PaymentReceived",
       "properties": {
-        "event": { "const": "PaymentReceived" },
-        "agreement_id": { "type": "string" },
-        "to": { "$ref": "#/definitions/Address" },
-        "amount": { "type": "string" },
-        "token": { "$ref": "#/definitions/Address" }
+        "event": {
+          "const": "PaymentReceived"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "to": {
+          "$ref": "#/definitions/Address"
+        },
+        "amount": {
+          "type": "string"
+        },
+        "token": {
+          "$ref": "#/definitions/Address"
+        }
       }
     },
     {
       "title": "ArbiterSet",
       "properties": {
-        "event": { "const": "ArbiterSet" },
-        "arbiter": { "$ref": "#/definitions/Address" }
+        "event": {
+          "const": "ArbiterSet"
+        },
+        "arbiter": {
+          "$ref": "#/definitions/Address"
+        }
       }
     },
     {
       "title": "DisputeRaised",
       "properties": {
-        "event": { "const": "DisputeRaised" },
-        "agreement_id": { "type": "string" }
+        "event": {
+          "const": "DisputeRaised"
+        },
+        "agreement_id": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "DisputeResolved",
       "properties": {
-        "event": { "const": "DisputeResolved" },
-        "agreement_id": { "type": "string" },
-        "pay_contributor": { "type": "string" },
-        "refund_employer": { "type": "string" }
+        "event": {
+          "const": "DisputeResolved"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "pay_contributor": {
+          "type": "string"
+        },
+        "refund_employer": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "AgreementCancelled",
       "properties": {
-        "event": { "const": "AgreementCancelled" },
-        "agreement_id": { "type": "string" }
+        "event": {
+          "const": "AgreementCancelled"
+        },
+        "agreement_id": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "GracePeriodFinalized",
       "properties": {
-        "event": { "const": "GracePeriodFinalized" },
-        "agreement_id": { "type": "string" }
+        "event": {
+          "const": "GracePeriodFinalized"
+        },
+        "agreement_id": {
+          "type": "string"
+        }
       }
     },
     {
       "title": "BatchPayrollClaimed",
       "properties": {
-        "event": { "const": "BatchPayrollClaimed" },
-        "agreement_id": { "type": "string" },
-        "total_claimed": { "type": "string" },
-        "successful_claims": { "type": "integer" },
-        "failed_claims": { "type": "integer" }
+        "event": {
+          "const": "BatchPayrollClaimed"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "total_claimed": {
+          "type": "string"
+        },
+        "successful_claims": {
+          "type": "integer"
+        },
+        "failed_claims": {
+          "type": "integer"
+        }
       }
     },
     {
       "title": "BatchMilestoneClaimed",
       "properties": {
-        "event": { "const": "BatchMilestoneClaimed" },
-        "agreement_id": { "type": "string" },
-        "total_claimed": { "type": "string" },
-        "successful_claims": { "type": "integer" },
-        "failed_claims": { "type": "integer" }
+        "event": {
+          "const": "BatchMilestoneClaimed"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "total_claimed": {
+          "type": "string"
+        },
+        "successful_claims": {
+          "type": "integer"
+        },
+        "failed_claims": {
+          "type": "integer"
+        }
+      }
+    },
+    {
+      "title": "BatchPayrollClaimFailed",
+      "properties": {
+        "event": {
+          "const": "BatchPayrollClaimFailed"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "employee": {
+          "$ref": "#/definitions/Address"
+        },
+        "error_code": {
+          "type": "integer"
+        }
+      }
+    },
+    {
+      "title": "BatchMilestoneClaimFailed",
+      "properties": {
+        "event": {
+          "const": "BatchMilestoneClaimFailed"
+        },
+        "agreement_id": {
+          "type": "string"
+        },
+        "milestone_id": {
+          "type": "integer"
+        },
+        "error_code": {
+          "type": "integer"
+        }
       }
     }
   ]

--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -256,3 +256,26 @@ pub struct MilestoneFundedEvent {
 pub fn emit_milestone_funded(env: &Env, event: MilestoneFundedEvent) {
     event.publish(env);
 }
+
+/// Event: Batch payroll claim failed for a specific employee.
+///
+/// Emitted once per failed entry in atch_claim_payroll so off-chain
+/// indexers can detect per-employee failures without re-simulating the batch.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BatchPayrollClaimFailedEvent {
+    pub agreement_id: u128,
+    pub employee: Address,
+    pub error_code: u32,
+}
+
+/// Event: Batch milestone claim failed for a specific milestone.
+///
+/// Emitted once per failed entry in atch_claim_milestones.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BatchMilestoneClaimFailedEvent {
+    pub agreement_id: u128,
+    pub milestone_id: u32,
+    pub error_code: u32,
+}

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -13,6 +13,7 @@ use crate::events::{
     GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved,
     MilestoneClaimed, MilestoneFundedEvent, PaymentReceivedEvent, PaymentSentEvent,
     PayrollClaimedEvent,
+    BatchPayrollClaimFailedEvent, BatchMilestoneClaimFailedEvent,
 };
 use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,
@@ -707,6 +708,12 @@ pub fn batch_claim_milestones(
                 amount_claimed: 0,
                 error_code: 1, // duplicate
             });
+            BatchMilestoneClaimFailedEvent {
+                agreement_id,
+                milestone_id,
+                error_code: 1,
+            }
+            .publish(env);
             continue;
         }
         processed.push_back(milestone_id);
@@ -720,6 +727,12 @@ pub fn batch_claim_milestones(
                 amount_claimed: 0,
                 error_code: 2, // invalid ID
             });
+            BatchMilestoneClaimFailedEvent {
+                agreement_id,
+                milestone_id,
+                error_code: 2,
+            }
+            .publish(env);
             continue;
         }
 
@@ -737,6 +750,12 @@ pub fn batch_claim_milestones(
                 amount_claimed: 0,
                 error_code: 3, // not approved
             });
+            BatchMilestoneClaimFailedEvent {
+                agreement_id,
+                milestone_id,
+                error_code: 3,
+            }
+            .publish(env);
             continue;
         }
 
@@ -754,6 +773,12 @@ pub fn batch_claim_milestones(
                 amount_claimed: 0,
                 error_code: 4, // already claimed
             });
+            BatchMilestoneClaimFailedEvent {
+                agreement_id,
+                milestone_id,
+                error_code: 4,
+            }
+            .publish(env);
             continue;
         }
 
@@ -2506,6 +2531,12 @@ pub fn batch_claim_payroll(
                 amount_claimed: 0,
                 error_code: PayrollError::Unauthorized as u32,
             });
+            BatchPayrollClaimFailedEvent {
+                agreement_id,
+                employee: employee.clone(),
+                error_code: PayrollError::Unauthorized as u32,
+            }
+            .publish(env);
             continue;
         }
 
@@ -2526,6 +2557,12 @@ pub fn batch_claim_payroll(
                 amount_claimed: 0,
                 error_code: PayrollError::NoPeriodsToClaim as u32,
             });
+            BatchPayrollClaimFailedEvent {
+                agreement_id,
+                employee: employee.clone(),
+                error_code: PayrollError::NoPeriodsToClaim as u32,
+            }
+            .publish(env);
             continue;
         }
 
@@ -2543,6 +2580,12 @@ pub fn batch_claim_payroll(
                         amount_claimed: 0,
                         error_code: PayrollError::AgreementNotFound as u32,
                     });
+                    BatchPayrollClaimFailedEvent {
+                        agreement_id,
+                        employee: employee.clone(),
+                        error_code: PayrollError::AgreementNotFound as u32,
+                    }
+                    .publish(env);
                     continue;
                 }
             };
@@ -2558,6 +2601,12 @@ pub fn batch_claim_payroll(
                     amount_claimed: 0,
                     error_code: PayrollError::InvalidData as u32,
                 });
+                BatchPayrollClaimFailedEvent {
+                    agreement_id,
+                    employee: employee.clone(),
+                    error_code: PayrollError::InvalidData as u32,
+                }
+                .publish(env);
                 continue;
             }
         };
@@ -2571,6 +2620,12 @@ pub fn batch_claim_payroll(
                 amount_claimed: 0,
                 error_code: PayrollError::InsufficientEscrowBalance as u32,
             });
+            BatchPayrollClaimFailedEvent {
+                agreement_id,
+                employee: employee.clone(),
+                error_code: PayrollError::InsufficientEscrowBalance as u32,
+            }
+            .publish(env);
             continue;
         }
 

--- a/onchain/contracts/stello_pay_contract/tests/test_event_emissions.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_event_emissions.rs
@@ -753,3 +753,51 @@ fn test_all_event_types_covered() {
     // All existing event types are covered in this test suite
     assert!(true);
 }
+
+/// Test: batch_claim_payroll emits per-employee failure events for invalid entries
+#[test]
+fn test_batch_claim_payroll_failure_events() {
+    let env = create_test_env();
+    let (_contract_id, client) = setup_contract(&env);
+    let employer = create_test_address(&env);
+    let employee = create_test_address(&env);
+    let token = create_test_address(&env);
+
+    let salary = 1000i128;
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &604800u64);
+    client.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    client.activate_agreement(&agreement_id);
+
+    // Call batch_claim_payroll with an out-of-bounds index (employee_count=1, index=5)
+    let mut indices: Vec<u32> = Vec::new(&env);
+    indices.push_back(5u32);
+    let _result = client.try_batch_claim_payroll(&employee, &agreement_id, &indices);
+
+    let count = count_events(&env, "batch_payroll_claim_failed_event");
+    assert!(count > 0, "Expected batch_payroll_claim_failed_event to be emitted");
+}
+
+/// Test: batch_claim_milestones emits per-milestone failure events for invalid entries
+#[test]
+fn test_batch_claim_milestone_failure_events() {
+    let env = create_test_env();
+    let (_contract_id, client) = setup_contract(&env);
+    let employer = create_test_address(&env);
+    let contributor = create_test_address(&env);
+    let token = create_token(&env);
+
+    // Create milestone agreement
+    let employer2 = create_test_address(&env);
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&employer2, &1000000);
+    let agreement_id = client.create_milestone_agreement(&employer2, &contributor, &token);
+    client.add_milestone(&agreement_id, &1000);
+    client.fund_milestone_agreement(&agreement_id, &employer2, &1000000);
+
+    // Call batch_claim_milestones with an invalid milestone_id (milestone_count=1, id=99)
+    let mut ids: Vec<u32> = Vec::new(&env);
+    ids.push_back(99u32);
+    let _result = client.try_batch_claim_milestones(&agreement_id, &ids);
+
+    let count = count_events(&env, "batch_milestone_claim_failed_event");
+    assert!(count > 0, "Expected batch_milestone_claim_failed_event to be emitted");
+}


### PR DESCRIPTION
## Description
Emit per-entry failure events in batch_claim_payroll and batch_claim_milestones so off-chain indexers can detect partial failures without re-simulating.

## Related Issue
Closes #505

## Changes
- Add BatchPayrollClaimFailedEvent and BatchMilestoneClaimFailedEvent structs in events.rs
- Emit BatchPayrollClaimFailedEvent in batch_claim_payroll for each failed entry
- Emit BatchMilestoneClaimFailedEvent in batch_claim_milestones for each failed entry
- Update events-schema.json with both new events
- Add tests verifying failure events are emitted

## Verification
- test_batch_claim_payroll_failure_events: calls batch_claim_payroll with out-of-bounds employee index, asserts batch_payroll_claim_failed_event emitted
- test_batch_claim_milestone_failure_events: calls batch_claim_milestones with invalid milestone ID, asserts batch_milestone_claim_failed_event emitted

## Risk Assessment
- Low: Events are additive; no logic change, no state mutation, no new failure paths
- Batch continues after each failure (existing behavior preserved)
- BatchPayrollResult / BatchMilestoneResult return values unchanged

## Wallet
RTC269fa5650798c3aa5086a128c025a546e0a41d0b
