### PR TITLE
fix(expense_reimbursement): use checked_add for escrow_amount in fund_expense (#598)

### DIFF
--- a/onchain/contracts/expense_reimbursement/src/lib.rs
+++ b/onchain/contracts/expense_reimbursement/src/lib.rs
@@ -319,7 +319,8 @@ impl ExpenseReimbursementContract {
         let token_client = token::Client::new(&env, &expense.token);
         token_client.transfer(&payer, &env.current_contract_address(), &amount);
 
-        expense.escrow_amount += amount;
+        expense.escrow_amount = expense.escrow_amount.checked_add(amount)
+            .expect("Escrow amount overflow");
         
         // Register the payer if none exists; else require same payer for refunds to be coherent
         if expense.payer.is_none() {

--- a/onchain/contracts/expense_reimbursement/tests/test_expense.rs
+++ b/onchain/contracts/expense_reimbursement/tests/test_expense.rs
@@ -827,3 +827,40 @@ fn test_multiple_expenses_with_unique_receipts_work_end_to_end() {
     assert_eq!(token_client.balance(&client.address), 0);
     assert_eq!(token_client.balance(&payer), 4000);
 }
+
+#[test]
+fn test_fund_expense_overflow_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let submitter = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_client = create_token(&env, &token_admin);
+    let client = create_contract(&env);
+
+    // Mint a huge amount to the payer so the token transfer succeeds
+    token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &i128::MAX);
+
+    client.initialize(&owner);
+    client.add_approver(&approver);
+
+    let expense_id = client.submit_expense(
+        &submitter,
+        &approver,
+        &token_client.address,
+        &500,
+        &String::from_str(&env, "receipt_overflow"),
+        &String::from_str(&env, "Overflow test"),
+    );
+
+    // Fund the expense with i128::MAX to fill escrow_amount to capacity
+    client.fund_expense(&payer, &expense_id, &i128::MAX);
+
+    // Second funding should overflow and panic
+    let result = client.try_fund_expense(&payer, &expense_id, &1);
+    assert!(result.is_err());
+}
+


### PR DESCRIPTION
## Summary

Closes #598

Replace `+=` operator with `checked_add` in `fund_expense()` to prevent
silent i128 overflow on the `escrow_amount` accumulator.

## Changes

- **lib.rs**: `expense.escrow_amount += amount` → `checked_add` with `.expect()`
- **test_expense.rs**: add `test_fund_expense_overflow_rejected` — funds
  `i128::MAX` then attempts `+1`, asserting the second call fails

## Security

Silent integer wrap on an escrow balance is a direct fund-safety bug.
`checked_add` ensures overflow is caught at the contract level before
any further state mutation.

## Test

```bash
cargo test -p expense-reimbursement
```