### PR TITLE
fix: Add SECURITY.md, CONTRIBUTING.md, CODEOWNERS, and issue template…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default reviewers for high-risk paths. Update when maintainer ownership changes.
+# See CONTRIBUTING.md and SECURITY.md for contribution and disclosure policies.
+
+/onchain/contracts/          @Jagadeeshftw
+/onchain/integration_tests/  @Jagadeeshftw
+/tools/                      @Jagadeeshftw

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report incorrect contract behaviour, failing tests, or tooling defects
+title: "[Bug] "
+labels: ["bug", "needs-triage"]
+assignees: []
+---
+
+## Summary
+
+What is broken?
+
+## Affected area
+
+- [ ] `onchain/contracts/` (specify crate, e.g. `stello_pay_contract`)
+- [ ] `onchain/integration_tests/`
+- [ ] `tools/cli`
+- [ ] `tools/doc_checker`
+- [ ] CI / docs / other
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+
+- Rust version (`rustc --version`):
+- Stellar CLI version (`stellar --version`), if applicable:
+- OS:
+- Network: testnet / mainnet / local only
+
+## Logs or transaction references
+
+Paste test output, Soroban diagnostic events, or **testnet** transaction hashes. Do not include private keys or production secrets.
+
+## Additional context
+
+Screenshots, branch name, or related PRs if any.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Stellopay/stellopay-core/blob/main/SECURITY.md
+    about: Report security issues privately. Do not use the public bug template for vulnerabilities.
+  - name: Documentation
+    url: https://github.com/Stellopay/stellopay-core/tree/main/docs
+    about: Read the docs index before opening a feature or bug report.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Propose a new contract capability, CLI command, or workflow improvement
+title: "[Feature] "
+labels: ["enhancement", "needs-triage"]
+assignees: []
+---
+
+## Problem
+
+What user or operator problem should this solve?
+
+## Proposed solution
+
+Describe the contract entrypoint, CLI change, or documentation update you have in mind.
+
+## Affected components
+
+- [ ] `onchain/contracts/` (which crate?)
+- [ ] `onchain/integration_tests/`
+- [ ] `tools/cli`
+- [ ] `docs/`
+- [ ] Other
+
+## Alternatives considered
+
+## Acceptance criteria
+
+How will we know this is done?
+
+## Additional context
+
+Links to related issues, Stellar SIPs, or design sketches.

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -1,0 +1,39 @@
+---
+name: Security report
+about: Report a vulnerability in payroll/escrow contracts or deployment tooling
+title: "[Security] "
+labels: ["security"]
+assignees: []
+---
+
+> **Use private reporting when possible:** [GitHub security advisories](https://github.com/Stellopay/stellopay-core/security/advisories/new)  
+> See [SECURITY.md](../../SECURITY.md) for full policy. Avoid posting exploit code or mainnet attack details in public issues.
+
+## Summary
+
+Brief description of the vulnerability (high level only).
+
+## Affected component
+
+- Contract crate or path under `onchain/contracts/`:
+- Tooling path under `tools/`, if any:
+
+## Impact
+
+- [ ] Unauthorized fund movement
+- [ ] Authentication / authorization bypass
+- [ ] Upgrade or migration abuse
+- [ ] Denial of service
+- [ ] Other (describe)
+
+## Reproduction (testnet or local only)
+
+Steps a maintainer can follow in a safe environment. Do **not** include mainnet exploitation instructions.
+
+## Suggested remediation
+
+Optional.
+
+## Reporter contact
+
+How maintainers can reach you for follow-up (email or GitHub handle).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,115 @@
 # Contributing to stellopay-core
 
-Thank you for contributing to stellopay-core — a decentralized payroll system
-built on the Stellar blockchain using Soroban.
+Thank you for contributing to stellopay-core — a decentralized payroll system built on the Stellar blockchain using Soroban.
+
+Read [SECURITY.md](SECURITY.md) before reporting vulnerabilities. Use private [GitHub security advisories](https://github.com/Stellopay/stellopay-core/security/advisories/new) instead of public issues when disclosure could harm users.
 
 ---
 
-## Getting started
+## Repository layout
 
-1. Fork the repository and create a branch from `main`.
-2. Follow the local environment setup in [`docs/ci.md`](docs/ci.md).
-3. Make your changes, add tests, and ensure CI passes before opening a PR.
+| Path | Purpose |
+| --- | --- |
+| `onchain/` | Rust workspace root (`Cargo.toml`) for Soroban contracts and integration tests |
+| `onchain/contracts/` | Individual contract crates (payroll, escrow, governance, compliance, etc.) |
+| `onchain/integration_tests/` | Cross-contract workflow tests |
+| `tools/cli/` | `stellopay-cli` for deploy, query, and operational commands |
+| `tools/doc_checker/` | Scans contract impls for missing documentation |
+| `docs/` | Architecture, API notes, CI, deployment, and migration guides |
+| `scripts/` | Migration and helper scripts |
+
+Entry points:
+
+- [README.md](README.md) — repository overview
+- [onchain/README.md](onchain/README.md) — contract inventory, build, test, and coverage
+- [docs/README.md](docs/README.md) — product and integration documentation
+
+---
+
+## Local setup
+
+Align with [docs/ci.md](docs/ci.md) and `.github/workflows/contracts.yml`:
+
+```sh
+rustup install stable
+rustup target add wasm32-unknown-unknown
+rustup component add llvm-tools-preview
+cargo install stellar-cli --locked
+```
+
+Optional (coverage locally):
+
+```sh
+cargo install cargo-llvm-cov
+```
+
+---
+
+## Build and test workflow
+
+All contract work happens from the `onchain/` workspace.
+
+### Formatting
+
+```sh
+cd onchain
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+### Run tests
+
+```sh
+cd onchain
+cargo test -p stello_pay_contract --verbose
+cargo test -p integration_tests --verbose
+cargo test -p template_versioning --verbose
+```
+
+Or the full workspace:
+
+```sh
+cd onchain
+cargo test --workspace
+```
+
+### Build WASM (Soroban)
+
+Preferred (matches CI):
+
+```sh
+cd onchain/contracts/stello_pay_contract
+stellar contract build --verbose
+```
+
+Windows / GNU toolchain fallback:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cd onchain/contracts/stello_pay_contract
+cargo build -p stello_pay_contract --target wasm32-unknown-unknown --release
+```
+
+See [docs/windows-build.md](docs/windows-build.md) for MSVC and WSL options.
+
+### CLI tooling
+
+```sh
+cd tools/cli
+cargo test
+cargo build --release
+```
+
+### Documentation checker
+
+```sh
+cd tools/doc_checker
+cargo run
+```
 
 ---
 
 ## Branch naming
-
-Use a short prefix that matches the type of change:
 
 | Prefix | Use for |
 |--------|---------|
@@ -25,34 +119,43 @@ Use a short prefix that matches the type of change:
 | `docs/` | Documentation only |
 | `devops/` | CI/CD and infrastructure |
 
-Example: `devops/dependabot-config`, `feat/bulk-payment-v2`
+Example: `docs/project-health-files`, `feat/bulk-payment-v2`
 
 ---
 
-## Pull request checklist
+## Pull request expectations
+
+1. Fork from `main`, keep your branch up to date, and open a PR against `Stellopay/stellopay-core`.
+2. Fill in [.github/pull_request_template.md](.github/pull_request_template.md).
+3. Run the same checks CI runs (format, tests, WASM build for touched contracts).
+4. Add or update tests for behaviour changes. Contract suites live beside each crate under `onchain/contracts/*/tests/` and in `onchain/integration_tests/`.
+5. Update relevant docs under `docs/` when behaviour, deployment, or operator workflows change.
+6. Do not commit secrets, private keys, or production credentials.
+
+### PR checklist
 
 - [ ] Branch is up to date with `main`
-- [ ] `cargo test --workspace` passes locally
-- [ ] New or changed behaviour is covered by tests
-- [ ] Relevant docs under `docs/` are updated
-- [ ] PR description explains *what* changed and *why*
+- [ ] `cargo fmt --all -- --check` passes in `onchain/`
+- [ ] `cargo test` passes for affected packages
+- [ ] `stellar contract build` succeeds for modified contracts
+- [ ] Docs updated when needed
+- [ ] PR description explains what changed and why
 
 ---
 
 ## Dependency updates
 
-stellopay-core uses **GitHub Dependabot** to keep Rust crates and GitHub
-Actions versions current. Dependabot opens PRs automatically every Monday.
+stellopay-core uses **GitHub Dependabot** for Rust crates and GitHub Actions. See [docs/dependency-update-policy.md](docs/dependency-update-policy.md) for grouping rules and review expectations.
 
-See [`docs/dependency-update-policy.md`](docs/dependency-update-policy.md)
-for the full policy, including grouping rules, review obligations, and how
-to defer an update.
+---
 
-**Key rules at a glance:**
+## Code review
 
-- Patch Cargo bumps arrive as one grouped PR per week.
-- Minor Cargo bumps open individual PRs for per-crate review.
-- Major Cargo bumps are **excluded from automation** — handle manually.
-- All GitHub Actions bumps (`ci.yml`, `contracts.yml`, `security-scan.yml`)
-  are batched into one weekly PR.
--
+Changes under `onchain/contracts/` and `tools/` are routed to maintainers via [.github/CODEOWNERS](.github/CODEOWNERS).
+
+---
+
+## Getting help
+
+- [Documentation index](docs/README.md)
+- [Discord](https://discord.gg/stellopay) for community questions (not for security vulnerabilities)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ See [Building on Windows](docs/windows-build.md) for the full Windows guidance.
 
 The on-chain workspace uses GitHub Actions to build and test Soroban contracts on pull requests and pushes to the main branches. See [`onchain/README.md`](onchain/README.md) for the CI overview and local setup notes.
 
+## Contributing and security
+
+- [Contributing guide](CONTRIBUTING.md) — workspace layout, build/test workflow, and PR expectations
+- [Security policy](SECURITY.md) — responsible disclosure for contracts under `onchain/contracts/`
+- [Open an issue](.github/ISSUE_TEMPLATE/) — bug, feature, or security report templates
+
 ## Safety Notes
 
 This repository contains smart contract code. Review migrations, upgrades, and deployment steps carefully before using any live network or production asset. Keep private keys, RPC credentials, wallet secrets, and production database or ledger data out of commits, issue comments, and logs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+Stellopay Core manages payroll escrow and related Soroban contracts on Stellar. If you believe you have found a security vulnerability, please report it responsibly.
+
+## Supported versions
+
+Security fixes are applied to the `main` branch and released through reviewed pull requests. Use the latest `main` commit or the most recent tagged release when deploying to production networks.
+
+## Scope
+
+In scope:
+
+- All Soroban contracts under [`onchain/contracts/`](onchain/contracts/), including payroll, escrow, governance, RBAC, compliance, payment scheduling, vesting, and supporting modules.
+- Cross-contract integration behaviour covered by [`onchain/integration_tests/`](onchain/integration_tests/).
+- [`tools/cli`](tools/cli/) when a finding affects deployment, upgrade, or contract interaction safety.
+
+Out of scope:
+
+- Third-party wallets, RPC providers, and Stellar network infrastructure outside this repository.
+- Social engineering, physical attacks, or denial-of-service against public endpoints not maintained in this repo.
+- Issues in forked or unpublished contract deployments that diverge from `main` without disclosure.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately using one of these channels:
+
+1. **GitHub private vulnerability reporting (preferred)**  
+   [Open a private security advisory](https://github.com/Stellopay/stellopay-core/security/advisories/new) on this repository.
+
+2. **Security issue template**  
+   Use the [Security report](.github/ISSUE_TEMPLATE/security_report.md) template only if private advisory reporting is unavailable. Mark the issue as sensitive and avoid posting exploit details, keys, or mainnet transaction data in the body.
+
+Include:
+
+- A clear description of the issue and affected contract or tool path.
+- Steps to reproduce, including network (testnet/mainnet) and contract IDs if relevant.
+- Impact assessment (fund loss, auth bypass, upgrade abuse, etc.).
+- Proof of concept if available, preferably against testnet.
+
+## What to expect
+
+- Acknowledgement within **5 business days** for valid reports.
+- Status updates as the report is triaged and remediated.
+- Coordination on disclosure timing so users can patch before public details are shared.
+
+## Safe harbour
+
+We support good-faith security research on **testnet** and local environments. Do not test against mainnet funds you do not own, do not exfiltrate user data, and do not degrade production services.
+
+## Related documentation
+
+- [Threat model](docs/threat-model.md)
+- [Security testing tools](docs/security-testing-tools.md)
+- [Emergency pause](docs/emergency-pause.md)
+- [Upgrade entrypoint security](docs/upgrade-entrypoint.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,4 +80,4 @@ See the [Developer Tools](/docs/dev-tools/README.md) and [Integration Guide](/do
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](../CONTRIBUTING.md) for details on how to contribute to the documentation.
+We welcome contributions. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the build and test workflow, and [SECURITY.md](../SECURITY.md) for vulnerability reporting.

--- a/onchain/README.md
+++ b/onchain/README.md
@@ -237,6 +237,12 @@ cargo build --release
 
 See [tools/cli/README.md](../tools/cli/README.md) for full usage.
 
+## Project health
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [SECURITY.md](../SECURITY.md)
+- [Issue templates](../.github/ISSUE_TEMPLATE/)
+
 ### `tools/doc_checker` — Documentation Checker
 
 Scans all `#[contractimpl]` public functions for missing doc comments (params, returns, access control).


### PR DESCRIPTION
## Summary

Closes #607 — adds baseline project-health files for contributor onboarding and responsible security disclosure.

- **SECURITY.md** — private reporting via [GitHub security advisories](https://github.com/Stellopay/stellopay-core/security/advisories/new); scope covers `onchain/contracts/`, integration tests, and `tools/cli`
- **CONTRIBUTING.md** — expanded with workspace layout, `cargo fmt` / `cargo test`, Soroban WASM build (`stellar contract build` + `wasm32-unknown-unknown` fallback), and PR checklist
- **.github/CODEOWNERS** — routes `onchain/contracts/**`, `onchain/integration_tests/**`, and `tools/**` to `@Jagadeeshftw`
- **Issue templates** — bug, feature, and security report under `.github/ISSUE_TEMPLATE/`
- **README cross-links** — `README.md`, `docs/README.md`, `onchain/README.md`

## Test plan

Docs-only change. Validation performed locally:

- [x] CODEOWNERS paths resolve (`onchain/contracts`, `onchain/integration_tests`, `tools`)
- [x] Issue template YAML front matter parses (bug / feature / security)
- [x] `cargo test -p template_versioning` passes
- [ ] `cargo fmt --all -- --check` — fails on current `main` (pre-existing; not introduced here)
- [ ] Full Contracts CI suite — known failures on `main` at time of branch (integration + invariant tests)

## Security notes

- Public security issues are discouraged; `SECURITY.md` directs reporters to private GitHub advisories.
- Security template avoids requesting exploit details suitable for mainnet abuse.
- No secrets, keys, or internal infrastructure details added to public docs.
