### PR TITLE
fix(governance): bound voting_period_seconds in init and update_config

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -51,7 +51,16 @@ Backward-compatible aliases are also present for earlier local names:
 ### Configuration Model
 
 - `quorum_votes` is an absolute participation threshold, not a percentage.
-- `voting_period_seconds` controls how long proposals stay open.
+- `voting_period_seconds` controls how long proposals stay open. Both `initialize`
+  and `update_config` enforce that it falls within
+  `[MIN_VOTING_PERIOD_SECONDS, MAX_VOTING_PERIOD_SECONDS]`:
+  - `MIN_VOTING_PERIOD_SECONDS = 3600` (1 hour) ensures voters have a realistic
+    window to participate.
+  - `MAX_VOTING_PERIOD_SECONDS = 2_592_000` (30 days) prevents a misconfigured
+    admin from setting a value near `u64::MAX`, which would trap proposals in
+    effectively perpetual voting and freeze governance.
+  - Values outside this range (including zero) are rejected with
+    `GovernanceError::VotingPeriodOutOfBounds`.
 - The timelock delay is owned by the linked `withdrawal_timelock` contract.
 - The governance contract does not store a separate execution delay.
 

--- a/onchain/contracts/governance/src/lib.rs
+++ b/onchain/contracts/governance/src/lib.rs
@@ -14,6 +14,19 @@ use withdrawal_timelock::{
     TimelockedOperation, WithdrawalTimelockClient,
 };
 
+/// Minimum allowed voting period, in seconds (1 hour).
+///
+/// A voting window shorter than this gives eligible voters effectively no time
+/// to participate, so values below it are rejected.
+pub const MIN_VOTING_PERIOD_SECONDS: u64 = 3_600;
+
+/// Maximum allowed voting period, in seconds (30 days).
+///
+/// An unbounded voting period would let a misconfigured admin set a value near
+/// `u64::MAX`, trapping proposals in effectively perpetual voting and freezing
+/// governance. Values above this bound are rejected.
+pub const MAX_VOTING_PERIOD_SECONDS: u64 = 30 * 24 * 60 * 60;
+
 /// Errors returned by the governance contract.
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -36,6 +49,24 @@ pub enum GovernanceError {
     TimelockQueueFailed = 15,
     TimelockExecutionFailed = 16,
     TimelockCancellationFailed = 17,
+    /// `voting_period_seconds` was outside the `[MIN_VOTING_PERIOD_SECONDS,
+    /// MAX_VOTING_PERIOD_SECONDS]` range.
+    VotingPeriodOutOfBounds = 18,
+}
+
+/// Validates that `voting_period_seconds` falls within the supported bounds.
+///
+/// Rejects zero (via the range check) as well as values below
+/// [`MIN_VOTING_PERIOD_SECONDS`] or above [`MAX_VOTING_PERIOD_SECONDS`]. The
+/// upper bound prevents a misconfigured admin from setting a period near
+/// `u64::MAX` that would trap proposals in perpetual voting.
+fn validate_voting_period(voting_period_seconds: u64) -> Result<(), GovernanceError> {
+    if voting_period_seconds < MIN_VOTING_PERIOD_SECONDS
+        || voting_period_seconds > MAX_VOTING_PERIOD_SECONDS
+    {
+        return Err(GovernanceError::VotingPeriodOutOfBounds);
+    }
+    Ok(())
 }
 
 /// Types of governance actions supported by the contract.
@@ -334,7 +365,9 @@ impl GovernanceContract {
     /// @param multisig_contract Multisig contract whose signer set authorizes execution.
     /// @param timelock_contract Timelock contract that queues passed proposals before execution.
     /// @param quorum_votes Minimum number of votes required for a proposal to pass quorum.
-    /// @param voting_period_seconds Duration of the voting window in seconds.
+    /// @param voting_period_seconds Duration of the voting window in seconds. Must be within
+    ///        `[MIN_VOTING_PERIOD_SECONDS, MAX_VOTING_PERIOD_SECONDS]`; out-of-range values are
+    ///        rejected with `VotingPeriodOutOfBounds` to prevent perpetual-voting misconfiguration.
     pub fn initialize(
         env: Env,
         owner: Address,
@@ -357,9 +390,7 @@ impl GovernanceContract {
         if quorum_votes == 0 {
             return Err(GovernanceError::InvalidQuorum);
         }
-        if voting_period_seconds == 0 {
-            return Err(GovernanceError::InvalidVotingPeriod);
-        }
+        validate_voting_period(voting_period_seconds)?;
 
         env.storage().persistent().set(&StorageKey::Owner, &owner);
         env.storage()
@@ -387,7 +418,9 @@ impl GovernanceContract {
     /// @dev Owner-only. Dependency contract addresses remain fixed after initialization.
     /// @param caller Owner address.
     /// @param quorum_votes New minimum number of participating votes required.
-    /// @param voting_period_seconds New voting window length.
+    /// @param voting_period_seconds New voting window length. Must be within
+    ///        `[MIN_VOTING_PERIOD_SECONDS, MAX_VOTING_PERIOD_SECONDS]`; out-of-range values are
+    ///        rejected with `VotingPeriodOutOfBounds`.
     pub fn update_config(
         env: Env,
         caller: Address,
@@ -399,9 +432,7 @@ impl GovernanceContract {
         if quorum_votes == 0 {
             return Err(GovernanceError::InvalidQuorum);
         }
-        if voting_period_seconds == 0 {
-            return Err(GovernanceError::InvalidVotingPeriod);
-        }
+        validate_voting_period(voting_period_seconds)?;
 
         env.storage()
             .persistent()

--- a/onchain/contracts/governance/tests/governance_tests.rs
+++ b/onchain/contracts/governance/tests/governance_tests.rs
@@ -2,7 +2,7 @@
 
 use governance::{
     GovernanceContract, GovernanceContractClient, GovernanceError, ProposalKind, ProposalStatus,
-    VoteChoice,
+    VoteChoice, MAX_VOTING_PERIOD_SECONDS, MIN_VOTING_PERIOD_SECONDS,
 };
 use multisig::{MultisigContract, MultisigContractClient};
 use rbac::{RbacContract, RbacContractClient, Role};
@@ -61,7 +61,7 @@ fn setup(env: &Env) -> TestContracts {
     multisig.initialize(&owner, &signers, &2u32, &None);
 
     timelock.initialize(&governance_id, &60u64);
-    governance.initialize(&owner, &rbac_id, &multisig_id, &timelock_id, &2u32, &100u64);
+    governance.initialize(&owner, &rbac_id, &multisig_id, &timelock_id, &2u32, &3600u64);
 
     TestContracts {
         governance,
@@ -96,7 +96,7 @@ fn initialize_links_external_contracts() {
     assert_eq!(multisig_id, setup.multisig.address);
     assert_eq!(timelock_id, setup.timelock.address);
     assert_eq!(quorum_votes, 2u32);
-    assert_eq!(voting_period, 100u64);
+    assert_eq!(voting_period, 3600u64);
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn employer_can_create_vote_finalize_and_multisig_signer_executes() {
         .governance
         .cast_vote(&setup.employer_b, &proposal_id, &VoteChoice::For);
 
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&proposal_id);
 
     let proposal = setup.governance.get_proposal(&proposal_id).unwrap();
@@ -201,7 +201,7 @@ fn proposal_is_defeated_without_quorum() {
         .governance
         .cast_vote(&setup.owner, &proposal_id, &VoteChoice::For);
 
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&proposal_id);
 
     let proposal = setup.governance.get_proposal(&proposal_id).unwrap();
@@ -228,7 +228,7 @@ fn proposal_is_defeated_when_against_votes_win() {
         .governance
         .cast_vote(&setup.employer_b, &proposal_id, &VoteChoice::Against);
 
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&proposal_id);
 
     let proposal = setup.governance.get_proposal(&proposal_id).unwrap();
@@ -251,7 +251,7 @@ fn only_multisig_signer_can_execute() {
         .governance
         .cast_vote(&setup.employer_a, &proposal_id, &VoteChoice::For);
 
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&proposal_id);
     advance_time(&env, 60);
 
@@ -277,7 +277,7 @@ fn canceling_succeeded_proposal_cancels_timelock_operation() {
         .governance
         .cast_vote(&setup.employer_a, &proposal_id, &VoteChoice::For);
 
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&proposal_id);
 
     let proposal = setup.governance.get_proposal(&proposal_id).unwrap();
@@ -309,7 +309,7 @@ fn upgrade_and_arbiter_proposals_apply_expected_state() {
     setup
         .governance
         .cast_vote(&setup.employer_a, &arbiter_proposal, &VoteChoice::For);
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&arbiter_proposal);
     advance_time(&env, 60);
     setup
@@ -331,7 +331,7 @@ fn upgrade_and_arbiter_proposals_apply_expected_state() {
     setup
         .governance
         .cast_vote(&setup.employer_b, &upgrade_proposal, &VoteChoice::For);
-    advance_time(&env, 101);
+    advance_time(&env, 3601);
     setup.governance.finalize_proposal(&upgrade_proposal);
     advance_time(&env, 60);
     setup
@@ -361,4 +361,143 @@ fn losing_employer_role_blocks_future_votes() {
         .governance
         .try_cast_vote(&setup.employer_a, &proposal_id, &VoteChoice::For);
     assert_eq!(res, Err(Ok(GovernanceError::NotEligibleVoter)));
+}
+
+/// Registers and links RBAC, multisig, and timelock contracts and returns the
+/// raw (uninitialized) governance client plus the owner, so voting-period
+/// boundary cases can be exercised against `initialize` directly.
+fn setup_uninitialized(
+    env: &Env,
+) -> (GovernanceContractClient<'static>, Address, Address, Address, Address) {
+    #[allow(deprecated)]
+    let governance_id = env.register_contract(None, GovernanceContract);
+    #[allow(deprecated)]
+    let rbac_id = env.register_contract(None, RbacContract);
+    #[allow(deprecated)]
+    let multisig_id = env.register_contract(None, MultisigContract);
+    #[allow(deprecated)]
+    let timelock_id = env.register_contract(None, WithdrawalTimelock);
+
+    let governance = GovernanceContractClient::new(env, &governance_id);
+    let rbac = RbacContractClient::new(env, &rbac_id);
+    let multisig = MultisigContractClient::new(env, &multisig_id);
+    let timelock = WithdrawalTimelockClient::new(env, &timelock_id);
+
+    let owner = Address::generate(env);
+    rbac.initialize(&owner);
+    let signers = Vec::from_array(env, [Address::generate(env), Address::generate(env)]);
+    multisig.initialize(&owner, &signers, &2u32, &None);
+    timelock.initialize(&governance_id, &60u64);
+
+    (governance, owner, rbac_id, multisig_id, timelock_id)
+}
+
+#[test]
+fn initialize_accepts_voting_period_at_min_and_max_bounds() {
+    let env = create_env();
+
+    for period in [MIN_VOTING_PERIOD_SECONDS, MAX_VOTING_PERIOD_SECONDS] {
+        let (governance, owner, rbac_id, multisig_id, timelock_id) = setup_uninitialized(&env);
+        let res = governance.try_initialize(
+            &owner,
+            &rbac_id,
+            &multisig_id,
+            &timelock_id,
+            &2u32,
+            &period,
+        );
+        assert!(res.is_ok(), "period {} should be accepted", period);
+        let (_, _, _, _, _, stored_period) = governance.get_config();
+        assert_eq!(stored_period, period);
+    }
+}
+
+#[test]
+fn initialize_rejects_zero_voting_period() {
+    let env = create_env();
+    let (governance, owner, rbac_id, multisig_id, timelock_id) = setup_uninitialized(&env);
+    let res = governance.try_initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &0u64,
+    );
+    assert_eq!(res, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+}
+
+#[test]
+fn initialize_rejects_voting_period_below_min() {
+    let env = create_env();
+    let (governance, owner, rbac_id, multisig_id, timelock_id) = setup_uninitialized(&env);
+    let res = governance.try_initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &(MIN_VOTING_PERIOD_SECONDS - 1),
+    );
+    assert_eq!(res, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+}
+
+#[test]
+fn initialize_rejects_voting_period_above_max() {
+    let env = create_env();
+    let (governance, owner, rbac_id, multisig_id, timelock_id) = setup_uninitialized(&env);
+    let res = governance.try_initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &(MAX_VOTING_PERIOD_SECONDS + 1),
+    );
+    assert_eq!(res, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+}
+
+#[test]
+fn initialize_rejects_voting_period_near_u64_max() {
+    let env = create_env();
+    let (governance, owner, rbac_id, multisig_id, timelock_id) = setup_uninitialized(&env);
+    let res = governance.try_initialize(
+        &owner,
+        &rbac_id,
+        &multisig_id,
+        &timelock_id,
+        &2u32,
+        &(u64::MAX - 1),
+    );
+    assert_eq!(res, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+}
+
+#[test]
+fn update_config_enforces_voting_period_bounds() {
+    let env = create_env();
+    let setup = setup(&env);
+
+    // Over-max and near-u64::MAX are rejected.
+    let too_large = setup
+        .governance
+        .try_update_config(&setup.owner, &2u32, &(MAX_VOTING_PERIOD_SECONDS + 1));
+    assert_eq!(too_large, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+
+    let near_max = setup
+        .governance
+        .try_update_config(&setup.owner, &2u32, &u64::MAX);
+    assert_eq!(near_max, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+
+    // Below-min is rejected.
+    let too_small = setup
+        .governance
+        .try_update_config(&setup.owner, &2u32, &(MIN_VOTING_PERIOD_SECONDS - 1));
+    assert_eq!(too_small, Err(Ok(GovernanceError::VotingPeriodOutOfBounds)));
+
+    // A valid in-range value is accepted and persisted.
+    setup
+        .governance
+        .update_config(&setup.owner, &2u32, &MAX_VOTING_PERIOD_SECONDS);
+    let (_, _, _, _, _, period) = setup.governance.get_config();
+    assert_eq!(period, MAX_VOTING_PERIOD_SECONDS);
 }


### PR DESCRIPTION
Adds an upper and lower bound on `voting_period_seconds` in both `initialize` and `update_config`.

- New constants `MIN_VOTING_PERIOD_SECONDS` (1 hour) and `MAX_VOTING_PERIOD_SECONDS` (30 days).
- New `GovernanceError::VotingPeriodOutOfBounds` (discriminant appended at end, =18).
- `validate_voting_period` helper applied in both functions; zero and near-`u64::MAX` values are now rejected, preventing perpetual-voting misconfiguration.
- Boundary tests (min, max, zero, below-min, over-max, near-u64::MAX, update_config). All 16 governance tests pass.
- Documented bounds in docs/governance.md.

Closes #513