### PR TITLE
feat(payroll): emit fx rate-change events (#488)

### DIFF
--- a/docs/events-schema.json
+++ b/docs/events-schema.json
@@ -167,6 +167,40 @@
         "successful_claims": { "type": "integer" },
         "failed_claims": { "type": "integer" }
       }
+    },
+    {
+      "title": "ExchangeRateUpdated",
+      "properties": {
+        "event": {
+          "const": "ExchangeRateUpdated"
+        },
+        "base": {
+          "": "#/definitions/Address"
+        },
+        "quote": {
+          "": "#/definitions/Address"
+        },
+        "rate": {
+          "type": "string"
+        },
+        "updated_by": {
+          "": "#/definitions/Address"
+        }
+      }
+    },
+    {
+      "title": "ExchangeRateAdminSet",
+      "properties": {
+        "event": {
+          "const": "ExchangeRateAdminSet"
+        },
+        "admin": {
+          "": "#/definitions/Address"
+        },
+        "set_by": {
+          "": "#/definitions/Address"
+        }
+      }
     }
   ]
 }

--- a/docs/multi-currency.md
+++ b/docs/multi-currency.md
@@ -208,3 +208,12 @@ client.claim_payroll_in_token(&employee, &agreement_id, &0u32, &payout_token);
   - `claim_payroll_in_token` shares the same eligibility and period-counting
     logic as `claim_payroll`, ensuring consistent invariants across currencies.
 
+
+### Events
+
+Each FX mutation emits a typed Soroban event for off-chain indexing:
+
+- ExchangeRateUpdated { base, quote, rate, updated_by } — emitted from set_exchange_rate after a successful storage write.
+- ExchangeRateAdminSet { admin, set_by } — emitted from set_exchange_rate_admin after a successful admin update.
+
+Events are emitted only on the authorized, successful path. A rejected call never produces a misleading event.

--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -256,3 +256,33 @@ pub struct MilestoneFundedEvent {
 pub fn emit_milestone_funded(env: &Env, event: MilestoneFundedEvent) {
     event.publish(env);
 }
+
+/// Event: Exchange rate updated.
+///
+/// Emitted from set_exchange_rate after a successful rate update.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ExchangeRateUpdatedEvent {
+    pub base: Address,
+    pub quote: Address,
+    pub rate: i128,
+    pub updated_by: Address,
+}
+
+pub fn emit_exchange_rate_updated(env: &Env, event: ExchangeRateUpdatedEvent) {
+    event.publish(env);
+}
+
+/// Event: Exchange rate admin set.
+///
+/// Emitted from set_exchange_rate_admin after a successful admin update.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ExchangeRateAdminSetEvent {
+    pub admin: Address,
+    pub set_by: Address,
+}
+
+pub fn emit_exchange_rate_admin_set(env: &Env, event: ExchangeRateAdminSetEvent) {
+    event.publish(env);
+}

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -13,6 +13,8 @@ use crate::events::{
     GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved,
     MilestoneClaimed, MilestoneFundedEvent, PaymentReceivedEvent, PaymentSentEvent,
     PayrollClaimedEvent,
+    emit_exchange_rate_updated, emit_exchange_rate_admin_set,
+    ExchangeRateUpdatedEvent, ExchangeRateAdminSetEvent,
 };
 use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,
@@ -1777,6 +1779,11 @@ pub fn set_exchange_rate_admin(
         .persistent()
         .set(&StorageKey::ExchangeRateAdmin, &admin);
 
+
+    emit_exchange_rate_admin_set(&env, ExchangeRateAdminSetEvent {
+        admin: admin.clone(),
+        set_by: caller.clone(),
+    });
     Ok(())
 }
 
@@ -1835,6 +1842,13 @@ pub fn set_exchange_rate(
     }
 
     DataKey::set_exchange_rate(env, &base, &quote, rate);
+
+    emit_exchange_rate_updated(&env, ExchangeRateUpdatedEvent {
+        base: base.clone(),
+        quote: quote.clone(),
+        rate,
+        updated_by: caller.clone(),
+    });
 
     Ok(())
 }

--- a/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Events, Ledger},
     token::StellarAssetClient,
-    Address, Env, Vec,
+    Address, Env, Symbol, TryFromVal, Vec,
 };
 
 use stello_pay_contract::storage::{DataKey, PayrollError};
@@ -185,4 +185,41 @@ fn test_claim_payroll_in_different_token_uses_fx_rate() {
         let paid = DataKey::get_agreement_paid_amount(&env, agreement_id);
         assert_eq!(paid, salary_per_period);
     });
+}
+
+/// Helper: count events by name
+fn count_events(env: &Env, event_name: &str) -> usize {
+    env.events().all().iter().filter(|e| {
+        if e.1.len() > 0 {
+            let topic = e.1.get(0).unwrap();
+            if let Ok(sym) = Symbol::try_from_val(env, &topic) {
+                return sym.to_string() == event_name;
+            }
+        }
+        false
+    }).count()
+}
+
+#[test]
+fn test_set_exchange_rate_emits_event() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    let rate: i128 = 1_000_000;
+
+    client.set_exchange_rate(&owner, &base, &quote, &rate);
+
+    let count = count_events(&env, \"exchange_rate_updated\");
+    assert!(count > 0, \"Expected exchange_rate_updated event\");
+}
+
+#[test]
+fn test_set_exchange_rate_admin_emits_event() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+    let admin = Address::generate(&env);
+
+    client.set_exchange_rate_admin(&owner, &admin);
+
+    let count = count_events(&env, \"exchange_rate_admin_set\");
+    assert!(count > 0, \"Expected exchange_rate_admin_set event\");
 }


### PR DESCRIPTION
## Description

Emit typed Soroban events from FX rate mutations to enable off-chain indexing.

## Changes

- Add ExchangeRateUpdatedEvent struct and emit_exchange_rate_updated helper
- Add ExchangeRateAdminSetEvent struct and emit_exchange_rate_admin_set helper
- Emit ExchangeRateUpdatedEvent from set_exchange_rate on successful rate update
- Emit ExchangeRateAdminSetEvent from set_exchange_rate_admin on successful admin update
- Update docs/events-schema.json with both event schemas
- Update docs/multi-currency.md with events section
- Add test assertions for both events

## Verification

- Test test_set_exchange_rate_emits_event asserts exchange_rate_updated event is emitted
- Test test_set_exchange_rate_admin_emits_event asserts exchange_rate_admin_set event is emitted

## Related Issue

Closes #488

## Changed Files

- onchain/contracts/stello_pay_contract/src/events.rs
- onchain/contracts/stello_pay_contract/src/payroll.rs
- onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
- docs/events-schema.json
- docs/multi-currency.md

## Risk

Low. Event-only changes with no logic modification.

## Execution Boundaries

- Only modifies event emission on the success path
- Failing paths (Unauthorized, ExchangeRateInvalid) do not emit events
- No state changes, no storage layout modifications

## Security Boundaries

- Events are emitted only after authorization checks pass
- Caller address is included as updated_by / set_by for audit trail
- No secrets exposed in event payloads

## Wallet

RTC269fa5650798c3aa5086a128c025a546e0a41d0b