### PR TITLE
docs: add SECURITY.md, CONTRIBUTING.md, CODEOWNERS, and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 * @Stellopay/maintainers
 
 # Soroban smart contracts
-/onchain/contracts/** @Stellopapay/contract-reviewers
+/onchain/contracts/** @Stellopay/contract-reviewers
 
 # Tooling
 /tools/** @Stellopay/tools-maintainers
@@ -16,4 +16,4 @@
 
 # Documentation
 /*.md @Stellopay/docs
-/SECURITY.md @Stellopapay/security
+/SECURITY.md @Stellopay/security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# File-level code ownership for Stellopay Core
+# Each line maps a file pattern to one or more owners.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-features/customizing-your-repository/about-code-owners
+
+# Default reviewers for the entire repository
+* @Stellopay/maintainers
+
+# Soroban smart contracts
+/onchain/contracts/** @Stellopapay/contract-reviewers
+
+# Tooling
+/tools/** @Stellopay/tools-maintainers
+
+# Build and CI configuration
+/.github/workflows/** @Stellopay/devops
+
+# Documentation
+/*.md @Stellopay/docs
+/SECURITY.md @Stellopapay/security

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Stellopay Core
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear and concise description of the bug.
+
+## Reproduction Steps
+1. ...
+2. ...
+3. ...
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- Rust version: `rustc --version`
+- Soroban CLI version: `soroban --version`
+- Network: testnet / mainnet
+
+## Additional Context
+Add any other context, logs, or screenshots here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for Stellopay Core
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+What problem does this feature solve?
+
+## Proposed Solution
+A clear description of what you want to happen.
+
+## Alternatives Considered
+What alternatives have you considered?
+
+## Additional Context
+Any other context, screenshots, or references.

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -1,0 +1,25 @@
+---
+name: Security Report
+about: Privately report a security vulnerability
+title: "[SECURITY] "
+labels: security
+assignees: ''
+---
+
+**IMPORTANT**: If this is a sensitive vulnerability, please use the GitHub Security Advisory tab instead:
+https://github.com/Stellopay/stellopay-core/security/advisories/new
+
+## Description
+What type of vulnerability is this?
+
+## Affected Component
+Which contract or tool is affected?
+
+## Impact
+What could an attacker achieve?
+
+## Steps to Reproduce
+How can this be demonstrated?
+
+## Suggested Fix (optional)
+Any ideas for how to address this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Stellopay Core
+
+Thank you for your interest in contributing! Stellopay Core is a Soroban-based payroll and escrow system on the Stellar network.
+
+## Getting Started
+
+### Prerequisites
+
+- Rust (stable, minimum 1.75.0)
+- WASM target: `rustup target add wasm32-unknown-unknown`
+- Soroban CLI: `cargo install --locked soroban-cli`
+- For testing: `cargo install cargo-deny cargo-audit`
+
+### Workspace Layout
+
+```
+onchain/contracts/       # Soroban smart contracts
+├── payroll/             # Payroll contract
+├── escrow/              # Escrow contract
+└── governance/          # Governance/multi-sig
+tools/                   # Off-chain tooling
+├── doc_checker/         # Documentation compliance checker
+├── compliance_checker/  # Compliance rule engine
+└── ...
+```
+
+### Build & Test
+
+```bash
+# Build all contracts
+cargo build --target wasm32-unknown-unknown --release
+
+# Run all tests
+cargo test --workspace
+
+# Format code
+cargo fmt --check
+
+# Lint
+cargo clippy --workspace -- -D warnings
+```
+
+### Pull Request Process
+
+1. Fork the repository and create a feature branch from `main`.
+2. If your change touches a contract, add or update tests.
+3. Ensure `cargo test --workspace` passes.
+4. Run `cargo fmt --check` before committing.
+5. Update documentation if your change affects public interfaces.
+6. Open a PR with a clear title and description referencing the related issue.
+
+### Commit Conventions
+
+We use conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, etc.
+
+## Code of Conduct
+
+All participants are expected to maintain a respectful and constructive environment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest `main` branch is supported with security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Stellopay Core, especially in the Soroban smart contracts under `onchain/contracts/`, please report it privately.
+
+**Do not open a public issue.** Instead, send a detailed report to the maintainers via the repository's security advisory tab:
+
+1. Go to https://github.com/Stellopay/stellopay-core/security/advisories/new
+2. Include a clear description of the vulnerability, affected contract(s), and a minimal reproduction if possible.
+3. You should receive an initial response within 48 hours.
+
+### Scope
+
+The following areas are in scope for security reports:
+- Soroban smart contracts in `onchain/contracts/`
+- Off-chain tools in `tools/` that interact with on-chain state
+- Build scripts and CI/CD pipelines that produce deployable artifacts
+
+### Out of Scope
+
+- General network-level attacks on the Stellar network
+- Issues in third-party dependencies (report those upstream)
+- Theoretical attacks without a demonstrated exploit path
+
+## Disclosure Timeline
+
+We aim to:
+- Acknowledge receipt within 48 hours
+- Provide a fix timeline within 5 business days
+- Deploy a fix before public disclosure
+
+We appreciate coordinated disclosure and will acknowledge security researchers who help us improve the project.


### PR DESCRIPTION
Closes #607

Adds project health documentation files:

- `SECURITY.md`: Responsible disclosure policy with monitored contact, scope (onchain contracts/tools), and disclosure timeline
- `CONTRIBUTING.md`: Workspace layout, build/test workflow, PR process, commit conventions
- `.github/CODEOWNERS`: File ownership mapping for `onchain/contracts/**`, `tools/**`, workflows, and docs
- `.github/ISSUE_TEMPLATE/`: Bug report, feature request, and security report templates

All templates render correctly in the GitHub UI and follow community best practices.