### PR TITLE
fix(withdrawal_timelock): validate withdrawal amount in queue (#586)

### DIFF
--- a/onchain/contracts/withdrawal_timelock/src/lib.rs
+++ b/onchain/contracts/withdrawal_timelock/src/lib.rs
@@ -35,6 +35,12 @@ pub enum TimelockError {
     NotReady = 7,
     /// Operation is no longer in `Queued` status.
     AlreadyExecutedOrCancelled = 8,
+    /// Amount in a Withdrawal operation must be positive.
+    ///
+    /// Rejecting zero or negative amounts at queue time prevents no-op
+    /// privileged operations from consuming timelock slots and polluting
+    /// the audit trail.
+    InvalidWithdrawalAmount = 9,
 }
 
 // ─── Domain Types ─────────────────────────────────────────────────────────────
@@ -48,6 +54,7 @@ pub enum OperationKind {
     /// Layout: `(token, to, amount)`.
     /// Actual token transfer is performed by an external orchestrator after
     /// the timelock is satisfied; this contract records the intent only.
+    /// The `amount` must be strictly positive (> 0) — validated at queue time.
     Withdrawal(Address, Address, i128),
 
     /// A generic administrative change on an external contract.
@@ -55,6 +62,8 @@ pub enum OperationKind {
     /// Layout: `(target_contract, payload_hash)`.
     /// The `payload_hash` is an opaque 32-byte commitment to the change
     /// payload; off-chain tooling must verify this hash before applying.
+    /// Fields are NOT validated by the timelock; the caller is responsible
+    /// for payload correctness.
     AdminChange(Address, soroban_sdk::BytesN<32>),
 }
 
@@ -131,6 +140,28 @@ fn validate_delay(d: u64) -> Result<(), TimelockError> {
     }
     if d > MAX_DELAY_SECONDS {
         return Err(TimelockError::DelayTooLarge);
+    }
+    Ok(())
+}
+
+/// Validates that an `OperationKind` carries semantically meaningful parameters.
+///
+/// # Validation scope
+///
+/// | Kind | Field(s) validated | Rule |
+/// |------|--------------------|------|
+/// | `Withdrawal` | `amount` | Must be strictly positive (> 0) |
+/// | `AdminChange` | *(none)* | Opaque payload — not interpreted by the timelock |
+///
+/// Rejecting zero or negative withdrawal amounts at queue time prevents
+/// no-op privileged operations from consuming timelock slots and polluting
+/// the audit trail. `AdminChange` fields are intentionally left unvalidated
+/// because the timelock cannot interpret their payload semantics.
+fn validate_operation_kind(kind: &OperationKind) -> Result<(), TimelockError> {
+    if let OperationKind::Withdrawal(_, _, amount) = kind {
+        if *amount <= 0 {
+            return Err(TimelockError::InvalidWithdrawalAmount);
+        }
     }
     Ok(())
 }
@@ -278,8 +309,14 @@ impl WithdrawalTimelock {
     /// @dev Admin-only. The `eta` is computed as `now + min_delay_seconds`.
     ///      The operation cannot be executed before `eta` has been reached.
     ///      Multiple distinct operations may be queued simultaneously; each
-    ///      receives a unique monotone id. Emits:
-    ///        `("timelock_queued", op_id) → kind`
+    ///      receives a unique monotone id.
+    ///
+    ///      **Validation**: `Withdrawal` kinds require `amount > 0`.
+    ///      Zero or negative amounts are rejected with `InvalidWithdrawalAmount`
+    ///      to prevent no-op privileged operations. `AdminChange` payloads are
+    ///      opaque and not validated by the timelock.
+    ///
+    ///      Emits: `("timelock_queued", op_id) → kind`
     ///      which off-chain monitors should subscribe to for alerting.
     /// @param caller Admin address queuing the operation; must authenticate.
     /// @param kind   `Withdrawal(token, to, amount)` or
@@ -288,6 +325,7 @@ impl WithdrawalTimelock {
     pub fn queue(env: Env, caller: Address, kind: OperationKind) -> Result<u128, TimelockError> {
         require_initialized(&env)?;
         require_admin(&env, &caller)?;
+        validate_operation_kind(&kind)?;
 
         let min_delay = read_min_delay(&env);
         // Defensive belt-and-suspenders: min_delay can only be 0 if the

--- a/onchain/contracts/withdrawal_timelock/tests/test_timelock.rs
+++ b/onchain/contracts/withdrawal_timelock/tests/test_timelock.rs
@@ -132,7 +132,7 @@ fn initialize_twice_fails() {
     assert_eq!(res, Err(Ok(TimelockError::AlreadyInitialized)));
 }
 
-// ─── Group B: Queue (7 tests) ────────────────────────────────────────────────
+// ─── Group B: Queue (9 tests) ────────────────────────────────────────────────
 
 #[test]
 fn queue_withdrawal_returns_op_id_one() {
@@ -230,6 +230,32 @@ fn queue_appends_to_operations_for() {
     assert_eq!(ids.len(), 2);
     assert_eq!(ids.get(0).unwrap(), id1);
     assert_eq!(ids.get(1).unwrap(), id2);
+}
+
+#[test]
+fn queue_zero_amount_withdrawal_fails() {
+    let env = create_env();
+    let (client, admin) = setup(&env);
+
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let kind = OperationKind::Withdrawal(token, to, 0i128);
+
+    let res = client.try_queue(&admin, &kind);
+    assert_eq!(res, Err(Ok(TimelockError::InvalidWithdrawalAmount)));
+}
+
+#[test]
+fn queue_negative_amount_withdrawal_fails() {
+    let env = create_env();
+    let (client, admin) = setup(&env);
+
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let kind = OperationKind::Withdrawal(token, to, -1i128);
+
+    let res = client.try_queue(&admin, &kind);
+    assert_eq!(res, Err(Ok(TimelockError::InvalidWithdrawalAmount)));
 }
 
 // ─── Group C: Execute (8 tests) ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Closes #586

Adds input validation to `queue()` in `withdrawal_timelock` to reject `Withdrawal` operations with zero or negative amounts.

## Changes
- **`lib.rs`**: Added `InvalidWithdrawalAmount` error variant (#9) and `validate_operation_kind()` helper that checks `amount > 0` for `Withdrawal` kinds. Validation is called at the top of `queue()` before storage writes. `AdminChange` payloads remain unvalidated (opaque to the timelock).
- **`test_timelock.rs`**: Added 2 new tests — `queue_zero_amount_withdrawal_fails` and `queue_negative_amount_withdrawal_fails` — asserting `InvalidWithdrawalAmount` is returned. Updated Group B count from 7 to 9 tests.

## Security
- Prevents no-op privileged operations from consuming timelock slots and polluting the audit trail.
- Validation scope is deliberately narrow: only fields the timelock can interpret are validated. `AdminChange` payloads are explicitly left opaque.

## Test coverage
- Zero amount → rejected
- Negative amount → rejected
- Positive amount → accepted (existing tests unchanged)
- Non-withdrawal kinds → unaffected