### PR TITLE
feat(compliance_checker): record rule id and reason in check_action 

### DIFF
--- a/onchain/contracts/compliance_checker/src/lib.rs
+++ b/onchain/contracts/compliance_checker/src/lib.rs
@@ -69,12 +69,27 @@ pub enum ReasonCode {
     GracePeriodRequired,
 }
 
+/// Canonical identifiers for each evaluated rule in the compliance engine.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TraceRule {
+    EmergencyPause,
+    AuxiliaryNotAllowed,
+    TerminalState,
+    InvalidCurrentState,
+    InvalidTargetState,
+    GracePeriodRequired,
+}
+
 /// Trace entry for a single rule evaluation.
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TraceEntry {
-    pub rule: ReasonCode,
+    pub rule: TraceRule,
     pub result: Decision,
+    /// Denial reason that caused this rule to decide `Deny`, or `None` for
+    /// allowed path evaluations.
+    pub reason: Option<ReasonCode>,
 }
 
 /// Result payload returned by rule evaluation.
@@ -181,7 +196,15 @@ impl ComplianceCheckerContract {
             .unwrap_or(false);
         
         let pause_result = if is_paused { Decision::Deny } else { Decision::Allow };
-        traces.push_back(TraceEntry { rule: ReasonCode::EmergencyPaused, result: pause_result });
+        traces.push_back(TraceEntry {
+            rule: TraceRule::EmergencyPause,
+            result: pause_result,
+            reason: if is_paused {
+                Some(ReasonCode::EmergencyPaused)
+            } else {
+                None
+            },
+        });
         
         if is_paused {
             return Self::make_decision(Decision::Deny, ReasonCode::EmergencyPaused, traces);
@@ -191,7 +214,15 @@ impl ComplianceCheckerContract {
         if executor != actor {
             let is_allowed = Self::is_auxiliary_allowed(env.clone(), executor);
             let aux_result = if is_allowed { Decision::Allow } else { Decision::Deny };
-            traces.push_back(TraceEntry { rule: ReasonCode::AuxiliaryNotAllowed, result: aux_result });
+            traces.push_back(TraceEntry {
+                rule: TraceRule::AuxiliaryNotAllowed,
+                result: aux_result,
+                reason: if is_allowed {
+                    None
+                } else {
+                    Some(ReasonCode::AuxiliaryNotAllowed)
+                },
+            });
             if !is_allowed {
                 return Self::make_decision(Decision::Deny, ReasonCode::AuxiliaryNotAllowed, traces);
             }
@@ -200,7 +231,15 @@ impl ComplianceCheckerContract {
         // 3. Terminal State check
         let is_terminal = current_state == AgreementStatus::Completed;
         let terminal_result = if is_terminal { Decision::Deny } else { Decision::Allow };
-        traces.push_back(TraceEntry { rule: ReasonCode::TerminalState, result: terminal_result });
+        traces.push_back(TraceEntry {
+            rule: TraceRule::TerminalState,
+            result: terminal_result,
+            reason: if is_terminal {
+                Some(ReasonCode::TerminalState)
+            } else {
+                None
+            },
+        });
         if is_terminal {
             return Self::make_decision(Decision::Deny, ReasonCode::TerminalState, traces);
         }
@@ -208,7 +247,15 @@ impl ComplianceCheckerContract {
         // 4. Invalid Current State check
         let is_current_valid = Self::is_action_allowed_from_state(action, current_state);
         let current_valid_result = if is_current_valid { Decision::Allow } else { Decision::Deny };
-        traces.push_back(TraceEntry { rule: ReasonCode::InvalidCurrentState, result: current_valid_result });
+        traces.push_back(TraceEntry {
+            rule: TraceRule::InvalidCurrentState,
+            result: current_valid_result,
+            reason: if is_current_valid {
+                None
+            } else {
+                Some(ReasonCode::InvalidCurrentState)
+            },
+        });
         if !is_current_valid {
             return Self::make_decision(Decision::Deny, ReasonCode::InvalidCurrentState, traces);
         }
@@ -217,7 +264,15 @@ impl ComplianceCheckerContract {
         let expected_target = Self::expected_target_state(action, current_state);
         let is_target_valid = target_state == expected_target;
         let target_valid_result = if is_target_valid { Decision::Allow } else { Decision::Deny };
-        traces.push_back(TraceEntry { rule: ReasonCode::InvalidTargetState, result: target_valid_result });
+        traces.push_back(TraceEntry {
+            rule: TraceRule::InvalidTargetState,
+            result: target_valid_result,
+            reason: if is_target_valid {
+                None
+            } else {
+                Some(ReasonCode::InvalidTargetState)
+            },
+        });
         if !is_target_valid {
             return Self::make_decision(Decision::Deny, ReasonCode::InvalidTargetState, traces);
         }
@@ -228,7 +283,15 @@ impl ComplianceCheckerContract {
             || action == PayrollAction::ClaimMilestone;
         if is_claim_action && current_state == AgreementStatus::Cancelled {
             let grace_result = if grace_period_active { Decision::Allow } else { Decision::Deny };
-            traces.push_back(TraceEntry { rule: ReasonCode::GracePeriodRequired, result: grace_result });
+            traces.push_back(TraceEntry {
+                rule: TraceRule::GracePeriodRequired,
+                result: grace_result,
+                reason: if grace_period_active {
+                    None
+                } else {
+                    Some(ReasonCode::GracePeriodRequired)
+                },
+            });
             if !grace_period_active {
                 return Self::make_decision(Decision::Deny, ReasonCode::GracePeriodRequired, traces);
             }

--- a/onchain/contracts/compliance_checker/tests/test_compliance.rs
+++ b/onchain/contracts/compliance_checker/tests/test_compliance.rs
@@ -5,7 +5,7 @@
 
 use compliance_checker::{
     AgreementStatus, ComplianceCheckerContract, ComplianceCheckerContractClient, Decision,
-    PayrollAction, ReasonCode,
+    PayrollAction, ReasonCode, TraceRule,
 };
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
@@ -288,5 +288,67 @@ fn test_claims_from_cancelled_require_grace_period() {
         );
         assert_eq!(allowed.decision, Decision::Allow);
         assert_eq!(allowed.reason, ReasonCode::Allowed);
+    }
+}
+
+#[test]
+fn test_deny_traces_include_rule_and_reason() {
+    let env = create_env();
+    let (_cid, client, admin) = setup(&env);
+    let actor = Address::generate(&env);
+    let auxiliary = Address::generate(&env);
+
+    let emergency = client.check_action(
+        &actor,
+        &auxiliary,
+        &PayrollAction::ActivateAgreement,
+        &AgreementStatus::Created,
+        &AgreementStatus::Active,
+        &false,
+    );
+    assert_eq!(emergency.decision, Decision::Deny);
+    assert_eq!(emergency.reason, ReasonCode::AuxiliaryNotAllowed);
+    let trace = emergency.traces.get(1).unwrap();
+    assert_eq!(trace.rule, TraceRule::AuxiliaryNotAllowed);
+    assert_eq!(trace.result, Decision::Deny);
+    assert_eq!(trace.reason, Some(ReasonCode::AuxiliaryNotAllowed));
+
+    client.set_emergency_pause(&admin, &true);
+    let emergency = client.check_action(
+        &actor,
+        &auxiliary,
+        &PayrollAction::ActivateAgreement,
+        &AgreementStatus::Created,
+        &AgreementStatus::Active,
+        &false,
+    );
+    assert_eq!(emergency.decision, Decision::Deny);
+    assert_eq!(emergency.reason, ReasonCode::EmergencyPaused);
+    let trace = emergency.traces.get(0).unwrap();
+    assert_eq!(trace.rule, TraceRule::EmergencyPause);
+    assert_eq!(trace.result, Decision::Deny);
+    assert_eq!(trace.reason, Some(ReasonCode::EmergencyPaused));
+}
+
+#[test]
+fn test_allow_path_traces_have_none_reasons() {
+    let env = create_env();
+    let (_cid, client, _admin) = setup(&env);
+    let actor = Address::generate(&env);
+
+    let decision = client.check_action(
+        &actor,
+        &actor,
+        &PayrollAction::ActivateAgreement,
+        &AgreementStatus::Created,
+        &AgreementStatus::Active,
+        &false,
+    );
+
+    assert_eq!(decision.decision, Decision::Allow);
+    assert_eq!(decision.reason, ReasonCode::Allowed);
+    assert_eq!(decision.traces.len(), 4);
+    for i in 0..decision.traces.len() {
+        assert!(decision.traces.get(i).unwrap().reason.is_none());
     }
 }


### PR DESCRIPTION
Extend compliance trace entries to include the evaluated rule identifier and denial reason.
Populate trace [reason](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) only for denied rule evaluations, keeping allow-path traces consistent and lightweight.
Add regression coverage for denied rule traces and allow-path trace consistency.
Security note: trace entries now accurately reflect the actual rule that produced a deny decision, preventing misrepresentation of allow vs deny semantics.

Closes #606