### PR TITLE
fix(milestones): use checked_add for cumulative milestone totals (#502)

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -356,15 +356,18 @@ pub fn add_milestone(env: Env, agreement_id: u128, amount: i128) -> Result<(), P
         .instance()
         .get(&MilestoneKey::TotalAmount(agreement_id))
         .unwrap_or(0);
+    let new_total = total
+        .checked_add(amount)
+        .ok_or(PayrollError::MilestoneAmountOverflow)?;
     env.storage()
         .instance()
-        .set(&MilestoneKey::TotalAmount(agreement_id), &(total + amount));
+        .set(&MilestoneKey::TotalAmount(agreement_id), &new_total);
 
     // Post-invariant: total amount should equal sum of milestones
     #[cfg(debug_assertions)]
     {
         let total_sum = sum_all_milestones(&env, agreement_id);
-        assert!(total_sum == total + amount, "Total amount mismatch after adding milestone");
+        assert!(total_sum == new_total, "Total amount mismatch after adding milestone");
     }
 
     MilestoneAdded {
@@ -397,7 +400,7 @@ fn sum_all_milestones(env: &Env, agreement_id: u128) -> i128 {
         .unwrap_or(0);
     let mut sum = 0i128;
     for i in 1..=count {
-        sum += env
+        sum = sum.saturating_add(env
             .storage()
             .instance()
             .get::<_, i128>(&MilestoneKey::MilestoneAmount(agreement_id, i))

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -372,6 +372,8 @@ pub enum PayrollError {
     MilestoneNotApproved = 40,
     /// Milestone has already been claimed.
     MilestoneAlreadyClaimed = 41,
+    /// Cumulative milestone total would overflow i128.
+    MilestoneAmountOverflow = 42,
 }
 
 /// Caps for how much a cancelled agreement's grace/dispute window may be extended on-chain.

--- a/onchain/contracts/stello_pay_contract/tests/test_milestones.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_milestones.rs
@@ -670,3 +670,18 @@ fn test_batch_claim_mixed_reports_error_codes() {
     assert_eq!(result.results.get(1).unwrap().error_code, 3); // not approved
     assert_eq!(result.results.get(2).unwrap().error_code, 1); // duplicate
 }
+
+/// Adding a milestone that pushes cumulative total past i128::MAX fails with MilestoneAmountOverflow.
+#[test]
+fn test_add_milestone_overflow_fails() {
+    let (env, employer, contributor, token, client) = create_test_env();
+    soroban_sdk::testutils::Ledger::new(&env).set_timestamp(1000);
+    let id = setup_milestone_agreement(&env, &client, &employer, &contributor, &token);
+
+    // Add first milestone at near-MAX
+    client.add_milestone(&id, &(i128::MAX - 1));
+
+    // Adding another should overflow the cumulative sum
+    let result = client.try_add_milestone(&id, &2i128);
+    assert_eq!(result.err(), Some(Ok(PayrollError::MilestoneAmountOverflow)));
+}


### PR DESCRIPTION
## Summary
Fixes #502 — uses `checked_add` instead of bare `+` for cumulative milestone totals in `add_milestone`, preventing silent i128 overflow.

## Changes
- **storage.rs**: Added `MilestoneAmountOverflow = 42` error variant
- **payroll.rs**: 
  - `add_milestone`: `total + amount` → `total.checked_add(amount).ok_or(MilestoneAmountOverflow)?`
  - `sum_all_milestones`: `sum += <expr>` → `sum = sum.saturating_add(<expr>)` (safe helper, debug-only invariant check)
  - Updated `debug_assertions` block to reference `new_total`
- **test_milestones.rs**: Added `test_add_milestone_overflow_fails` — verifies overflow on cumulative total > i128::MAX

## Testing
```bash
cargo test -p stello_pay_contract test_add_milestone_overflow_fails
```
