### PR TITLE
fix(payroll): reject zero max_cumulative_extension_bps in set_grace_extension_policy (#506)

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1489,7 +1489,7 @@ pub fn set_grace_extension_policy(
     // Sanity bounds so a compromised owner key cannot configure absurd values in one tx.
     const MAX_BPS: u32 = 500_000;
     const MAX_PER_CALL: u64 = 730 * 24 * 3600;
-    if policy.max_cumulative_extension_bps > MAX_BPS {
+    if policy.max_cumulative_extension_bps == 0 || policy.max_cumulative_extension_bps > MAX_BPS {
         return Err(PayrollError::GraceExtensionInvalid);
     }
     if policy.max_extension_per_call_seconds == 0

--- a/onchain/contracts/stello_pay_contract/tests/test_grace_period_extension.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_grace_period_extension.rs
@@ -317,6 +317,23 @@ fn test_set_grace_extension_policy_rejects_absurd_bps() {
         .unwrap();
     assert_eq!(e, PayrollError::GraceExtensionInvalid);
 }
+#[test]
+fn test_set_grace_extension_policy_rejects_zero_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, client, owner) = setup(&env);
+    let p = GracePeriodExtensionPolicy {
+        max_cumulative_extension_bps: 0,
+        max_extension_per_call_seconds: 3600,
+    };
+    let e = client
+        .try_set_grace_extension_policy(&owner, &p)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, PayrollError::GraceExtensionInvalid);
+}
+
 
 #[test]
 fn test_grace_period_extended_event_emitted() {


### PR DESCRIPTION
## Summary
Closes #506

## Changes
- **payroll.rs**: Add `policy.max_cumulative_extension_bps == 0` check before `> MAX_BPS` guard in `set_grace_extension_policy`, returning `PayrollError::GraceExtensionInvalid`
- **test_grace_period_extension.rs**: Add `test_set_grace_extension_policy_rejects_zero_bps` test

## Why
The `set_grace_extension_policy` function already rejects zero `max_extension_per_call_seconds` but silently accepts zero `max_cumulative_extension_bps`, which would disable all grace extensions with no error.

## Testing
- `test_set_grace_extension_policy_rejects_zero_bps`: asserts zero bps returns `GraceExtensionInvalid`
- All existing tests continue to pass