### PR TITLE
fix(payroll): document and enforce rounding/dust policy in FX conversion (#489)

### DIFF
--- a/docs/multi-currency.md
+++ b/docs/multi-currency.md
@@ -208,3 +208,19 @@ client.claim_payroll_in_token(&employee, &agreement_id, &0u32, &payout_token);
   - `claim_payroll_in_token` shares the same eligibility and period-counting
     logic as `claim_payroll`, ensuring consistent invariants across currencies.
 
+
+### Rounding Policy
+
+The FX conversion function \convert_amount\ always **rounds toward zero**
+(truncation) via integer division. This is a deliberate choice:
+
+- The contributor is **never over-paid**, which prevents escrow shortfall.
+- Any fractional remainder (dust) is silently discarded. The dust is not
+  tracked individually because each claim independently converts and the
+  aggregate shortfall across many claims is bounded by one unit per claim.
+  Escrow accounting naturally retains these residuals.
+- If a non-zero input produces a zero converted output (i.e.
+  \mount * rate < FX_SCALE\), the call returns \ExchangeRateInvalid\
+  to prevent silent non-payment.
+- This rounding policy matches the round-down semantics used by the
+  payment-splitter path elsewhere in the codebase.

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -2889,6 +2889,31 @@ fn get_next_agreement_id(env: &Env) -> u128 {
 ///
 /// The rate is interpreted as `quote_per_base * FX_SCALE`, where `from_token`
 /// is the base and `to_token` is the quote.
+/// Converts mount from rom_token to 	o_token using the configured FX rate.
+///
+/// # Rounding Policy
+///
+/// This function always **rounds toward zero** (truncation) via integer division.
+/// This is a deliberate choice for payroll: the contributor is never over-paid,
+/// and any remainder (dust) stays in the contract escrow balance.
+///
+/// # Dust Handling
+///
+/// A sub-unit remainder is silently discarded. The dust is not tracked individually
+/// because each claim independently converts and the aggregate shortfall across many
+/// claims is bounded by one unit per conversion. Escrow accounting naturally retains
+/// these fractional residuals.
+///
+/// # Zero-Output Guard
+///
+/// If the converted result is zero while the input mount is non-zero (i.e.
+/// mount * rate < FX_SCALE), the function returns ExchangeRateInvalid.
+/// This prevents silent non-payment for economically insignificant conversions.
+///
+/// # Panics / Errors
+/// * ExchangeRateNotFound — no rate is configured for the (from_token, to_token) pair
+/// * ExchangeRateInvalid — rate is zero, negative, or conversion produces zero output
+/// * ExchangeRateOverflow — intermediate multiplication exceeds i128 bounds
 fn convert_amount(
     env: &Env,
     from_token: &Address,
@@ -2923,9 +2948,15 @@ fn convert_amount(
         .checked_mul(rate)
         .ok_or(PayrollError::ExchangeRateOverflow)?;
 
+    // Round toward zero (truncation): discard fractional remainder
     let converted = scaled
         .checked_div(FX_SCALE)
         .ok_or(PayrollError::ExchangeRateInvalid)?;
+
+    // Zero-output guard: non-zero input must produce non-zero output
+    if converted == 0 && amount > 0 {
+        return Err(PayrollError::ExchangeRateInvalid);
+    }
 
     Ok(converted)
 }

--- a/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs
@@ -186,3 +186,65 @@ fn test_claim_payroll_in_different_token_uses_fx_rate() {
         assert_eq!(paid, salary_per_period);
     });
 }
+
+// ---------------------------------------------------------------------------
+// Dust, boundary, and sub-unit tests (#489 - rounding/dust policy)
+// ---------------------------------------------------------------------------
+
+/// Non-zero input smaller than FX_SCALE/rate should produce ExchangeRateInvalid.
+#[test]
+fn test_convert_currency_zero_output_guard() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    // Rate = 1 => FX_SCALE = 1_000_000, so amount < 1_000_000 truncates to 0
+    client.set_exchange_rate(&owner, &base, &quote, &1_000_000i128);
+
+    // 1 unit should convert to 0 because 1 * 1_000_000 / 1_000_000 = 1 (actually this is fine)
+    // Let's use rate = 1 and amount = 1 → 1 * 1 / 1_000_000 = 0 in integer math
+    client.set_exchange_rate(&owner, &base, &quote, &1i128);
+    let result = client.try_convert_currency(&base, &quote, &999_999i128);
+    assert!(
+        result.is_err(),
+        "Expected ExchangeRateInvalid for sub-unit conversion"
+    );
+}
+
+/// Round-down (truncation) test: amount=1, rate=999_999 should produce 0.
+#[test]
+fn test_convert_currency_truncation_round_down() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    // rate = 999_999 → 1 * 999_999 / 1_000_000 = 0 (truncated)
+    client.set_exchange_rate(&owner, &base, &quote, &999_999i128);
+    let result = client.try_convert_currency(&base, &quote, &1i128);
+    assert!(
+        result.is_err(),
+        "Expected ExchangeRateInvalid for sub-unit truncation"
+    );
+}
+
+/// Boundary: amount * rate == FX_SCALE should produce exactly 1.
+#[test]
+fn test_convert_currency_exact_fx_scale() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    // rate * amount == FX_SCALE exactly → 1 unit
+    client.set_exchange_rate(&owner, &base, &quote, &1_000_000i128);
+    let result = client.convert_currency(&base, &quote, &1i128);
+    assert_eq!(result, 1);
+}
+
+/// Large amounts near i128 bounds should not overflow.
+#[test]
+fn test_convert_currency_large_amount() {
+    let (env, owner, _employer, _arbiter, client) = create_test_env();
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+    client.set_exchange_rate(&owner, &base, &quote, &1i128);
+    // i128::MAX / FX_SCALE ≈ 1.7e30, so this should work
+    let result = client.convert_currency(&base, &quote, &(i128::MAX / 1_000_000));
+    assert!(result > 0);
+}


### PR DESCRIPTION
## Description

Document and enforce the rounding/dust policy in the FX conversion path. The existing integer division (truncation toward zero) is explicitly documented as the chosen rounding direction, and a zero-output guard is added to prevent silent non-payment.

## Changes

- **payroll.rs (convert_amount):** Add comprehensive doc comment documenting rounding policy, dust handling, and zero-output guard. Add converted == 0 && amount > 0 guard returning ExchangeRateInvalid.
- **docs/multi-currency.md:** Add Rounding Policy section documenting truncation, dust handling, and the zero-output guard.
- **test_multi_currency.rs:** Add 4 tests:
  - test_convert_currency_zero_output_guard — sub-unit amount rejected
  - test_convert_currency_truncation_round_down — truncation produces zero rejected
  - test_convert_currency_exact_fx_scale — exact FX_SCALE boundary works
  - test_convert_currency_large_amount — near-i128::MAX doesn't overflow

## Verification

Each new test asserts specific behavior: zero-output guard, truncation round-down, exact boundary, and large amounts.

## Related Issue

Closes #489

## Changed Files

- onchain/contracts/stello_pay_contract/src/payroll.rs
- docs/multi-currency.md
- onchain/contracts/stello_pay_contract/tests/test_multi_currency.rs

## Risk

Low. The rounding direction (truncation) is unchanged. The zero-output guard is a new but safe rejection path for inputs too small to convert.

## Execution Boundaries

- Only adds documentation, a zero-output guard, and tests
- No change to the conversion arithmetic itself

## Security Boundaries

- Zero-output guard prevents silent short-payment on sub-unit conversions
- Rounding policy (round-down) ensures contributor is never over-paid

## Wallet

RTC269fa5650798c3aa5086a128c025a546e0a41d0b