### PR TITLE
fix(payroll): validate non-zero bounds in set_grace_extension_policy

### DIFF
--- a/docs/grace-period.md
+++ b/docs/grace-period.md
@@ -45,6 +45,14 @@ Defaults (if owner never sets policy):
 
 Owner updates are constrained by hard sanity limits inside `set_grace_extension_policy` (e.g. bps ≤ 500_000, per-call ≤ 730 days).
 
+**Non-zero requirement.** Both `max_cumulative_extension_bps` and
+`max_extension_per_call_seconds` must be strictly greater than zero. A zero value
+on either field silently disables all grace extensions (no extension can ever be
+applied), so it is treated as an invalid configuration and rejected with
+`GraceExtensionInvalid` rather than interpreted as "disabled". To intentionally
+stop allowing extensions, set the caps to a small explicit non-zero value so the
+choice is auditable and cannot happen by accident.
+
 ## Errors
 
 | `PayrollError` | When |

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1481,6 +1481,23 @@ pub fn get_grace_extension_policy(env: &Env) -> GracePeriodExtensionPolicy {
 }
 
 /// Sets caps for per-agreement grace extensions. Callable only by the contract owner.
+///
+/// # Policy semantics
+/// Both policy fields must be strictly positive. A zero value is treated as an
+/// invalid configuration (not "disabled"), because a zero cap silently disables
+/// all grace extensions and removes a safety mechanism with no error:
+/// - `max_cumulative_extension_bps == 0` would make every extension exceed the
+///   (zero) cumulative cap, so no extension could ever be applied.
+/// - `max_extension_per_call_seconds == 0` would reject every single-call
+///   extension.
+///
+/// To intentionally stop allowing extensions, set the caps to a small, explicit
+/// non-zero value rather than zero, so the configuration choice is auditable and
+/// cannot happen by accident. Both fields are also bounded above so a compromised
+/// owner key cannot configure absurd values in one transaction.
+///
+/// Returns [`PayrollError::GraceExtensionInvalid`] when either field is zero or
+/// exceeds its upper bound.
 pub fn set_grace_extension_policy(
     env: &Env,
     caller: Address,
@@ -1494,7 +1511,11 @@ pub fn set_grace_extension_policy(
     // Sanity bounds so a compromised owner key cannot configure absurd values in one tx.
     const MAX_BPS: u32 = 500_000;
     const MAX_PER_CALL: u64 = 730 * 24 * 3600;
-    if policy.max_cumulative_extension_bps > MAX_BPS {
+    // Reject zero on both fields: a zero cap silently disables grace extensions,
+    // which must be an explicit, non-zero configuration rather than an accident.
+    if policy.max_cumulative_extension_bps == 0
+        || policy.max_cumulative_extension_bps > MAX_BPS
+    {
         return Err(PayrollError::GraceExtensionInvalid);
     }
     if policy.max_extension_per_call_seconds == 0

--- a/onchain/contracts/stello_pay_contract/tests/test_grace_period_extension.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_grace_period_extension.rs
@@ -319,6 +319,75 @@ fn test_set_grace_extension_policy_rejects_absurd_bps() {
 }
 
 #[test]
+fn test_set_grace_extension_policy_rejects_zero_cumulative_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, client, owner) = setup(&env);
+    let p = GracePeriodExtensionPolicy {
+        max_cumulative_extension_bps: 0,
+        max_extension_per_call_seconds: 3600,
+    };
+    let e = client
+        .try_set_grace_extension_policy(&owner, &p)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, PayrollError::GraceExtensionInvalid);
+}
+
+#[test]
+fn test_set_grace_extension_policy_rejects_zero_per_call_seconds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, client, owner) = setup(&env);
+    let p = GracePeriodExtensionPolicy {
+        max_cumulative_extension_bps: 5000,
+        max_extension_per_call_seconds: 0,
+    };
+    let e = client
+        .try_set_grace_extension_policy(&owner, &p)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, PayrollError::GraceExtensionInvalid);
+}
+
+#[test]
+fn test_set_grace_extension_policy_rejects_both_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, client, owner) = setup(&env);
+    let p = GracePeriodExtensionPolicy {
+        max_cumulative_extension_bps: 0,
+        max_extension_per_call_seconds: 0,
+    };
+    let e = client
+        .try_set_grace_extension_policy(&owner, &p)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, PayrollError::GraceExtensionInvalid);
+}
+
+#[test]
+fn test_set_grace_extension_policy_accepts_minimal_nonzero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, client, owner) = setup(&env);
+    // Smallest valid (explicitly-nonzero) configuration is accepted; existing
+    // valid configs are unaffected by the new lower-bound check.
+    let p = GracePeriodExtensionPolicy {
+        max_cumulative_extension_bps: 1,
+        max_extension_per_call_seconds: 1,
+    };
+    client.set_grace_extension_policy(&owner, &p);
+    let got = client.get_grace_extension_policy();
+    assert_eq!(got.max_cumulative_extension_bps, 1);
+    assert_eq!(got.max_extension_per_call_seconds, 1);
+}
+
+#[test]
 fn test_grace_period_extended_event_emitted() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
`set_grace_extension_policy` rejected zero on `max_extension_per_call_seconds` but not on `max_cumulative_extension_bps`, so an owner could set the cumulative cap to zero and silently disable all grace extensions with no error.

- Reject `max_cumulative_extension_bps == 0` (the per-call zero check already existed).
- Documented policy semantics: zero is invalid, not "disabled"; to stop extensions, set an explicit small non-zero cap so the choice is auditable.
- Tests added: zero cumulative bps, zero per-call seconds, both zero rejected with `GraceExtensionInvalid`; minimal non-zero config still accepted; existing valid configs unaffected. All 19 grace-extension tests pass.

Closes #506