### PR TITLE
fix(salary_adjustment): validate inputs on retroactive path (#514)

### DIFF
--- a/onchain/contracts/salary_adjustment/src/lib.rs
+++ b/onchain/contracts/salary_adjustment/src/lib.rs
@@ -566,6 +566,14 @@ impl SalaryAdjustmentContract {
             "Use create_adjustment for forward adjustments"
         );
 
+        assert_adjustment_inputs(
+            &env,
+            current_salary,
+            new_salary,
+            effective_date,
+            true, // allow_retroactive — retroactive path is inherently retroactive
+        );
+
         let zero = BytesN::from_array(&env, &[0; 32]);
         assert!(reason_hash != zero, "Retroactive reason hash required");
 

--- a/onchain/contracts/salary_adjustment/tests/test_adjustment.rs
+++ b/onchain/contracts/salary_adjustment/tests/test_adjustment.rs
@@ -934,3 +934,35 @@ fn test_get_owner() {
 
     assert_eq!(client.get_owner(), Some(owner));
 }
+
+// ============================================================================
+// RETROACTIVE NO-OP NEGATIVE TEST (#514)
+// ============================================================================
+
+/// A retroactive adjustment with new_salary == current_salary must be rejected.
+#[test]
+#[should_panic(expected = "New salary must differ from current salary")]
+fn test_retroactive_adjustment_noop_rejected() {
+    let env = create_env();
+    set_time(&env, 1_000);
+    let client = create_contract(&env);
+    let owner = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let employee = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let raw_reason_hash = reason_hash(&env, 42);
+
+    client.initialize(&owner);
+
+    // Retroactive no-op: new_salary (5_000) == current_salary (5_000)
+    client.create_retroactive_adjustment(
+        &owner,
+        &employer,
+        &employee,
+        &approver,
+        &5_000,
+        &5_000,
+        &500,
+        &raw_reason_hash,
+    );
+}


### PR DESCRIPTION
## Description

Add input validation (assert_adjustment_inputs) to create_retroactive_adjustment to ensure parity with the normal adjustment path. Previously the retroactive path skipped this validation, allowing no-op adjustments (new_salary == current_salary) to be created.

## Changes

- Add assert_adjustment_inputs call in create_retroactive_adjustment before the reason_hash check
- Add test_retroactive_adjustment_noop_rejected test asserting retroactive no-op is rejected

## Verification

- test_retroactive_adjustment_noop_rejected: retroactive adjustment with new_salary == current_salary panics with "New salary must differ from current salary"
- Existing test_authorized_retroactive_adjustment_works_and_is_logged still passes (no regression)

## Related Issue

Closes #514

## Changed Files

- onchain/contracts/salary_adjustment/src/lib.rs
- onchain/contracts/salary_adjustment/tests/test_adjustment.rs

## Risk

Low. Validation-only addition to the retroactive path mirroring already-tested normal-path validation.

## Execution Boundaries

- Only adds assert_adjustment_inputs call
- No storage layout or control flow changes
- No new error types added

## Security Boundaries

- Prevents no-op retroactive adjustments from polluting the audit trail
- Ensures the retroactive (privileged) path is not less validated than the normal path

## Wallet

RTC269fa5650798c3aa5086a128c025a546e0a41d0b