### PR TITLE
fix(payment_retry): reject contradictory retry config (intervals + zero attempts) (#511)

### DIFF
--- a/onchain/contracts/payment_retry/src/lib.rs
+++ b/onchain/contracts/payment_retry/src/lib.rs
@@ -265,6 +265,15 @@ fn validate_retry_configuration(max_retry_attempts: u32, retry_intervals: &Vec<u
         );
     }
 
+    // Guard against contradictory configuration where intervals exist
+    // but no retries can occur (max_retry_attempts = 0).
+    if retry_intervals.len() > 0 {
+        assert!(
+            max_retry_attempts > 0,
+            "Max retry attempts must be positive when retry intervals are specified"
+        );
+    }
+
     let mut i: u32 = 0;
     while i < retry_intervals.len() {
         let interval = retry_intervals.get(i).expect("Retry interval missing");


### PR DESCRIPTION
## Summary

Fixes #511 by adding validation in `validate_retry_configuration` to reject the contradictory case where `retry_intervals` is non-empty but `max_retry_attempts` is zero.

## Problem

`validate_retry_configuration` allowed `max_retry_attempts=0` with a non-empty `retry_intervals` list. This produces a contradictory configuration: intervals exist in the schedule, but no retries can ever execute.

## Fix

Added a guard after the existing `max_retry_attempts > 0` ↔ `retry_intervals.len() > 0` check:

```rust
if retry_intervals.len() > 0 {
    assert!(max_retry_attempts > 0,
        "Max retry attempts must be positive when retry intervals are specified");
}
```

This ensures:
- If intervals are specified → attempts must be positive
- If attempts are positive → intervals must be specified (existing check)

The fix is symmetric and completes the two-way invariant.

## Files changed

- `onchain/contracts/payment_retry/src/lib.rs`: 5-line addition in `validate_retry_configuration`