### PR TITLE
fix(payroll): reject duplicate employee in add_employee_to_agreement (#501)

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1319,7 +1319,7 @@ pub fn add_employee_to_agreement(
     agreement_id: u128,
     employee: Address,
     salary_per_period: i128,
-) {
+) -> Result<(), PayrollError> {
     let mut agreement = get_agreement(env, agreement_id).expect("Agreement not found");
 
     agreement.employer.require_auth();
@@ -1341,6 +1341,13 @@ pub fn add_employee_to_agreement(
         .persistent()
         .get(&StorageKey::AgreementEmployees(agreement_id))
         .unwrap_or(Vec::new(env));
+
+    // Reject duplicate employee address in the same agreement (#501)
+    for e in employees.iter() {
+        if e.address == employee {
+            return Err(PayrollError::EmployeeAlreadyExists);
+        }
+    }
 
     employees.push_back(EmployeeInfo {
         address: employee.clone(),
@@ -1365,6 +1372,8 @@ pub fn add_employee_to_agreement(
             salary_per_period,
         },
     );
+
+    Ok(())
 }
 
 /// Activates an agreement

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -372,6 +372,8 @@ pub enum PayrollError {
     MilestoneNotApproved = 40,
     /// Milestone has already been claimed.
     MilestoneAlreadyClaimed = 41,
+    /// Duplicate employee address in the same agreement.
+    EmployeeAlreadyExists = 42,
 }
 
 /// Caps for how much a cancelled agreement's grace/dispute window may be extended on-chain.

--- a/onchain/contracts/stello_pay_contract/tests/test_agreement.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_agreement.rs
@@ -7,7 +7,7 @@
 #![allow(deprecated)]
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
-use stello_pay_contract::storage::{AgreementMode, AgreementStatus};
+use stello_pay_contract::storage::{AgreementMode, AgreementStatus, PayrollError};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
 // ============================================================================
@@ -506,4 +506,21 @@ fn test_agreement_with_long_periods() {
     let agreement_id = client.create_payroll_agreement(&employer, &token, &long_grace);
     let agreement = client.get_agreement(&agreement_id).unwrap();
     assert_eq!(agreement.grace_period_seconds, long_grace);
+}
+
+/// Adding the same employee twice to the same agreement must fail with EmployeeAlreadyExists.
+#[test]
+fn test_add_duplicate_employee_fails() {
+    let env = create_test_env();
+    let (_contract_id, client) = setup_contract(&env);
+    let employer = create_test_address(&env);
+    let token = create_test_address(&env);
+    let employee = create_test_address(&env);
+    let salary = 2000i128;
+
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &604800u64);
+    client.add_employee_to_agreement(&agreement_id, &employee, &salary);
+
+    let result = client.try_add_employee_to_agreement(&agreement_id, &employee, &salary);
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary
Fixes #501 — adds a duplicate-employee guard to `add_employee_to_agreement`.

## Changes
- **storage.rs**: Added `EmployeeAlreadyExists = 42` error variant
- **payroll.rs**: Changed `add_employee_to_agreement` to return `Result<(), PayrollError>` and check for existing employee address before insertion
- **test_agreement.rs**: Added `test_add_duplicate_employee_fails` test

## Testing
```bash
cargo test -p stello_pay_contract test_add_duplicate_employee_fails
```
