### PR TITLE
fix(events): correct misspelled dispute event emitter function names

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -136,7 +136,7 @@ pub struct DisputeRaisedEvent {
     pub agreement_id: u128,
 }
 
-pub fn emit_dsipute_raised(env: &Env, event: DisputeRaisedEvent) {
+pub fn emit_dispute_raised(env: &Env, event: DisputeRaisedEvent) {
     event.publish(env);
 }
 
@@ -149,7 +149,7 @@ pub struct DisputeResolvedEvent {
     pub refund_employer: i128,
 }
 
-pub fn emit_dsipute_resolved(env: &Env, event: DisputeResolvedEvent) {
+pub fn emit_dispute_resolved(env: &Env, event: DisputeResolvedEvent) {
     event.publish(env);
 }
 pub fn emit_payroll_claimed(env: &Env, event: PayrollClaimedEvent) {

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{Address, Env, Vec};
 use crate::audit::{record_entry, AuditEvent};
 use crate::events::{
     emit_agreement_activated, emit_agreement_cancelled, emit_agreement_created,
-    emit_agreement_paused, emit_agreement_resumed, emit_dsipute_raised, emit_dsipute_resolved,
+    emit_agreement_paused, emit_agreement_resumed, emit_dispute_raised, emit_dispute_resolved,
     emit_employee_added, emit_grace_period_extended, emit_grace_period_finalized,
     emit_milestone_funded, emit_payment_received, emit_payment_sent, emit_payroll_claimed,
     emit_set_arbiter, AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent,
@@ -1637,7 +1637,7 @@ pub fn raise_dispute(env: &Env, caller: Address, agreement_id: u128) -> Result<(
         .persistent()
         .set(&StorageKey::Agreement(agreement_id), &agreement);
 
-    emit_dsipute_raised(env, DisputeRaisedEvent { agreement_id });
+    emit_dispute_raised(env, DisputeRaisedEvent { agreement_id });
     record_entry(
         env,
         caller,
@@ -1788,7 +1788,7 @@ fn resolve_dispute_core(
         .persistent()
         .set(&StorageKey::Agreement(agreement_id), &agreement);
 
-    emit_dsipute_resolved(
+    emit_dispute_resolved(
         env,
         DisputeResolvedEvent {
             agreement_id,


### PR DESCRIPTION
## Summary
Fixes #487

Renames two misspelled public event emitter functions:
- `emit_dsipute_raised` → `emit_dispute_raised`
- `emit_dsipute_resolved` → `emit_dispute_resolved`

## Changes
- **events.rs**: Fixed function names on both emitters
- **payroll.rs**: Updated import statement and both call sites (raise_dispute, resolve_dispute_core)

## Verification
- Zero occurrences of "dsipute" remain in either file
- No behavioral changes — only identifier names were corrected
- Event topic/data shape unchanged