### PR TITLE
fix(payroll): validate arbiter in set_arbiter (reject self/no-op)

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1366,6 +1366,15 @@ pub fn activate_agreement(env: &Env, agreement_id: u128) {
 pub fn set_arbiter(env: &Env, caller: Address, arbiter: Address) -> bool {
     caller.require_auth();
 
+    // Reject self-appointment to preserve dispute neutrality.
+    assert!(arbiter != caller, "Arbiter cannot be the caller/employer");
+
+    // Reject setting the same arbiter again (no-op).
+    let current: Option<Address> = env.storage().persistent().get(&StorageKey::Arbiter);
+    if let Some(ref cur) = current {
+        assert!(arbiter != *cur, "Arbiter is already set to this address");
+    }
+
     env.storage()
         .persistent()
         .set(&StorageKey::Arbiter, &arbiter);


### PR DESCRIPTION
## Summary

Adds validation to `set_arbiter` to reject self-appointment and duplicate arbiter sets, preserving neutral dispute resolution.

Closes #508

## Changes

- Reject `arbiter == caller` (self-appointment undermines neutrality)
- Reject setting the same arbiter address (no-op detection)
- Uses existing `assert!` pattern consistent with the codebase

## Security Impact

Prevents an employer/contract-owner from appointing themselves as arbiter, which would undermine neutral dispute resolution.