### PR TITLE
fix(payment_retry): reject contradictory retry config

### DIFF
--- a/onchain/contracts/payment_retry/src/lib.rs
+++ b/onchain/contracts/payment_retry/src/lib.rs
@@ -248,6 +248,11 @@ fn mark_processed(env: &Env, payment_id: BytesN<32>) {
 
 /// Validates that `max_retry_attempts` and `retry_intervals` satisfy protocol
 /// constraints. Called at creation time; never called during retry processing.
+///
+/// A no-retry policy (`max_retry_attempts == 0`) must not carry retry
+/// intervals. Otherwise operators can submit a contradictory configuration that
+/// looks like it has backoff windows but terminally fails on the first missed
+/// attempt because no retries are actually allowed.
 fn validate_retry_configuration(max_retry_attempts: u32, retry_intervals: &Vec<u64>) {
     assert!(
         max_retry_attempts <= MAX_RETRY_ATTEMPTS,
@@ -258,7 +263,12 @@ fn validate_retry_configuration(max_retry_attempts: u32, retry_intervals: &Vec<u
         "Too many retry intervals"
     );
 
-    if max_retry_attempts > 0 {
+    if max_retry_attempts == 0 {
+        assert!(
+            retry_intervals.len() == 0,
+            "Retry intervals require retry attempts"
+        );
+    } else {
         assert!(
             retry_intervals.len() > 0,
             "Retry intervals required when retries are enabled"
@@ -639,5 +649,30 @@ impl PaymentRetryContract {
         env.storage()
             .persistent()
             .get::<_, Address>(&StorageKey::Owner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::vec;
+
+    #[test]
+    fn retry_configuration_allows_zero_attempts_without_intervals() {
+        let env = Env::default();
+        validate_retry_configuration(0, &vec![&env]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Retry intervals require retry attempts")]
+    fn retry_configuration_rejects_zero_attempts_with_intervals() {
+        let env = Env::default();
+        validate_retry_configuration(0, &vec![&env, 30u64]);
+    }
+
+    #[test]
+    fn retry_configuration_allows_positive_attempts_with_intervals() {
+        let env = Env::default();
+        validate_retry_configuration(3, &vec![&env, 30u64, 60u64]);
     }
 }


### PR DESCRIPTION
## Summary
- reject contradictory retry policies where `max_retry_attempts == 0` but `retry_intervals` is non-empty
- document the no-retry invariant in `validate_retry_configuration`
- add focused unit coverage for zero-attempt/no-interval, zero-attempt/with-interval, and positive-attempt/with-interval configurations

Fixes #511.

## Verification
```bash
export PATH="$HOME/.cargo/bin:$PATH"
cargo test -p payment_retry --lib
```

Result: `3 passed; 0 failed`.

Note: I ran the package integration tests first, but the existing `contracts/payment_retry/tests/test_retry.rs` suite does not compile against the current contract API (`PaymentStatus`, `create_payment_request`, and `status` field references are stale). This PR therefore adds focused lib-level regression coverage for the touched validator and verifies it with `--lib`.

## Security notes
A no-retry request now cannot carry misleading backoff intervals. Operators either configure zero retries with no intervals, or configure one or more retry attempts with at least one positive interval.
