### PR TITLE
feat: add Dependabot config for Cargo and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot configuration for Stellopay Core
+# Keeps Cargo dependencies and GitHub Actions up to date automatically.
+#
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      soroban-deps:
+        patterns:
+          - "soroban-*"
+          - "stellar-*"
+        update-types:
+          - "minor"
+          - "patch"
+      workspace-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "soroban-*"
+          - "stellar-*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #608

Adds `.github/dependabot.yml` with:

- **cargo ecosystem**: Weekly schedule (Mondays, 09:00 UTC), grouped updates for `soroban-*`/`stellar-*` dependencies and workspace deps separately. Limited to minor/patch updates. Max 10 open PRs.
- **github-actions ecosystem**: Weekly schedule, grouped. Max 5 open PRs.

Both entries include appropriate labels (`dependencies`, `rust`, `ci`) for easy triage.

## Verification
- YAML syntax validated
- Config-only change, no functional impact