### PR TITLE
feat(payroll): emit and audit events on multisig threshold changes

### DIFF
--- a/docs/events-schema.json
+++ b/docs/events-schema.json
@@ -167,6 +167,19 @@
         "successful_claims": { "type": "integer" },
         "failed_claims": { "type": "integer" }
       }
+    },
+    {
+      "title": "MultisigConfigChanged",
+      "description": "Emitted by set_multisig_config on every successful update so off-chain monitors can detect changes to the approval-requirement thresholds. Exposes only public configuration (no signer secrets).",
+      "properties": {
+        "event": { "const": "MultisigConfigChanged" },
+        "caller": { "$ref": "#/definitions/Address" },
+        "multisig_contract": { "$ref": "#/definitions/Address" },
+        "old_large_threshold": { "type": "string" },
+        "new_large_threshold": { "type": "string" },
+        "old_dispute_threshold": { "type": "string" },
+        "new_dispute_threshold": { "type": "string" }
+      }
     }
   ]
 }

--- a/docs/multisig.md
+++ b/docs/multisig.md
@@ -139,3 +139,26 @@ The test suite covers:
 - Zero-amount payment rejection
 - ContractUpgrade and DisputeResolution flows
 - Query function correctness
+
+### Observability: payroll multisig threshold changes
+
+The `stello_pay_contract` payroll contract gates large payments and dispute
+resolutions behind multisig approval, using two thresholds configured via
+`set_multisig_config(owner, multisig_contract, large_payment_threshold,
+dispute_resolution_threshold)`.
+
+Because changing these thresholds alters the contract's security posture, every
+successful `set_multisig_config` call now:
+
+- emits a `MultisigConfigChanged` event (see `docs/events-schema.json`) carrying
+  the `caller`, the `multisig_contract`, and the old vs new values for both
+  thresholds, so off-chain monitors can detect approval-requirement changes
+  mid-lifecycle; and
+- records a tamper-evident audit entry through the contract's existing audit
+  path (`AuditEvent::MultisigConfigChanged`, action `multisig_config_changed`,
+  contract-level `agreement_id = 0`).
+
+The event exposes only public configuration; it never includes multisig signer
+secrets. Emission and audit recording are covered by
+`onchain/contracts/stello_pay_contract/tests/test_event_emissions.rs`
+(`test_multisig_config_changed_event*`).

--- a/onchain/contracts/stello_pay_contract/src/audit.rs
+++ b/onchain/contracts/stello_pay_contract/src/audit.rs
@@ -9,6 +9,11 @@ pub enum AuditEvent {
     AgreementCancelled,
     DisputeRaised,
     DisputeResolved,
+    /// A multisig threshold configuration change (`set_multisig_config`).
+    ///
+    /// This is a contract-level event not tied to an agreement; entries use a
+    /// sentinel `agreement_id` of `0`.
+    MultisigConfigChanged,
 }
 
 /// Append-only audit entry for critical agreement lifecycle transitions.
@@ -42,6 +47,7 @@ impl AuditEvent {
             AuditEvent::AgreementCancelled => Symbol::new(env, "agreement_cancelled"),
             AuditEvent::DisputeRaised => Symbol::new(env, "dispute_raised"),
             AuditEvent::DisputeResolved => Symbol::new(env, "dispute_resolved"),
+            AuditEvent::MultisigConfigChanged => Symbol::new(env, "multisig_config_changed"),
         }
     }
 }

--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -256,3 +256,34 @@ pub struct MilestoneFundedEvent {
 pub fn emit_milestone_funded(env: &Env, event: MilestoneFundedEvent) {
     event.publish(env);
 }
+
+/// Event: Multisig threshold configuration changed.
+///
+/// Emitted by `set_multisig_config` on every successful update so off-chain
+/// monitors can detect when the approval requirements (which gate large payments
+/// and dispute resolutions) change mid-lifecycle. Carries the previous and new
+/// thresholds and the owner that performed the change.
+///
+/// Topics: `("MULTISIG", "config")` (derived from the struct/field layout by the
+/// `#[contractevent]` macro). The event exposes only public configuration; it
+/// does not include any multisig signer secrets.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct MultisigConfigChangedEvent {
+    /// Owner address that performed the change.
+    pub caller: Address,
+    /// New multisig contract address now configured.
+    pub multisig_contract: Address,
+    /// Previous large-payment threshold (0 if previously unset/disabled).
+    pub old_large_threshold: i128,
+    /// New large-payment threshold.
+    pub new_large_threshold: i128,
+    /// Previous dispute-resolution threshold (0 if previously unset/disabled).
+    pub old_dispute_threshold: i128,
+    /// New dispute-resolution threshold.
+    pub new_dispute_threshold: i128,
+}
+
+pub fn emit_multisig_config_changed(env: &Env, event: MultisigConfigChangedEvent) {
+    event.publish(env);
+}

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -6,13 +6,13 @@ use crate::events::{
     emit_agreement_activated, emit_agreement_cancelled, emit_agreement_created,
     emit_agreement_paused, emit_agreement_resumed, emit_dsipute_raised, emit_dsipute_resolved,
     emit_employee_added, emit_grace_period_extended, emit_grace_period_finalized,
-    emit_milestone_funded, emit_payment_received, emit_payment_sent, emit_payroll_claimed,
-    emit_set_arbiter, AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent,
-    AgreementPausedEvent, AgreementResumedEvent, ArbiterSetEvent, BatchMilestoneClaimedEvent,
-    BatchPayrollClaimedEvent, DisputeRaisedEvent, DisputeResolvedEvent, EmployeeAddedEvent,
-    GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved,
-    MilestoneClaimed, MilestoneFundedEvent, PaymentReceivedEvent, PaymentSentEvent,
-    PayrollClaimedEvent,
+    emit_milestone_funded, emit_multisig_config_changed, emit_payment_received, emit_payment_sent,
+    emit_payroll_claimed, emit_set_arbiter, AgreementActivatedEvent, AgreementCancelledEvent,
+    AgreementCreatedEvent, AgreementPausedEvent, AgreementResumedEvent, ArbiterSetEvent,
+    BatchMilestoneClaimedEvent, BatchPayrollClaimedEvent, DisputeRaisedEvent, DisputeResolvedEvent,
+    EmployeeAddedEvent, GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded,
+    MilestoneApproved, MilestoneClaimed, MilestoneFundedEvent, MultisigConfigChangedEvent,
+    PaymentReceivedEvent, PaymentSentEvent, PayrollClaimedEvent,
 };
 use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,
@@ -98,6 +98,20 @@ pub fn set_multisig_config(
     if owner != stored_owner {
         return Err(PayrollError::Unauthorized);
     }
+
+    // Capture the previous thresholds before overwriting so the emitted event
+    // and audit entry can report old-vs-new values (0 = previously unset).
+    let old_large_payment_threshold: i128 = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::LargePaymentThreshold)
+        .unwrap_or(0);
+    let old_dispute_resolution_threshold: i128 = env
+        .storage()
+        .persistent()
+        .get(&StorageKey::DisputeResolutionThreshold)
+        .unwrap_or(0);
+
     env.storage()
         .persistent()
         .set(&StorageKey::MultisigContract, &multisig_contract);
@@ -108,6 +122,33 @@ pub fn set_multisig_config(
         &StorageKey::DisputeResolutionThreshold,
         &dispute_resolution_threshold,
     );
+
+    // Emit a structured event so off-chain monitors observe approval-requirement
+    // changes mid-lifecycle. Only public configuration is exposed.
+    emit_multisig_config_changed(
+        env,
+        MultisigConfigChangedEvent {
+            caller: owner.clone(),
+            multisig_contract: multisig_contract.clone(),
+            old_large_threshold: old_large_payment_threshold,
+            new_large_threshold: large_payment_threshold,
+            old_dispute_threshold: old_dispute_resolution_threshold,
+            new_dispute_threshold: dispute_resolution_threshold,
+        },
+    );
+
+    // Record a tamper-evident audit entry via the existing audit path. This is a
+    // contract-level change, so it uses the sentinel `agreement_id = 0` and
+    // reports the new large-payment threshold as the entry's `amount`.
+    record_entry(
+        env,
+        owner,
+        AuditEvent::MultisigConfigChanged,
+        0,
+        None,
+        Some(large_payment_threshold),
+    );
+
     Ok(())
 }
 

--- a/onchain/contracts/stello_pay_contract/tests/test_event_emissions.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_event_emissions.rs
@@ -728,6 +728,73 @@ fn test_no_duplicate_events() {
 }
 
 // ============================================================================
+// MULTISIG CONFIG EVENT TESTS
+// ============================================================================
+
+/// Test: multisig_config_changed_event is emitted with old/new thresholds and caller.
+#[test]
+fn test_multisig_config_changed_event() {
+    let env = create_test_env();
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(&env, &contract_id);
+    let owner = create_test_address(&env);
+    client.initialize(&owner);
+
+    let multisig = create_test_address(&env);
+
+    // First config: previous thresholds default to 0.
+    client.set_multisig_config(&owner, &multisig, &1_000i128, &2_000i128);
+
+    assert!(has_event(&env, "multisig_config_changed_event"));
+    let event = find_event(&env, "multisig_config_changed_event").unwrap();
+    let caller: Address = get_event_field(&env, &event.2, "caller");
+    let old_large: i128 = get_event_field(&env, &event.2, "old_large_threshold");
+    let new_large: i128 = get_event_field(&env, &event.2, "new_large_threshold");
+    let old_dispute: i128 = get_event_field(&env, &event.2, "old_dispute_threshold");
+    let new_dispute: i128 = get_event_field(&env, &event.2, "new_dispute_threshold");
+    assert_eq!(caller, owner);
+    assert_eq!(old_large, 0);
+    assert_eq!(new_large, 1_000);
+    assert_eq!(old_dispute, 0);
+    assert_eq!(new_dispute, 2_000);
+
+    // An audit entry was recorded via the existing audit path.
+    assert_eq!(client.get_audit_entry_count(), 1);
+}
+
+/// Test: a second config change reports the previous thresholds as the old values.
+#[test]
+fn test_multisig_config_changed_event_reports_previous_values() {
+    let env = create_test_env();
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(&env, &contract_id);
+    let owner = create_test_address(&env);
+    client.initialize(&owner);
+    let multisig = create_test_address(&env);
+
+    client.set_multisig_config(&owner, &multisig, &1_000i128, &2_000i128);
+    client.set_multisig_config(&owner, &multisig, &5_000i128, &9_000i128);
+
+    // Capture the second call's event before any further invocation (read calls
+    // also reset the test host's event buffer). It must carry the first call's
+    // thresholds as the old values, proving old-vs-new tracking across changes.
+    let event = find_event(&env, "multisig_config_changed_event").unwrap();
+    let old_large: i128 = get_event_field(&env, &event.2, "old_large_threshold");
+    let new_large: i128 = get_event_field(&env, &event.2, "new_large_threshold");
+    let old_dispute: i128 = get_event_field(&env, &event.2, "old_dispute_threshold");
+    let new_dispute: i128 = get_event_field(&env, &event.2, "new_dispute_threshold");
+    assert_eq!(old_large, 1_000);
+    assert_eq!(new_large, 5_000);
+    assert_eq!(old_dispute, 2_000);
+    assert_eq!(new_dispute, 9_000);
+
+    // Two config changes produce two persistent audit entries.
+    assert_eq!(client.get_audit_entry_count(), 2);
+}
+
+// ============================================================================
 // SUMMARY TEST
 // ============================================================================
 


### PR DESCRIPTION
`set_multisig_config` changed `large_payment_threshold` / `dispute_resolution_threshold` with no event or audit entry, so off-chain monitors could not detect approval-requirement changes mid-lifecycle.

Changes:
- New `MultisigConfigChangedEvent` in `src/events.rs` (caller, multisig_contract, old/new large & dispute thresholds) with doc comments and an `emit_multisig_config_changed` helper.
- `set_multisig_config` now reads the previous thresholds, emits the event with old-vs-new values, and records a tamper-evident audit entry via the existing audit path.
- New `AuditEvent::MultisigConfigChanged` variant (action `multisig_config_changed`), recorded with a contract-level sentinel `agreement_id = 0`.
- Event documented in `docs/events-schema.json` and `docs/multisig.md`.
- The event exposes only public configuration (no signer secrets).

Tests (in test_event_emissions.rs): asserts event emitted with correct caller and old/new thresholds (incl. previous-values-on-second-change) and that audit entries are recorded. All 24 event-emission tests pass; full crate builds clean.

Closes #504