### PR TITLE
fix(audit_logger): clamp get_logs limit with MAX_PAGE_SIZE and skip orphaned entries

### DIFF
--- a/onchain/contracts/audit_logger/src/lib.rs
+++ b/onchain/contracts/audit_logger/src/lib.rs
@@ -4,6 +4,10 @@ use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, 
 use stellar_contract_utils::upgradeable::UpgradeableInternal;
 use stellar_macros::Upgradeable;
 
+/// Maximum page size for log queries to prevent unbounded iteration.
+/// Mirrors `payment_history` pagination pattern.
+const MAX_PAGE_SIZE: u32 = 100;
+
 /// Storage keys for the audit logger contract.
 #[contracttype]
 #[derive(Clone)]
@@ -284,6 +288,9 @@ impl AuditLoggerContract {
             return Err(AuditError::InvalidArguments);
         }
 
+        // Clamp limit to MAX_PAGE_SIZE to prevent unbounded iteration
+        let limit = core::cmp::min(limit, MAX_PAGE_SIZE);
+
         let first_id: u64 = env
             .storage()
             .persistent()
@@ -302,6 +309,8 @@ impl AuditLoggerContract {
         let mut results = Vec::new(&env);
         let mut remaining = core::cmp::min(limit as u64, log_count - offset as u64);
 
+        // Track skipped count for orphaned entries (pruned by retention)
+        let mut skipped: u64 = 0;
         let mut current_id = first_id + offset as u64;
         while remaining > 0 {
             if let Some(entry) = env
@@ -310,9 +319,17 @@ impl AuditLoggerContract {
                 .get::<_, AuditLogEntry>(&StorageKey::LogEntry(current_id))
             {
                 results.push_back(entry);
+                remaining -= 1;
+            } else {
+                // Entry was pruned by retention; skip and continue
+                skipped += 1;
             }
             current_id += 1;
-            remaining -= 1;
+
+            // Safety bound: stop if we've scanned far beyond the expected range
+            if skipped > MAX_PAGE_SIZE as u64 * 2 {
+                break;
+            }
         }
 
         Ok(results)
@@ -332,6 +349,9 @@ impl AuditLoggerContract {
         if limit == 0 {
             return Err(AuditError::InvalidArguments);
         }
+
+        // Clamp limit to MAX_PAGE_SIZE to prevent unbounded iteration
+        let limit = core::cmp::min(limit, MAX_PAGE_SIZE);
 
         let first_id: u64 = env
             .storage()

--- a/onchain/contracts/audit_logger/tests/test_audit.rs
+++ b/onchain/contracts/audit_logger/tests/test_audit.rs
@@ -95,4 +95,65 @@ fn test_get_logs_pagination() {
     assert_eq!(page.get(0).unwrap().id, 2u64);
     assert_eq!(page.get(1).unwrap().id, 3u64);
     assert_eq!(page.get(2).unwrap().id, 4u64);
+#[test]
+fn test_get_logs_limit_clamped() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+
+    let contract_id = env.register(AuditLoggerContract, ());
+    let client = AuditLoggerContractClient::new(&env, &contract_id);
+
+    client.initialize(&owner, &0);
+
+    // Append 5 logs
+    let actor = Address::generate(&env);
+    for i in 0..5u64 {
+        client.append_log_(&actor, &symbol_short!("test"), &None, &None);
+    }
+
+    // Request more than MAX_PAGE_SIZE - should be clamped
+    let result = client.get_logs(&0, &(MAX_PAGE_SIZE + 1));
+    assert_eq!(result.len(), 5);
+}
+
+#[test]
+fn test_get_logs_beyond_max_page_size() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+
+    let contract_id = env.register(AuditLoggerContract, ());
+    let client = AuditLoggerContractClient::new(&env, &contract_id);
+
+    client.initialize(&owner, &0);
+
+    // Append more logs than MAX_PAGE_SIZE
+    let actor = Address::generate(&env);
+    for i in 0..200u64 {
+        client.append_log_(&actor, &symbol_short!("test"), &None, &None);
+    }
+
+    // Request all - should be clamped to MAX_PAGE_SIZE
+    let result = client.get_logs(&0, &200);
+    assert_eq!(result.len(), MAX_PAGE_SIZE as usize);
+}
+
+#[test]
+fn test_get_latest_logs_clamped() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+
+    let contract_id = env.register(AuditLoggerContract, ());
+    let client = AuditLoggerContractClient::new(&env, &contract_id);
+
+    client.initialize(&owner, &0);
+
+    let actor = Address::generate(&env);
+    for i in 0..200u64 {
+        client.append_log_(&actor, &symbol_short!("test"), &None, &None);
+    }
+
+    let result = client.get_latest_logs(&200);
+    assert_eq!(result.len(), MAX_PAGE_SIZE as usize);
+}
+
 }


### PR DESCRIPTION
## Summary
Closes #604

### Changes
- Add `MAX_PAGE_SIZE = 100` constant matching `payment_history` pattern
- Clamp `limit` in both `get_logs()` and `get_latest_logs()` 
- Skip orphaned entries (pruned by retention) gracefully with safety bound
- Track skipped entries to prevent infinite loops on retention gaps

### Security
- Bounded iteration prevents budget-exhaustion DoS from uncapped `limit`
- Safety bound (`skipped > MAX_PAGE_SIZE * 2`) prevents infinite loops on retention-deleted entries

### Tests Added
- `test_get_logs_limit_clamped`: basic limit clamping
- `test_get_logs_beyond_max_page_size`: large limit beyond MAX_PAGE_SIZE
- `test_get_latest_logs_clamped`: clamping in get_latest_logs