### PR TITLE
fix(rate_limiter): require positive burst and refill_rate

### DIFF
--- a/onchain/contracts/rate_limiter/src/lib.rs
+++ b/onchain/contracts/rate_limiter/src/lib.rs
@@ -51,6 +51,16 @@ pub struct LimitConfig {
     /// Tokens added to the bucket per second (refill rate)
     pub refill_rate: u32,
 }
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RateLimitError {
+    /// Burst capacity must be greater than zero to allow traffic
+    InvalidBurst = 1,
+    /// Refill rate must be greater than zero to allow token regeneration
+    InvalidRefillRate = 2,
+}
+
 
 #[contract]
 pub struct RateLimiter;
@@ -88,11 +98,20 @@ impl RateLimiter {
     /// @param enabled Whether to enforce the global limit.
     /// @param burst Global maximum burst capacity.
     /// @param refill_rate Global tokens added per second.
-    pub fn set_global_limit(env: Env, enabled: bool, burst: u32, refill_rate: u32) {
+    pub fn set_global_limit(env: Env, enabled: bool, burst: u32, refill_rate: u32) -> Result<(), RateLimitError> {
         Self::require_admin_auth(&env);
+        if enabled {
+            if burst == 0 {
+                return Err(RateLimitError::InvalidBurst);
+            }
+            if refill_rate == 0 {
+                return Err(RateLimitError::InvalidRefillRate);
+            }
+        }
         env.storage().persistent().set(&StorageKey::GlobalLimitEnabled, &enabled);
         env.storage().persistent().set(&StorageKey::GlobalBurst, &burst);
         env.storage().persistent().set(&StorageKey::GlobalRefillRate, &refill_rate);
+        Ok(())
     }
 
     /// Sets a per-address limit override.
@@ -101,9 +120,16 @@ impl RateLimiter {
     /// @param addr Subject address.
     /// @param burst Max burst capacity for this address.
     /// @param refill_rate Tokens added per second for this address.
-    pub fn set_limit_for(env: Env, addr: Address, burst: u32, refill_rate: u32) {
+    pub fn set_limit_for(env: Env, addr: Address, burst: u32, refill_rate: u32) -> Result<(), RateLimitError> {
         Self::require_admin_auth(&env);
+        if burst == 0 {
+            return Err(RateLimitError::InvalidBurst);
+        }
+        if refill_rate == 0 {
+            return Err(RateLimitError::InvalidRefillRate);
+        }
         env.storage().persistent().set(&StorageKey::Limit(addr), &LimitConfig { burst, refill_rate });
+        Ok(())
     }
 
     /// Removes a per-address limit override.

--- a/onchain/contracts/rate_limiter/tests/test_rate_limit.rs
+++ b/onchain/contracts/rate_limiter/tests/test_rate_limit.rs
@@ -159,5 +159,72 @@ fn test_admin_transfer() {
     
     client.transfer_admin(&admin2);
     assert_eq!(client.get_admin(), Some(admin2.clone()));
+#[test]
+fn test_set_limit_for_zero_burst_rejected() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let addr = Address::generate(&env);
+    let contract_id = env.register(RateLimiter, ());
+    let client = RateLimiterClient::new(&env, &contract_id);
+    client.initialize(&admin, &10, &2, &false);
+    
+    // Try to set zero burst - should be rejected
+    let result: Result<(), _> = client.try_set_limit_for(&addr, &0, &5);
+    assert!(result.is_err());
 }
 
+#[test]
+fn test_set_limit_for_zero_refill_rejected() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let addr = Address::generate(&env);
+    let contract_id = env.register(RateLimiter, ());
+    let client = RateLimiterClient::new(&env, &contract_id);
+    client.initialize(&admin, &10, &2, &false);
+    
+    // Try to set zero refill_rate - should be rejected
+    let result: Result<(), _> = client.try_set_limit_for(&addr, &5, &0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_limit_for_both_zero_rejected() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let addr = Address::generate(&env);
+    let contract_id = env.register(RateLimiter, ());
+    let client = RateLimiterClient::new(&env, &contract_id);
+    client.initialize(&admin, &10, &2, &false);
+    
+    // Try to set both zero
+    let result: Result<(), _> = client.try_set_limit_for(&addr, &0, &0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_global_limit_zero_burst_rejected() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RateLimiter, ());
+    let client = RateLimiterClient::new(&env, &contract_id);
+    client.initialize(&admin, &10, &2, &false);
+    
+    // Try to enable global limit with zero burst
+    let result: Result<(), _> = client.try_set_global_limit(&true, &0, &5);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_global_limit_zero_refill_rate_rejected() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RateLimiter, ());
+    let client = RateLimiterClient::new(&env, &contract_id);
+    client.initialize(&admin, &10, &2, &false);
+    
+    // Try to enable global limit with zero refill_rate
+    let result: Result<(), _> = client.try_set_global_limit(&true, &5, &0);
+    assert!(result.is_err());
+}
+
+}


### PR DESCRIPTION
## Summary
Closes #510

### Changes
- Add `RateLimitError` enum with `InvalidBurst` and `InvalidRefillRate` variants
- Validate `burst > 0` and `refill_rate > 0` in `set_limit_for`
- Validate `burst > 0` and `refill_rate > 0` in `set_global_limit` (when enabled)
- Return `Result<(), RateLimitError>` instead of silently storing zero values

### Security
- Prevents silent DoS: zero-capacity rate limits permanently block traffic
- No existing valid limit configurations are affected
- Admin bypass remains intact for governance controllers

### Tests Added
- `test_set_limit_for_zero_burst_rejected`
- `test_set_limit_for_zero_refill_rejected`  
- `test_set_limit_for_both_zero_rejected`
- `test_set_global_limit_zero_burst_rejected`
- `test_set_global_limit_zero_refill_rate_rejected`