### PR TITLE
fix(expense_reimbursement): authorize live caller in add_approver

### DIFF
--- a/onchain/contracts/expense_reimbursement/src/lib.rs
+++ b/onchain/contracts/expense_reimbursement/src/lib.rs
@@ -209,30 +209,30 @@ impl ExpenseReimbursementContract {
             .set(&StorageKey::Initialized, &true);
     }
 
-    /// Add an approver who can approve/reject expenses
-    pub fn add_approver(env: Env, approver: Address) {
+    /// Add an approver who can approve/reject expenses.
+    ///
+    /// # Authorization
+    /// Authorizes the live `caller`: it requires `caller`'s signature via
+    /// `require_auth` and asserts that `caller` is the contract owner. Any
+    /// non-owner caller is rejected, so only the owner can mutate the approver set.
+    pub fn add_approver(env: Env, caller: Address, approver: Address) {
         require_initialized(&env);
-        let owner: Address = env
-            .storage()
-            .persistent()
-            .get(&StorageKey::Owner)
-            .expect("Owner not set");
-        require_owner(&env, &owner);
+        require_owner(&env, &caller);
 
         env.storage()
             .persistent()
             .set(&StorageKey::ApproverRole(approver), &true);
     }
 
-    /// Remove an approver
-    pub fn remove_approver(env: Env, approver: Address) {
+    /// Remove an approver.
+    ///
+    /// # Authorization
+    /// Authorizes the live `caller`: it requires `caller`'s signature via
+    /// `require_auth` and asserts that `caller` is the contract owner. Any
+    /// non-owner caller is rejected, so only the owner can mutate the approver set.
+    pub fn remove_approver(env: Env, caller: Address, approver: Address) {
         require_initialized(&env);
-        let owner: Address = env
-            .storage()
-            .persistent()
-            .get(&StorageKey::Owner)
-            .expect("Owner not set");
-        require_owner(&env, &owner);
+        require_owner(&env, &caller);
 
         env.storage()
             .persistent()

--- a/onchain/contracts/expense_reimbursement/tests/test_expense.rs
+++ b/onchain/contracts/expense_reimbursement/tests/test_expense.rs
@@ -98,7 +98,7 @@ fn test_add_and_check_approver() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     assert!(client.is_approver(&approver));
 }
@@ -113,11 +113,54 @@ fn test_remove_approver() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
     assert!(client.is_approver(&approver));
 
-    client.remove_approver(&approver);
+    client.remove_approver(&owner, &approver);
     assert!(!client.is_approver(&approver));
+}
+
+#[test]
+fn test_add_approver_rejects_non_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let non_owner = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let client = create_contract(&env);
+
+    client.initialize(&owner);
+
+    // A non-owner caller (even with a valid signature) must not be able to
+    // mutate the approver set.
+    let result = client.try_add_approver(&non_owner, &approver);
+    assert!(result.is_err());
+
+    // The approver set is unchanged.
+    assert!(!client.is_approver(&approver));
+}
+
+#[test]
+fn test_remove_approver_rejects_non_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let non_owner = Address::generate(&env);
+    let approver = Address::generate(&env);
+    let client = create_contract(&env);
+
+    client.initialize(&owner);
+    client.add_approver(&owner, &approver);
+    assert!(client.is_approver(&approver));
+
+    // A non-owner caller must not be able to remove an approver.
+    let result = client.try_remove_approver(&non_owner, &approver);
+    assert!(result.is_err());
+
+    // The approver role is still in place.
+    assert!(client.is_approver(&approver));
 }
 
 #[test]
@@ -133,7 +176,7 @@ fn test_submit_expense() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -169,7 +212,7 @@ fn test_submit_expense_empty_receipt_payload_fails() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     client.submit_expense(
         &submitter,
@@ -197,7 +240,7 @@ fn test_submit_expense_oversized_receipt_payload_fails() {
     let oversized = "x".repeat(4097);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     client.submit_expense(
         &submitter,
@@ -224,7 +267,7 @@ fn test_same_receipt_payload_rejected_on_second_submission() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let payload = String::from_str(&env, "same-receipt-payload");
 
@@ -261,7 +304,7 @@ fn test_different_receipt_payloads_allowed() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let id1 = client.submit_expense(
         &submitter_a,
@@ -299,7 +342,7 @@ fn test_submit_expense_zero_amount_fails() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     client.submit_expense(
         &submitter,
@@ -324,7 +367,7 @@ fn test_submit_expense_self_approve_fails() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&submitter_and_approver);
+    client.add_approver(&owner, &submitter_and_approver);
 
     client.submit_expense(
         &submitter_and_approver,
@@ -352,7 +395,7 @@ fn test_fund_expense() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -390,7 +433,7 @@ fn test_approve_expense_full() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -425,7 +468,7 @@ fn test_approve_expense_partial() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -461,8 +504,8 @@ fn test_approve_expense_requires_designated_approver() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
-    client.add_approver(&unauthorized_approver);
+    client.add_approver(&owner, &approver);
+    client.add_approver(&owner, &unauthorized_approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -496,7 +539,7 @@ fn test_approval_links_to_audit_logger_when_configured() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
     client.set_audit_logger(&owner, &audit_logger);
     assert_eq!(client.get_audit_logger(), Some(audit_logger));
 
@@ -546,7 +589,7 @@ fn test_approve_expense_unfunded_fails() {
     let client = create_contract(&env);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -577,7 +620,7 @@ fn test_reject_expense_refunds() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -618,7 +661,7 @@ fn test_pay_expense_full() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -658,7 +701,7 @@ fn test_pay_expense_cannot_be_paid_twice() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -693,7 +736,7 @@ fn test_pay_expense_partial() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -730,7 +773,7 @@ fn test_cancel_expense_refunds() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &1_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,
@@ -770,7 +813,7 @@ fn test_multiple_expenses_with_unique_receipts_work_end_to_end() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &5_000);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id1 = client.submit_expense(
         &submitter1,
@@ -844,7 +887,7 @@ fn test_fund_expense_overflow_rejected() {
     token::StellarAssetClient::new(&env, &token_client.address).mint(&payer, &i128::MAX);
 
     client.initialize(&owner);
-    client.add_approver(&approver);
+    client.add_approver(&owner, &approver);
 
     let expense_id = client.submit_expense(
         &submitter,

--- a/onchain/integration_tests/tests/test_expense_audit_logger_integration.rs
+++ b/onchain/integration_tests/tests/test_expense_audit_logger_integration.rs
@@ -77,7 +77,7 @@ fn test_expense_approval_records_audit_log() {
 
     // Initialize contracts
     expense_client.initialize(&expense_owner);
-    expense_client.add_approver(&approver);
+    expense_client.add_approver(&expense_owner, &approver);
     audit_client.initialize(&expense_owner, &100u32); // retention limit 100
 
     // Configure expense contract to use audit logger
@@ -138,7 +138,7 @@ fn test_expense_rejection_does_not_create_audit_log() {
     let tok = token(&env);
 
     expense_client.initialize(&expense_owner);
-    expense_client.add_approver(&approver);
+    expense_client.add_approver(&expense_owner, &approver);
     audit_client.initialize(&expense_owner, &100u32);
     expense_client.set_audit_logger(&expense_owner, &audit_id);
 
@@ -171,7 +171,7 @@ fn test_expense_approval_without_audit_logger() {
     let tok = token(&env);
 
     expense_client.initialize(&expense_owner);
-    expense_client.add_approver(&approver);
+    expense_client.add_approver(&expense_owner, &approver);
 
     let eid = expense_client.submit_expense(
         &submitter,


### PR DESCRIPTION
## Problem

`add_approver()` (and its sibling `remove_approver()`) in
`onchain/contracts/expense_reimbursement/src/lib.rs` fetched the stored `owner`
from contract storage and passed **that** value into the ownership check:

```rust
let owner: Address = env.storage().persistent().get(&StorageKey::Owner)...;
require_owner(&env, &owner);
```

Because `require_owner` runs `addr.require_auth()` and then asserts
`addr == owner`, passing the self-fetched owner makes the equality check a
tautology and ties authorization to a value the contract supplied to itself
rather than to the live transaction caller. The function had no `caller`
parameter at all, so the access-control intent was effectively unenforced.

The correct pattern already existed in `set_audit_logger`, which takes the
caller address as a parameter.

##  Changes
- `add_approver` / `remove_approver` now take a `caller: Address` parameter and
  pass the live caller to `require_owner`. `require_owner` calls
  `caller.require_auth()` (proving the signature) and asserts `caller == owner`,
  so any non-owner is rejected.
- Added `///` documentation on both functions describing the authorization
  contract.
- Audited sibling functions:
  - `set_audit_logger` — already used the correct (parameterized) pattern.
  - `approve_expense` / `reject_expense` / `cancel_expense` / `fund_expense` —
    authorize against their own roles (approver / submitter / payer) as intended.
- Updated all existing call sites (unit tests + integration tests) to the new
  two-argument signature.

## Acceptance criteria

- [x] `add_approver` authorizes the actual caller.
- [x] Non-owner callers are rejected.
- [x] Sibling functions audited for the same bug.
- [x] Negative test added.

## Tests

New tests in `onchain/contracts/expense_reimbursement/tests/test_expense.rs`:

- `test_add_approver_rejects_non_owner` — a non-owner `try_add_approver` fails
  and the approver set is left unchanged.
- `test_remove_approver_rejects_non_owner` — a non-owner `try_remove_approver`
  fails and the existing approver role is preserved.

Existing happy-path coverage (`test_add_and_check_approver`,
`test_remove_approver`) updated to the new signature and still passes.

The integration suite (`test_expense_audit_logger_integration.rs`) call sites
were updated to the new signature and continue to pass.

Run (workspace root is `onchain/`; package name uses an underscore):

```bash
cd onchain
cargo test -p expense_reimbursement
cargo test -p integration_tests --test test_expense_audit_logger_integration
```

### Results

`expense_reimbursement` unit tests — all 28 pass, including the two new
negative tests:

```
running 28 tests
test test_add_approver_rejects_non_owner ... ok
test test_remove_approver_rejects_non_owner ... ok
...
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Expense audit-logger integration tests — all 3 pass:

```
running 3 tests
test test_expense_approval_without_audit_logger ... ok
test test_expense_rejection_does_not_create_audit_log ... ok
test test_expense_approval_records_audit_log ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

### Pre-existing unrelated failures (out of scope)

`cargo test -p integration_tests` also reports 2 failures in
`test_salary_adjustment_payroll_integration.rs`
(`test_salary_adjustment_apply_updates_payroll_salary`,
`test_salary_decrease_affects_payroll_claim`). These are **not** caused by this
change:

- This branch's diff touches only `expense_reimbursement` source/tests and the
  expense audit-logger integration test — no salary/payroll files.
- The same tests fail identically on an untouched `main`, so they are a
  pre-existing issue and out of scope for this PR.

## Security notes

Access control now checks the live caller. Only the contract owner can mutate
the approver set; there is no path that lets a non-owner add or remove
approvers.

Closes the access-control issue in `add_approver`. #599 
