### PR TITLE
feat(rate_limiter): add read-only get_usage query (#600)

### DIFF
--- a/onchain/contracts/rate_limiter/src/lib.rs
+++ b/onchain/contracts/rate_limiter/src/lib.rs
@@ -143,6 +143,38 @@ impl RateLimiter {
         Self::consume_bucket(&env, StorageKey::Usage(subject.clone()), limit.burst, limit.refill_rate)
     }
 
+    /// Gets the current usage state for an address without mutating state.
+    ///
+    /// @notice Read-only query returning the effective token count after computing
+    ///         refill at the current ledger timestamp.
+    /// @dev Performs no mutation and requires no authentication.
+    /// @param addr Address to query.
+    /// @return Usage with token count as of now and the snapshot timestamp.
+    pub fn get_usage(env: Env, addr: Address) -> Usage {
+        Self::require_initialized(&env);
+
+        let limit = Self::get_limit_config(&env, &addr);
+        let now = env.ledger().timestamp();
+        let key = StorageKey::Usage(addr);
+
+        let stored: Usage = env.storage().persistent().get(&key).unwrap_or(Usage {
+            last_update: now,
+            tokens: limit.burst,
+        });
+
+        let elapsed = now.saturating_sub(stored.last_update);
+        let mut tokens = stored.tokens;
+        if elapsed > 0 {
+            let new_tokens = (elapsed as u32).saturating_mul(limit.refill_rate);
+            tokens = tokens.saturating_add(new_tokens);
+            if tokens > limit.burst {
+                tokens = limit.burst;
+            }
+        }
+
+        Usage { last_update: now, tokens }
+    }
+
     /// Explicitly resets usage for an address.
     ///
     /// @dev Only callable by admin.
@@ -218,4 +250,3 @@ impl RateLimiter {
         admin.require_auth();
     }
 }
-

--- a/onchain/contracts/rate_limiter/tests/test_rate_limit.rs
+++ b/onchain/contracts/rate_limiter/tests/test_rate_limit.rs
@@ -161,3 +161,38 @@ fn test_admin_transfer() {
     assert_eq!(client.get_admin(), Some(admin2.clone()));
 }
 
+#[test]
+fn test_get_usage_read_only() {
+    let env = create_env();
+    let (_id, client) = register_contract(&env);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 100);
+    client.initialize(&admin, &5u32, &1u32, &false);
+
+    // Fresh user shows full burst
+    let usage = client.get_usage(&user);
+    assert_eq!(usage.tokens, 5);
+
+    // Consume 2, get_usage reflects state after consumption
+    client.check_and_consume(&user);
+    client.check_and_consume(&user);
+    let usage2 = client.get_usage(&user);
+    assert_eq!(usage2.tokens, 3);
+
+    // Advance 2s: tokens refill to cap (3 + 2*1 = 5, capped at 5)
+    env.ledger().with_mut(|li| li.timestamp = 102);
+    let usage3 = client.get_usage(&user);
+    assert_eq!(usage3.tokens, 5);
+
+    // get_usage does NOT mutate state
+    let usage4 = client.get_usage(&user);
+    assert_eq!(usage4.tokens, 5);
+    assert_eq!(client.check_and_consume(&user), 4);
+
+    // Address with no limit uses defaults
+    let new_user = Address::generate(&env);
+    let usage5 = client.get_usage(&new_user);
+    assert_eq!(usage5.tokens, 5);
+}


### PR DESCRIPTION
## Summary

Closes #600

Adds a `get_usage(address)` function that returns the effective Usage after computing refill at the current ledger timestamp.

### Changes
- **lib.rs**: Added `get_usage(env, addr) -> Usage` — read-only query
  - Requires contract to be initialized
  - Computes refill without mutating state
  - Handles addresses with no configured limit (uses defaults)
  - No authentication required
- **test_rate_limit.rs**: Added `test_get_usage_read_only` test
  - Full burst for fresh address
  - After consumption
  - After time-advance refill (capped at burst)
  - Verifies no mutation
  - No-limit address uses defaults

### Security
The query is purely observational — it performs no state mutation and requires no authentication, matching the existing read-only pattern of `get_limit_for` and `get_admin`.