### PR TITLE
fix(price_oracle): validate tolerance_bps <= 10_000 in configure_pair

### DIFF
--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -41,6 +41,7 @@ pub enum OracleError {
     DuplicateVote = 11,
     /// Source submitted too frequently; must wait at least `min_submit_interval_secs`.
     SubmissionRateLimited = 12,
+    ToleranceOutOfRange = 13,
 }
 
 // ============================================================================
@@ -365,6 +366,9 @@ impl PriceOracleContract {
         }
         if max_staleness_seconds == 0 || quorum_n == 0 || quorum_window_seconds == 0 {
             return Err(OracleError::InvalidPairConfig);
+        }
+        if tolerance_bps > 10_000 {
+            return Err(OracleError::ToleranceOutOfRange);
         }
 
         let cfg = PairConfig {

--- a/onchain/contracts/price_oracle/tests/test_oracle.rs
+++ b/onchain/contracts/price_oracle/tests/test_oracle.rs
@@ -1426,3 +1426,53 @@ fn test_rate_limit_zero_interval_is_disabled() {
     let res = oracle_client.try_push_price(&source, &base, &quote, &2_100_000i128, &1_001u64);
     assert!(res.is_ok());
 }
+
+// === Tolerance BPS boundary tests (Issue #594) ===
+#[test]
+fn test_tolerance_bps_zero_accepted() {
+    let env = create_env();
+    let (payroll_id, _, _) = setup_payroll(&env);
+    let (_, oracle_client, oracle_owner) = setup_oracle(&env, &payroll_id);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    let res = oracle_client.try_configure_pair(
+        &oracle_owner, &base, &quote,
+        &500_000i128, &5_000_000i128, &600u64,
+        &2u32, &0u32, &60u64, &0u64,
+    );
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_tolerance_bps_max_accepted() {
+    let env = create_env();
+    let (payroll_id, _, _) = setup_payroll(&env);
+    let (_, oracle_client, oracle_owner) = setup_oracle(&env, &payroll_id);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    let res = oracle_client.try_configure_pair(
+        &oracle_owner, &base, &quote,
+        &500_000i128, &5_000_000i128, &600u64,
+        &2u32, &10_000u32, &60u64, &0u64,
+    );
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_tolerance_bps_over_max_rejected() {
+    let env = create_env();
+    let (payroll_id, _, _) = setup_payroll(&env);
+    let (_, oracle_client, oracle_owner) = setup_oracle(&env, &payroll_id);
+    let base = Address::generate(&env);
+    let quote = Address::generate(&env);
+
+    let res = oracle_client.try_configure_pair(
+        &oracle_owner, &base, &quote,
+        &500_000i128, &5_000_000i128, &600u64,
+        &2u32, &10_001u32, &60u64, &0u64,
+    );
+    assert_eq!(res, Err(Ok(OracleError::ToleranceOutOfRange)));
+}
+


### PR DESCRIPTION
## Summary
Validate `tolerance_bps` upper bound in `price_oracle::configure_pair`.

## Changes
- Add `ToleranceOutOfRange` error variant (#13) to `OracleError`
- Reject `tolerance_bps > 10_000` in `configure_pair` with the new error
- Add 3 tests: zero accepted, 10_000 accepted, 10_001 rejected

## Fixes
Closes #594

## Security
An unbounded tolerance neutralizes deviation protection; the cap restores a meaningful guard.