### PR TITLE
fix(payroll): reject duplicate employee in add_employee_to_agreement

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -509,6 +509,10 @@ impl PayrollContract {
     /// - Agreement must be in Created status
     /// - Agreement must be Payroll mode
     /// - Caller must be the employer
+    /// - The employee address must not already be present in the agreement;
+    ///   a duplicate add panics with `PayrollError::EmployeeAlreadyExists` to
+    ///   preserve the 1:1 employee-to-salary mapping. A previously removed
+    ///   employee may be re-added.
     pub fn add_employee_to_agreement(
         env: Env,
         agreement_id: u128,

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -23,7 +23,7 @@ use crate::storage::{
 };
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    contractclient, contracttype, token, IntoVal, Symbol, Val,
+    contractclient, contracttype, panic_with_error, token, IntoVal, Symbol, Val,
 };
 
 /// Minimal interface for cross-contract calls into the deployed multisig contract.
@@ -1346,6 +1346,16 @@ pub fn add_employee_to_agreement(
         .persistent()
         .get(&StorageKey::AgreementEmployees(agreement_id))
         .unwrap_or(Vec::new(env));
+
+    // Reject duplicate employee addresses. Each address must map to exactly one
+    // salary entry within an agreement; adding the same address twice would
+    // create two salary streams and corrupt per-employee claim accounting.
+    // A removed employee can be re-added because they are no longer present.
+    for existing in employees.iter() {
+        if existing.address == employee {
+            panic_with_error!(env, PayrollError::EmployeeAlreadyExists);
+        }
+    }
 
     employees.push_back(EmployeeInfo {
         address: employee.clone(),

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -374,6 +374,10 @@ pub enum PayrollError {
     MilestoneNotApproved = 40,
     /// Milestone has already been claimed.
     MilestoneAlreadyClaimed = 41,
+    /// An employee with the same address is already present in the agreement's
+    /// employee list. Adding it again would create two salary entries and break
+    /// the 1:1 employee-to-index mapping, so the duplicate add is rejected.
+    EmployeeAlreadyExists = 42,
 }
 
 /// Caps for how much a cancelled agreement's grace/dispute window may be extended on-chain.

--- a/onchain/contracts/stello_pay_contract/tests/test_agreement.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_agreement.rs
@@ -166,6 +166,58 @@ fn test_add_multiple_employees() {
     assert_eq!(agreement.total_amount, 6000);
 }
 
+/// Adding the same employee address twice must be rejected to preserve the
+/// 1:1 employee-to-salary mapping.
+#[test]
+fn test_add_duplicate_employee_fails() {
+    let env = create_test_env();
+    let (_contract_id, client) = setup_contract(&env);
+    let employer = create_test_address(&env);
+    let token = create_test_address(&env);
+    let employee = create_test_address(&env);
+
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &604800u64);
+    client.add_employee_to_agreement(&agreement_id, &employee, &1000);
+
+    // Re-adding the same address must fail with EmployeeAlreadyExists.
+    let res = client.try_add_employee_to_agreement(&agreement_id, &employee, &2000);
+    let expected: soroban_sdk::Error =
+        stello_pay_contract::storage::PayrollError::EmployeeAlreadyExists.into();
+    assert_eq!(res, Err(Ok(expected)));
+
+    // The original single entry and total are unchanged.
+    let employees = client.get_agreement_employees(&agreement_id);
+    assert_eq!(employees.len(), 1);
+    let agreement = client.get_agreement(&agreement_id).unwrap();
+    assert_eq!(agreement.total_amount, 1000);
+}
+
+/// A different employee address can still be added after a duplicate is rejected.
+#[test]
+fn test_add_duplicate_does_not_block_other_employees() {
+    let env = create_test_env();
+    let (_contract_id, client) = setup_contract(&env);
+    let employer = create_test_address(&env);
+    let token = create_test_address(&env);
+    let e1 = create_test_address(&env);
+    let e2 = create_test_address(&env);
+
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &604800u64);
+    client.add_employee_to_agreement(&agreement_id, &e1, &1000);
+
+    let dup = client.try_add_employee_to_agreement(&agreement_id, &e1, &1000);
+    let expected: soroban_sdk::Error =
+        stello_pay_contract::storage::PayrollError::EmployeeAlreadyExists.into();
+    assert_eq!(dup, Err(Ok(expected)));
+
+    // A distinct address still works.
+    client.add_employee_to_agreement(&agreement_id, &e2, &2000);
+    let employees = client.get_agreement_employees(&agreement_id);
+    assert_eq!(employees.len(), 2);
+    let agreement = client.get_agreement(&agreement_id).unwrap();
+    assert_eq!(agreement.total_amount, 3000);
+}
+
 /// Adding employee with zero salary must fail.
 #[test]
 #[should_panic(expected = "Salary must be positive")]


### PR DESCRIPTION
`add_employee_to_agreement` did not check whether the employee address was already present, allowing two salary entries for one address and corrupting per-employee claim accounting.

- Added `PayrollError::EmployeeAlreadyExists` (discriminant 42, appended at end).
- The function now scans the existing employee list and rejects a duplicate with `panic_with_error!(EmployeeAlreadyExists)`, matching the function's existing panic-style validation.
- Documented the guard on the entrypoint.
- Tests: duplicate add rejected with the specific error and leaves state unchanged; a distinct address still adds successfully. All 27 test_agreement tests pass.

Closes #501