### PR TITLE
fix(slashing_penalty): reject zero quorum in initialize

### DIFF
--- a/onchain/contracts/slashing_penalty/src/lib.rs
+++ b/onchain/contracts/slashing_penalty/src/lib.rs
@@ -212,6 +212,9 @@ impl SlashingPenaltyContract {
         admin.require_auth();
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&TOKEN, &token);
+                if quorum == 0 {
+            return Err(SlashError::InvalidConfig);
+        }
         env.storage().instance().set(&QUORUM, &quorum.max(DEFAULT_QUORUM));
         env.storage().instance().set(&SLASHERS, &Vec::<Address>::new(&env));
         env.storage().instance().set(&STAKES, &Map::<Address, i128>::new(&env));

--- a/onchain/contracts/slashing_penalty/tests/integration_test.rs
+++ b/onchain/contracts/slashing_penalty/tests/integration_test.rs
@@ -615,3 +615,24 @@ fn test_slash_exactly_at_appeal_deadline_still_open() {
     let result = t.client.try_execute_slash(&hash);
     assert_eq!(result, Err(Ok(SlashError::AppealWindowOpen)));
 }
+
+#[test]
+fn test_initialize_quorum_zero_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SlashingPenaltyContract);
+    let client = SlashingPenaltyContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let result = client.try_initialize(
+        &admin, &token,
+        &0u32,        // zero quorum - should be rejected
+        &5_000u32,
+        &6_000i128,
+        &9_000i128,
+        &86_400u64,
+    );
+    assert_eq!(result, Err(Ok(SlashError::InvalidConfig)));
+}
+


### PR DESCRIPTION
## Summary
Reject `quorum == 0` in `slashing_penalty::initialize` with a typed error instead of silently raising to `DEFAULT_QUORUM`.

## Changes
- Add explicit zero-quorum check in `initialize` before `.max(DEFAULT_QUORUM)` coercion
- Returns `SlashError::InvalidConfig` when `quorum_threshold == 0`
- Add negative test asserting `quorum = 0` returns an error

## Fixes
Closes #584

## Security
Quorum directly gates slashing authority; coercion must not let a zero-config deploy proceed.