### PR TITLE
Implement payment retry batch processing

### DIFF
--- a/onchain/contracts/payment_retry/src/lib.rs
+++ b/onchain/contracts/payment_retry/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! Payers deposit funds into this contract's escrow. An off-chain keeper (or
 //! any caller) invokes `process_due_payments` periodically; each call checks
-//! all `Pending` records whose `next_retry_at` has elapsed and attempts the
+//! tracked retry records whose `next_retry_at` has elapsed and attempts the
 //! transfer. If the escrow balance is still insufficient the record is
 //! rescheduled according to its `retry_intervals` list. Once `retry_count`
 //! exceeds `max_retry_attempts` the record transitions to `Failed` and a
@@ -58,7 +58,7 @@
 //!
 //! Off-chain payroll systems should subscribe to the events emitted by this
 //! contract:
-//! * `payment_succeeded` — mark the corresponding payroll period as paid.
+//! * `payment_success`   — mark the corresponding payroll period as paid.
 //! * `payment_failed`    — flag the agreement for manual review; the funds
 //!   remain in escrow until a human operator cancels or re-funds.
 //!
@@ -136,6 +136,7 @@ enum StorageKey {
     Initialized,
     Owner,
     Payment(BytesN<32>),
+    PendingPayments,
     Processed(BytesN<32>),
 }
 
@@ -246,6 +247,48 @@ fn mark_processed(env: &Env, payment_id: BytesN<32>) {
         .set(&StorageKey::Processed(payment_id), &true);
 }
 
+fn read_pending_payment_ids(env: &Env) -> Vec<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get::<_, Vec<BytesN<32>>>(&StorageKey::PendingPayments)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn write_pending_payment_ids(env: &Env, payment_ids: &Vec<BytesN<32>>) {
+    env.storage()
+        .persistent()
+        .set(&StorageKey::PendingPayments, payment_ids);
+}
+
+fn track_pending_payment(env: &Env, payment_id: BytesN<32>) {
+    let mut payment_ids = read_pending_payment_ids(env);
+
+    let mut i: u32 = 0;
+    while i < payment_ids.len() {
+        if payment_ids.get(i).expect("pending payment id missing") == payment_id {
+            return;
+        }
+        i = i.saturating_add(1);
+    }
+
+    payment_ids.push_back(payment_id);
+    write_pending_payment_ids(env, &payment_ids);
+}
+
+fn untrack_pending_payment(env: &Env, payment_id: BytesN<32>) {
+    let mut payment_ids = read_pending_payment_ids(env);
+
+    let mut i: u32 = 0;
+    while i < payment_ids.len() {
+        if payment_ids.get(i).expect("pending payment id missing") == payment_id {
+            payment_ids.remove(i);
+            write_pending_payment_ids(env, &payment_ids);
+            return;
+        }
+        i = i.saturating_add(1);
+    }
+}
+
 /// Validates that `max_retry_attempts` and `retry_intervals` satisfy protocol
 /// constraints. Called at creation time; never called during retry processing.
 fn validate_retry_configuration(max_retry_attempts: u32, retry_intervals: &Vec<u64>) {
@@ -260,7 +303,7 @@ fn validate_retry_configuration(max_retry_attempts: u32, retry_intervals: &Vec<u
 
     if max_retry_attempts > 0 {
         assert!(
-            retry_intervals.len() > 0,
+            !retry_intervals.is_empty(),
             "Retry intervals required when retries are enabled"
         );
     }
@@ -293,6 +336,95 @@ fn interval_for_retry(retry_intervals: &Vec<u64>, retry_count: u32) -> u64 {
     }
 
     retry_intervals.get(index).expect("Retry interval missing")
+}
+
+/// Attempts one due payment and returns whether the record was actually
+/// evaluated in this call. Not-due, already-processed, and terminal records
+/// return `false` so batch callers can report an accurate processed count.
+fn process_payment_if_due(env: &Env, payment_id: BytesN<32>) -> bool {
+    if already_processed(env, payment_id.clone()) {
+        untrack_pending_payment(env, payment_id);
+        return false;
+    }
+
+    let mut payment = read_payment(env, payment_id.clone());
+
+    if payment.state == RetryState::Success || payment.state == RetryState::Failed {
+        untrack_pending_payment(env, payment_id);
+        return false;
+    }
+
+    if payment.retry_count > payment.max_retry_attempts {
+        payment.state = RetryState::Failed;
+        write_payment(env, &payment);
+        untrack_pending_payment(env, payment_id);
+        return true;
+    }
+
+    let now = env.ledger().timestamp();
+    if now < payment.next_retry_at {
+        return false;
+    }
+
+    let token_client = token::Client::new(env, &payment.token);
+    let balance = token_client.balance(&env.current_contract_address());
+
+    if balance >= payment.amount {
+        mark_processed(env, payment_id.clone());
+        payment.state = RetryState::Success;
+        write_payment(env, &payment);
+        untrack_pending_payment(env, payment_id.clone());
+
+        let recipient = match payment.alternate_payout.clone() {
+            Some(alternate_payout) => alternate_payout,
+            None => payment.recipient.clone(),
+        };
+
+        token_client.transfer(&env.current_contract_address(), &recipient, &payment.amount);
+
+        env.events().publish(
+            ("payment_success", payment_id.clone()),
+            PaymentSucceededEvent {
+                payment_id,
+                recipient,
+                amount: payment.amount,
+            },
+        );
+    } else {
+        payment.retry_count = payment.retry_count.saturating_add(1);
+        if payment.retry_count > payment.max_retry_attempts {
+            payment.state = RetryState::Failed;
+            untrack_pending_payment(env, payment_id.clone());
+        } else {
+            payment.state = RetryState::Retrying;
+            let interval = interval_for_retry(&payment.retry_intervals, payment.retry_count);
+            payment.next_retry_at = now.saturating_add(interval);
+        }
+        write_payment(env, &payment);
+
+        env.events().publish(
+            ("payment_retry_failed", payment_id.clone()),
+            RetryScheduledEvent {
+                payment_id: payment_id.clone(),
+                retry_count: payment.retry_count,
+                next_retry_at: payment.next_retry_at,
+            },
+        );
+
+        if payment.state == RetryState::Failed {
+            env.events().publish(
+                ("payment_failed", payment.id.clone()),
+                PaymentFailedEvent {
+                    payment_id: payment.id,
+                    retry_count: payment.retry_count,
+                    max_retry_attempts: payment.max_retry_attempts,
+                    notifier: payment.failure_notifier,
+                },
+            );
+        }
+    }
+
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -384,7 +516,11 @@ impl PaymentRetryContract {
     ) {
         require_initialized(&env);
         // Permissionless entry point, but we check if already exists
-        if env.storage().persistent().has(&StorageKey::Payment(payment_id.clone())) {
+        if env
+            .storage()
+            .persistent()
+            .has(&StorageKey::Payment(payment_id.clone()))
+        {
             return;
         }
 
@@ -410,6 +546,7 @@ impl PaymentRetryContract {
         };
 
         write_payment(&env, &payment);
+        track_pending_payment(&env, payment_id.clone());
 
         env.events().publish(
             ("retry_scheduled", payment_id.clone()),
@@ -424,83 +561,7 @@ impl PaymentRetryContract {
 
     pub fn process_retry(env: Env, payment_id: BytesN<32>) {
         require_initialized(&env);
-
-        if already_processed(&env, payment_id.clone()) {
-            return; // idempotency guard
-        }
-
-        let mut payment = read_payment(&env, payment_id.clone());
-
-        if payment.state == RetryState::Success || payment.state == RetryState::Failed {
-            return;
-        }
-
-        if payment.retry_count > payment.max_retry_attempts {
-            payment.state = RetryState::Failed;
-            write_payment(&env, &payment);
-            return;
-        }
-
-        let now = env.ledger().timestamp();
-        if now < payment.next_retry_at {
-            return;
-        }
-
-        let token_client = token::Client::new(&env, &payment.token);
-        let balance = token_client.balance(&env.current_contract_address());
-
-        if balance >= payment.amount {
-            // Idempotency: mark processed BEFORE transfer
-            mark_processed(&env, payment_id.clone());
-            payment.state = RetryState::Success;
-            write_payment(&env, &payment);
-
-            token_client.transfer(
-                &env.current_contract_address(),
-                &payment.recipient,
-                &payment.amount,
-            );
-
-            env.events().publish(
-                ("payment_success", payment_id.clone()),
-                PaymentSucceededEvent {
-                    payment_id,
-                    recipient: payment.alternate_payout.unwrap_or(payment.recipient),
-                    amount: payment.amount,
-                },
-            );
-        } else {
-            payment.retry_count = payment.retry_count.saturating_add(1);
-            if payment.retry_count > payment.max_retry_attempts {
-                payment.state = RetryState::Failed;
-            } else {
-                payment.state = RetryState::Retrying;
-                let interval = interval_for_retry(&payment.retry_intervals, payment.retry_count);
-                payment.next_retry_at = now.saturating_add(interval);
-            }
-            write_payment(&env, &payment);
-
-            env.events().publish(
-                ("payment_retry_failed", payment_id.clone()),
-                RetryScheduledEvent {
-                    payment_id,
-                    retry_count: payment.retry_count,
-                    next_retry_at: payment.next_retry_at,
-                },
-            );
-
-            if payment.state == RetryState::Failed {
-                env.events().publish(
-                    ("payment_failed", payment.id.clone()),
-                    PaymentFailedEvent {
-                        payment_id: payment.id,
-                        retry_count: payment.retry_count,
-                        max_retry_attempts: payment.max_retry_attempts,
-                        notifier: payment.failure_notifier,
-                    },
-                );
-            }
-        }
+        process_payment_if_due(&env, payment_id);
     }
 
     /// Deposits tokens from the payer into this contract's escrow.
@@ -537,17 +598,17 @@ impl PaymentRetryContract {
         );
 
         let token_client = token::Client::new(&env, &payment.token);
-        token_client.transfer(&payer, &env.current_contract_address(), &amount);
+        token_client.transfer(&payer, env.current_contract_address(), &amount);
     }
 
     /// Processes up to `max_payments` due payment requests in a single call.
     ///
-    /// For each `Pending` record whose `next_retry_at ≤ now`:
+    /// For each tracked non-terminal record whose `next_retry_at ≤ now`:
     /// * If the escrow balance covers `amount`: transfer succeeds →
-    ///   `status = Completed`, emit `payment_succeeded`.
+    ///   `state = Success`, emit `payment_success`.
     /// * If the escrow balance is insufficient:
     ///   - Increment `retry_count`.
-    ///   - If `retry_count > max_retry_attempts`: `status = Failed`,
+    ///   - If `retry_count > max_retry_attempts`: `state = Failed`,
     ///     emit `payment_failed`.
     ///   - Otherwise: compute `next_retry_at` and emit `retry_scheduled`.
     ///
@@ -557,7 +618,7 @@ impl PaymentRetryContract {
     ///
     /// Safe to call multiple times per ledger. Each record's `next_retry_at`
     /// acts as a gate; records already processed in the same time window are
-    /// skipped. Terminal records (`Completed`, `Failed`, `Cancelled`) are never
+    /// skipped. Terminal records (`Success`, `Failed`) are never
     /// re-processed.
     ///
     /// # Arguments
@@ -570,8 +631,6 @@ impl PaymentRetryContract {
     ///
     /// Number of payment records actually evaluated (not necessarily
     /// transferred) in this call.
-    /// Processes due payment requests.
-    /// Redirects to 'process_retry' for the blueprint's new logic.
     pub fn process_due_payments(env: Env, max_payments: u32) -> u32 {
         require_initialized(&env);
 
@@ -579,14 +638,22 @@ impl PaymentRetryContract {
             return 0;
         }
 
-        // Note: In a real production system, we'd iterate over all pending payments.
-        // For this orchestration demo, we'll assume the keeper calls 'process_retry' directly
-        // or we implement a way to list pending IDs.
-        // For now, I'll leave this as a stub or implement a simple iteration if storage allows.
-        0
+        let payment_ids = read_pending_payment_ids(&env);
+        let mut processed: u32 = 0;
+        let mut i: u32 = 0;
+
+        while i < payment_ids.len() && processed < max_payments {
+            let payment_id = payment_ids.get(i).expect("pending payment id missing");
+            if process_payment_if_due(&env, payment_id) {
+                processed = processed.saturating_add(1);
+            }
+            i = i.saturating_add(1);
+        }
+
+        processed
     }
 
-    /// Cancels a `Pending` payment request, preventing any future processing.
+    /// Cancels a non-terminal payment request, preventing any future processing.
     ///
     /// The payer should separately reclaim escrow funds by withdrawing the
     /// deposited tokens. (Fund withdrawal is out of scope for this contract;
@@ -620,6 +687,7 @@ impl PaymentRetryContract {
 
         payment.state = RetryState::Failed; // Treat cancellation as a terminal failure state
         write_payment(&env, &payment);
+        untrack_pending_payment(&env, payment_id);
     }
 
     /// Returns a payment request by ID, or `None` if it does not exist.

--- a/onchain/contracts/payment_retry/tests/test_retry.rs
+++ b/onchain/contracts/payment_retry/tests/test_retry.rs
@@ -1,27 +1,16 @@
-//! Comprehensive tests for the PaymentRetry contract.
+//! Focused tests for the current PaymentRetry API.
 //!
-//! Coverage targets:
-//! * Initialization (happy path, double-init guard)
-//! * `create_payment_request` — happy path, zero amount, missing intervals,
-//!   too many retries, oversized interval, alternate payout
-//! * `fund_payment` — happy path, wrong payer, terminal state guard
-//! * `process_due_payments` — immediate success, retry on insufficient balance,
-//!   backoff timing, last-interval reuse, terminal failure, alternate payout
-//!   routing, max_payments bound, zero max_retries terminal, idempotency
-//! * `cancel_payment` — cancels pending, prevents processing, wrong payer
-//! * View helpers (`get_payment`, `get_owner`)
-//! * Edge cases: zero max_retries, multiple payments, process limit
+//! These tests cover `schedule_retry`, single-record `process_retry`, and the
+//! keeper-facing `process_due_payments` batch entry point.
 
 #![cfg(test)]
 
-use payment_retry::{PaymentRetryContract, PaymentRetryContractClient, PaymentStatus};
+use payment_retry::{PaymentRetryContract, PaymentRetryContractClient, RetryConfig, RetryState};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    vec, Address, Env,
+    Address, BytesN, Env, Vec,
 };
-
-// ─── Fixtures ────────────────────────────────────────────────────────────────
 
 fn create_env() -> Env {
     let env = Env::default();
@@ -37,1104 +26,400 @@ fn register_contract(env: &Env) -> (Address, PaymentRetryContractClient<'static>
 }
 
 fn create_token_contract<'a>(env: &Env, admin: &Address) -> TokenClient<'a> {
-    let token_addr = env.register_stellar_asset_contract(admin.clone());
+    let token_addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
     TokenClient::new(env, &token_addr)
 }
 
-// ─── Initialization ──────────────────────────────────────────────────────────
+fn payment_id(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+fn retry_config(env: &Env, max_retries: u32, intervals: &[u64]) -> RetryConfig {
+    let mut retry_intervals = Vec::new(env);
+    for interval in intervals {
+        retry_intervals.push_back(*interval);
+    }
+
+    RetryConfig {
+        max_retries,
+        retry_intervals,
+    }
+}
+
+struct PaymentInput<'a> {
+    id_seed: u8,
+    payer: &'a Address,
+    recipient: &'a Address,
+    token: &'a Address,
+    amount: i128,
+    max_retries: u32,
+    intervals: &'a [u64],
+}
+
+fn schedule_payment(
+    env: &Env,
+    client: &PaymentRetryContractClient<'static>,
+    input: PaymentInput<'_>,
+) -> BytesN<32> {
+    let id = payment_id(env, input.id_seed);
+    client.schedule_retry(
+        &id,
+        input.payer,
+        input.recipient,
+        input.token,
+        &input.amount,
+        &retry_config(env, input.max_retries, input.intervals),
+    );
+    id
+}
 
 #[test]
 fn test_initialize_and_read_owner() {
     let env = create_env();
-    let (_id, client) = register_contract(&env);
+    let (_contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
 
     client.initialize(&owner);
-    assert_eq!(client.get_owner(), Some(owner.clone()));
+    assert_eq!(client.get_owner(), Some(owner));
 }
 
 #[test]
-fn test_initialize_double_init_rejected() {
+fn test_schedule_retry_stores_due_payment() {
     let env = create_env();
-    let (_id, client) = register_contract(&env);
+    let (_contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
-
-    client.initialize(&owner);
-    let second = client.try_initialize(&owner);
-    assert!(second.is_err());
-}
-
-// ─── create_payment_request ──────────────────────────────────────────────────
-
-#[test]
-fn test_create_payment_request_happy_path() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
     let payer = Address::generate(&env);
     let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let token = create_token_contract(&env, &token_admin);
 
+    client.initialize(&owner);
     env.ledger().with_mut(|li| li.timestamp = 100);
 
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &500i128,
-        &3u32,
-        &vec![&env, 30u64, 60u64],
-        &notifier,
-        &None,
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 1,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 250,
+            max_retries: 2,
+            intervals: &[30, 60],
+        },
     );
 
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.id, payment_id);
-    assert_eq!(record.payer, payer);
-    assert_eq!(record.recipient, recipient);
-    assert_eq!(record.amount, 500);
-    assert_eq!(record.retry_count, 0);
-    assert_eq!(record.max_retry_attempts, 3);
-    assert_eq!(record.status, PaymentStatus::Pending);
-    assert_eq!(record.next_retry_at, 100); // immediately eligible
-    assert!(record.alternate_payout.is_none());
+    let payment = client.get_payment(&id).unwrap();
+    assert_eq!(payment.id, id);
+    assert_eq!(payment.payer, payer);
+    assert_eq!(payment.recipient, recipient);
+    assert_eq!(payment.amount, 250);
+    assert_eq!(payment.retry_count, 0);
+    assert_eq!(payment.max_retry_attempts, 2);
+    assert_eq!(payment.next_retry_at, 100);
+    assert_eq!(payment.state, RetryState::Scheduled);
 }
 
 #[test]
-fn test_create_payment_request_with_alternate_payout() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let alternate = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &Some(alternate.clone()),
-    );
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.alternate_payout, Some(alternate));
-}
-
-#[test]
-fn test_create_payment_request_zero_amount_rejected() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let result = client.try_create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &0i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_create_payment_request_missing_intervals_rejected() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    // max_retry_attempts > 0 but empty intervals
-    let result = client.try_create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env],
-        &notifier,
-        &None,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_create_payment_request_zero_retries_no_intervals_allowed() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    // zero retries with empty intervals is valid
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &0u32,
-        &vec![&env],
-        &notifier,
-        &None,
-    );
-    assert!(client.get_payment(&payment_id).is_some());
-}
-
-#[test]
-fn test_create_payment_request_interval_too_large_rejected() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    // 2 years in seconds exceeds MAX_SINGLE_RETRY_INTERVAL_SECONDS
-    let result = client.try_create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 63_072_001u64],
-        &notifier,
-        &None,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_create_payment_increments_id() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let id1 = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-    let id2 = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-    assert_eq!(id2, id1 + 1);
-}
-
-// ─── fund_payment ────────────────────────────────────────────────────────────
-
-#[test]
-fn test_fund_payment_happy_path() {
+fn test_process_due_payments_succeeds_and_returns_count() {
     let env = create_env();
     let (contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
-    client.initialize(&owner);
-
     let payer = Address::generate(&env);
     let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let token = create_token_contract(&env, &token_admin);
     let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &300i128);
 
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
+    client.initialize(&owner);
+    asset_admin.mint(&payer, &100);
+
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 2,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 100,
+            max_retries: 2,
+            intervals: &[30],
+        },
     );
+    client.fund_payment(&payer, &id, &100);
+    assert_eq!(token.balance(&contract_id), 100);
 
-    client.fund_payment(&payer, &payment_id, &100i128);
-    assert_eq!(token.balance(&contract_id), 100i128);
+    let processed = client.process_due_payments(&10);
+    assert_eq!(processed, 1);
+
+    let payment = client.get_payment(&id).unwrap();
+    assert_eq!(payment.state, RetryState::Success);
+    assert_eq!(payment.retry_count, 0);
+    assert_eq!(token.balance(&recipient), 100);
+    assert_eq!(token.balance(&contract_id), 0);
+
+    assert_eq!(client.process_due_payments(&10), 0);
+    assert_eq!(token.balance(&recipient), 100);
 }
 
 #[test]
-fn test_fund_payment_wrong_payer_rejected() {
+fn test_process_due_payments_respects_next_retry_at() {
     let env = create_env();
     let (_contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
-    client.initialize(&owner);
-
     let payer = Address::generate(&env);
-    let attacker = Address::generate(&env);
     let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let token = create_token_contract(&env, &token_admin);
+    let asset_admin = StellarAssetClient::new(&env, &token.address);
 
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
+    client.initialize(&owner);
+    env.ledger().with_mut(|li| li.timestamp = 0);
+
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 3,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 100,
+            max_retries: 2,
+            intervals: &[30, 60],
+        },
     );
 
-    let result = client.try_fund_payment(&attacker, &payment_id, &100i128);
-    assert!(result.is_err());
+    assert_eq!(client.process_due_payments(&10), 1);
+    let payment = client.get_payment(&id).unwrap();
+    assert_eq!(payment.state, RetryState::Retrying);
+    assert_eq!(payment.retry_count, 1);
+    assert_eq!(payment.next_retry_at, 30);
+
+    asset_admin.mint(&payer, &100);
+    client.fund_payment(&payer, &id, &100);
+
+    env.ledger().with_mut(|li| li.timestamp = 29);
+    assert_eq!(client.process_due_payments(&10), 0);
+    assert_eq!(client.get_payment(&id).unwrap().state, RetryState::Retrying);
+
+    env.ledger().with_mut(|li| li.timestamp = 30);
+    assert_eq!(client.process_due_payments(&10), 1);
+    assert_eq!(client.get_payment(&id).unwrap().state, RetryState::Success);
+    assert_eq!(token.balance(&recipient), 100);
 }
 
 #[test]
-fn test_fund_payment_after_cancel_rejected() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-
-    client.cancel_payment(&payer, &payment_id);
-
-    let result = client.try_fund_payment(&payer, &payment_id, &100i128);
-    assert!(result.is_err());
-}
-
-// ─── process_due_payments — success paths ────────────────────────────────────
-
-#[test]
-fn test_process_succeeds_immediately_when_funded() {
+fn test_process_due_payments_respects_max_payments() {
     let env = create_env();
     let (contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-    let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &200i128);
-
-    env.ledger().with_mut(|li| li.timestamp = 10);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &2u32,
-        &vec![&env, 5u64, 10u64],
-        &notifier,
-        &None,
-    );
-
-    client.fund_payment(&payer, &payment_id, &100i128);
-    assert_eq!(token.balance(&contract_id), 100i128);
-
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 1);
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Completed);
-    assert_eq!(record.retry_count, 0);
-    assert_eq!(token.balance(&recipient), 100i128);
-    assert_eq!(token.balance(&contract_id), 0i128);
-}
-
-#[test]
-fn test_process_routes_to_alternate_payout() {
-    let env = create_env();
-    let (contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let alternate = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-    let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &200i128);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &Some(alternate.clone()),
-    );
-
-    client.fund_payment(&payer, &payment_id, &100i128);
-    client.process_due_payments(&10u32);
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Completed);
-    // Funds went to alternate, not recipient
-    assert_eq!(token.balance(&alternate), 100i128);
-    assert_eq!(token.balance(&recipient), 0i128);
-    assert_eq!(token.balance(&contract_id), 0i128);
-}
-
-// ─── process_due_payments — retry and backoff ────────────────────────────────
-
-#[test]
-fn test_retries_then_succeeds_after_funding() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-    let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &500i128);
-
-    env.ledger().with_mut(|li| li.timestamp = 0);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &3u32,
-        &vec![&env, 10u64, 20u64],
-        &notifier,
-        &None,
-    );
-
-    // No funding yet — first attempt fails, schedules retry at t=10.
-    let processed = client.process_due_payments(&1u32);
-    assert_eq!(processed, 1);
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Pending);
-    assert_eq!(record.retry_count, 1);
-    assert_eq!(record.next_retry_at, 10);
-
-    // Top up before retry window opens.
-    client.fund_payment(&payer, &payment_id, &100i128);
-    env.ledger().with_mut(|li| li.timestamp = 10);
-
-    let processed = client.process_due_payments(&1u32);
-    assert_eq!(processed, 1);
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Completed);
-    assert_eq!(record.retry_count, 1);
-    assert_eq!(token.balance(&recipient), 100i128);
-}
-
-#[test]
-fn test_retry_not_due_before_next_retry_at() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    env.ledger().with_mut(|li| li.timestamp = 0);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &2u32,
-        &vec![&env, 30u64],
-        &notifier,
-        &None,
-    );
-
-    // First attempt fails at t=0; next_retry_at = 30.
-    client.process_due_payments(&1u32);
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.next_retry_at, 30);
-
-    // Advance to t=20 (still before next_retry_at=30).
-    env.ledger().with_mut(|li| li.timestamp = 20);
-    let processed = client.process_due_payments(&10u32);
-    // Record is still Pending but not due yet — not counted as processed.
-    assert_eq!(processed, 0);
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.retry_count, 1); // unchanged
-}
-
-#[test]
-fn test_retry_allowed_at_exact_next_retry_at() {
-    let env = create_env();
-    let (_, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-    let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &200i128);
-
-    env.ledger().with_mut(|li| li.timestamp = 0);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &2u32,
-        &vec![&env, 15u64],
-        &notifier,
-        &None,
-    );
-
-    // First attempt fails; next_retry_at = 15.
-    client.process_due_payments(&1u32);
-
-    // Fund and advance to exactly t=15.
-    client.fund_payment(&payer, &payment_id, &100i128);
-    env.ledger().with_mut(|li| li.timestamp = 15);
-
-    let processed = client.process_due_payments(&1u32);
-    assert_eq!(processed, 1);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().status,
-        PaymentStatus::Completed
-    );
-}
-
-#[test]
-fn test_backoff_uses_last_interval_when_retry_count_exceeds_list() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    env.ledger().with_mut(|li| li.timestamp = 0);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &4u32,
-        &vec![&env, 7u64], // single interval; all retries reuse it
-        &notifier,
-        &None,
-    );
-
-    // Retry 1: next_retry_at = 0 + 7 = 7
-    client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        7
-    );
-
-    // Retry 2: next_retry_at = 7 + 7 = 14
-    env.ledger().with_mut(|li| li.timestamp = 7);
-    client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        14
-    );
-
-    // Retry 3: next_retry_at = 14 + 7 = 21
-    env.ledger().with_mut(|li| li.timestamp = 14);
-    client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        21
-    );
-}
-
-#[test]
-fn test_backoff_uses_stepped_intervals() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    env.ledger().with_mut(|li| li.timestamp = 0);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &3u32,
-        &vec![&env, 10u64, 30u64, 60u64],
-        &notifier,
-        &None,
-    );
-
-    // Retry 1 → interval[0] = 10
-    client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        10
-    );
-
-    // Retry 2 → interval[1] = 30
-    env.ledger().with_mut(|li| li.timestamp = 10);
-    client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        40 // 10 + 30
-    );
-
-    // Retry 3 → interval[2] = 60
-    env.ledger().with_mut(|li| li.timestamp = 40);
-    client.process_due_payments(&1u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().next_retry_at,
-        100 // 40 + 60
-    );
-}
-
-// ─── process_due_payments — terminal failure ─────────────────────────────────
-
-#[test]
-fn test_fails_after_max_retries_exceeded() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    env.ledger().with_mut(|li| li.timestamp = 1);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &2u32, // 2 retries allowed
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-
-    // Retry #1 at t=1 (immediately eligible)
-    client.process_due_payments(&10u32);
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Pending);
-    assert_eq!(record.retry_count, 1);
-    assert_eq!(record.next_retry_at, 6);
-
-    // Retry #2 at t=6
-    env.ledger().with_mut(|li| li.timestamp = 6);
-    client.process_due_payments(&10u32);
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Pending);
-    assert_eq!(record.retry_count, 2);
-    assert_eq!(record.next_retry_at, 11);
-
-    // Retry #3 at t=11 → exceeds max_retry_attempts=2 → terminal Failed
-    env.ledger().with_mut(|li| li.timestamp = 11);
-    client.process_due_payments(&10u32);
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Failed);
-    assert_eq!(record.retry_count, 3);
-    assert_eq!(record.failure_notifier, notifier);
-}
-
-#[test]
-fn test_zero_max_retries_fails_on_first_missed_attempt() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    // No funding — first attempt will fail, retry_count=1 > max_retry_attempts=0 → Failed.
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &0u32,
-        &vec![&env],
-        &notifier,
-        &None,
-    );
-
-    client.process_due_payments(&10u32);
-
-    let record = client.get_payment(&payment_id).unwrap();
-    assert_eq!(record.status, PaymentStatus::Failed);
-    assert_eq!(record.retry_count, 1);
-}
-
-#[test]
-fn test_failed_record_not_reprocessed() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &0u32,
-        &vec![&env],
-        &notifier,
-        &None,
-    );
-
-    // Drive to Failed.
-    client.process_due_payments(&10u32);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().status,
-        PaymentStatus::Failed
-    );
-
-    // Subsequent call should not process the failed record.
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 0);
-}
-
-// ─── cancel_payment ──────────────────────────────────────────────────────────
-
-#[test]
-fn test_cancel_prevents_future_processing() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &50i128,
-        &1u32,
-        &vec![&env, 4u64],
-        &notifier,
-        &None,
-    );
-
-    client.cancel_payment(&payer, &payment_id);
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().status,
-        PaymentStatus::Cancelled
-    );
-
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 0);
-}
-
-#[test]
-fn test_cancel_wrong_payer_rejected() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let attacker = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-
-    let result = client.try_cancel_payment(&attacker, &payment_id);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_cancel_already_completed_rejected() {
-    let env = create_env();
-    let (_, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-    let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &200i128);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-    client.fund_payment(&payer, &payment_id, &100i128);
-    client.process_due_payments(&1u32);
-
-    let result = client.try_cancel_payment(&payer, &payment_id);
-    assert!(result.is_err());
-}
-
-// ─── process limit ────────────────────────────────────────────────────────────
-
-#[test]
-fn test_max_payments_bound_is_enforced() {
-    let env = create_env();
-    let (contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
     let payer = Address::generate(&env);
     let recipient_a = Address::generate(&env);
     let recipient_b = Address::generate(&env);
-    let notifier = Address::generate(&env);
+    let recipient_c = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let token = create_token_contract(&env, &token_admin);
     let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &500i128);
 
-    let id_a = client.create_payment_request(
-        &payer,
-        &recipient_a,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
+    client.initialize(&owner);
+    asset_admin.mint(&payer, &300);
+
+    let id_a = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 4,
+            payer: &payer,
+            recipient: &recipient_a,
+            token: &token.address,
+            amount: 100,
+            max_retries: 1,
+            intervals: &[30],
+        },
     );
-    let id_b = client.create_payment_request(
-        &payer,
-        &recipient_b,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
+    let id_b = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 5,
+            payer: &payer,
+            recipient: &recipient_b,
+            token: &token.address,
+            amount: 100,
+            max_retries: 1,
+            intervals: &[30],
+        },
+    );
+    let id_c = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 6,
+            payer: &payer,
+            recipient: &recipient_c,
+            token: &token.address,
+            amount: 100,
+            max_retries: 1,
+            intervals: &[30],
+        },
     );
 
-    client.fund_payment(&payer, &id_a, &100i128);
-    client.fund_payment(&payer, &id_b, &100i128);
-    assert_eq!(token.balance(&contract_id), 200i128);
+    client.fund_payment(&payer, &id_a, &100);
+    client.fund_payment(&payer, &id_b, &100);
+    client.fund_payment(&payer, &id_c, &100);
+    assert_eq!(token.balance(&contract_id), 300);
 
-    // Only process one at a time.
-    let processed = client.process_due_payments(&1u32);
-    assert_eq!(processed, 1);
-
-    let p_a = client.get_payment(&id_a).unwrap();
-    let p_b = client.get_payment(&id_b).unwrap();
-    assert_eq!(p_a.status, PaymentStatus::Completed);
-    assert_eq!(p_b.status, PaymentStatus::Pending);
-
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 1);
+    assert_eq!(client.process_due_payments(&2), 2);
     assert_eq!(
-        client.get_payment(&id_b).unwrap().status,
-        PaymentStatus::Completed
+        client.get_payment(&id_a).unwrap().state,
+        RetryState::Success
+    );
+    assert_eq!(
+        client.get_payment(&id_b).unwrap().state,
+        RetryState::Success
+    );
+    assert_eq!(
+        client.get_payment(&id_c).unwrap().state,
+        RetryState::Scheduled
+    );
+
+    assert_eq!(client.process_due_payments(&10), 1);
+    assert_eq!(
+        client.get_payment(&id_c).unwrap().state,
+        RetryState::Success
     );
 }
 
 #[test]
-fn test_process_zero_max_payments_returns_zero() {
+fn test_process_due_payments_returns_zero_for_zero_limit() {
     let env = create_env();
     let (_contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let processed = client.process_due_payments(&0u32);
-    assert_eq!(processed, 0);
-}
-
-// ─── Idempotency ─────────────────────────────────────────────────────────────
-
-#[test]
-fn test_completed_record_not_reprocessed() {
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
     let payer = Address::generate(&env);
     let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+
+    client.initialize(&owner);
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 7,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 100,
+            max_retries: 1,
+            intervals: &[30],
+        },
+    );
+
+    assert_eq!(client.process_due_payments(&0), 0);
+    assert_eq!(
+        client.get_payment(&id).unwrap().state,
+        RetryState::Scheduled
+    );
+}
+
+#[test]
+fn test_terminal_failure_is_not_reprocessed() {
+    let env = create_env();
+    let (_contract_id, client) = register_contract(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+
+    client.initialize(&owner);
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 8,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 100,
+            max_retries: 0,
+            intervals: &[],
+        },
+    );
+
+    assert_eq!(client.process_due_payments(&10), 1);
+    let failed = client.get_payment(&id).unwrap();
+    assert_eq!(failed.state, RetryState::Failed);
+    assert_eq!(failed.retry_count, 1);
+
+    assert_eq!(client.process_due_payments(&10), 0);
+}
+
+#[test]
+fn test_process_retry_removes_completed_record_from_batch_index() {
+    let env = create_env();
+    let (_contract_id, client) = register_contract(&env);
+    let owner = Address::generate(&env);
+    let payer = Address::generate(&env);
+    let recipient = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let token = create_token_contract(&env, &token_admin);
     let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &200i128);
 
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
+    client.initialize(&owner);
+    asset_admin.mint(&payer, &100);
+
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 9,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 100,
+            max_retries: 1,
+            intervals: &[30],
+        },
     );
-    client.fund_payment(&payer, &payment_id, &100i128);
-    client.process_due_payments(&1u32);
+    client.fund_payment(&payer, &id, &100);
 
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().status,
-        PaymentStatus::Completed
-    );
-
-    // Second call should not re-process the completed record.
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 0);
-    assert_eq!(token.balance(&recipient), 100i128);
+    client.process_retry(&id);
+    assert_eq!(client.get_payment(&id).unwrap().state, RetryState::Success);
+    assert_eq!(client.process_due_payments(&10), 0);
 }
 
 #[test]
-fn test_cancelled_record_not_reprocessed() {
+fn test_cancelled_record_is_skipped_by_batch_processing() {
     let env = create_env();
     let (_contract_id, client) = register_contract(&env);
     let owner = Address::generate(&env);
-    client.initialize(&owner);
-
     let payer = Address::generate(&env);
     let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let token = create_token_contract(&env, &token_admin);
 
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &2u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
-    );
-    client.cancel_payment(&payer, &payment_id);
-
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 0);
-}
-
-// ─── Security: cannot drain via infinite retries ─────────────────────────────
-
-#[test]
-fn test_cannot_exceed_max_retry_attempts_cap() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
     client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    // Exceeds MAX_RETRY_ATTEMPTS (100)
-    let result = client.try_create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &101u32,
-        &vec![&env, 1u64],
-        &notifier,
-        &None,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_payment_permanently_blocked_after_exhausting_retries() {
-    // Verify that once a record is Failed it cannot be re-activated or
-    // drained via further process_due_payments calls.
-    let env = create_env();
-    let (_contract_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    let payer = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let notifier = Address::generate(&env);
-    let token_admin = Address::generate(&env);
-    let token = create_token_contract(&env, &token_admin);
-
-    let payment_id = client.create_payment_request(
-        &payer,
-        &recipient,
-        &token.address,
-        &100i128,
-        &1u32,
-        &vec![&env, 5u64],
-        &notifier,
-        &None,
+    let id = schedule_payment(
+        &env,
+        &client,
+        PaymentInput {
+            id_seed: 10,
+            payer: &payer,
+            recipient: &recipient,
+            token: &token.address,
+            amount: 100,
+            max_retries: 1,
+            intervals: &[30],
+        },
     );
 
-    // Retry 1 — insufficient escrow.
-    client.process_due_payments(&10u32);
-    // Retry 2 — exceeds max, becomes Failed.
-    env.ledger().with_mut(|li| li.timestamp = 5);
-    client.process_due_payments(&10u32);
-
-    assert_eq!(
-        client.get_payment(&payment_id).unwrap().status,
-        PaymentStatus::Failed
-    );
-
-    // Even after funding is attempted, the guard rejects non-Pending records.
-    let asset_admin = StellarAssetClient::new(&env, &token.address);
-    asset_admin.mint(&payer, &200i128);
-    let result = client.try_fund_payment(&payer, &payment_id, &100i128);
-    assert!(result.is_err());
-
-    // And process_due_payments cannot revive it either.
-    let processed = client.process_due_payments(&10u32);
-    assert_eq!(processed, 0);
-}
-
-// ─── View functions ───────────────────────────────────────────────────────────
-
-#[test]
-fn test_get_payment_returns_none_for_missing_id() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-    let owner = Address::generate(&env);
-    client.initialize(&owner);
-
-    assert!(client.get_payment(&9999u128).is_none());
-}
-
-#[test]
-fn test_get_owner_before_init_returns_none() {
-    let env = create_env();
-    let (_id, client) = register_contract(&env);
-
-    assert!(client.get_owner().is_none());
+    client.cancel_payment(&payer, &id);
+    assert_eq!(client.get_payment(&id).unwrap().state, RetryState::Failed);
+    assert_eq!(client.process_due_payments(&10), 0);
 }


### PR DESCRIPTION
## Summary
- add a persistent pending-payment index for scheduled retry records
- implement `process_due_payments` by scanning due records up to `max_payments`
- route both batch and single-record retry processing through shared idempotent logic
- refresh payment retry tests to match the current `schedule_retry` / `RetryState` API and cover due counts, max limits, backoff gates, terminal cleanup, and idempotency

Closes #588.

## Validation
- `cargo fmt -p payment_retry --check`
- `git diff --check`
- `cargo test -p payment_retry`
- `cargo test -p integration_tests test_retry_orchestration`
- `cargo clippy -p payment_retry --all-targets`

Note: existing `Events::publish` deprecation warnings remain in `payment_retry`; this PR keeps the event API unchanged and focuses on the batch retry behavior.