### PR TITLE
feat(storage): add extend_ttl bumps for long-lived persistent keys

### DIFF
--- a/docs/storage-optimization-summary.md
+++ b/docs/storage-optimization-summary.md
@@ -170,6 +170,36 @@ The implementation maintains full backward compatibility:
 4. **Analytics:** Add analytics functions for payroll insights
 5. **Bulk Operations:** Add more bulk operation types
 
+## State Archival / TTL Strategy
+
+Soroban archives persistent entries once their time-to-live (TTL) lapses. Long-lived
+but infrequently-accessed payroll data (agreements, escrow balances, employee salary
+and claimed-period records) could otherwise be archived mid-lifecycle, breaking later
+claims and refunds.
+
+To prevent this, TTL constants are centralized in `storage.rs` and the contract bumps
+TTL on access of these long-lived keys:
+
+- `PERSISTENT_TTL_THRESHOLD` (~30 days of ledgers): when a key's remaining TTL drops
+  below this, it is extended.
+- `PERSISTENT_BUMP_AMOUNT` (~90 days of ledgers): the target TTL a bump extends to.
+- `extend_persistent_ttl(env, key)`: a no-op when the key is absent; otherwise calls
+  `extend_ttl(PERSISTENT_TTL_THRESHOLD, PERSISTENT_BUMP_AMOUNT)`.
+
+Bumps are applied in the centralized accessors and `get_agreement`:
+
+- `get_agreement` / `get_agreement_escrow_balance` (read paths)
+- `set_agreement_escrow_balance`, `set_employee_salary`,
+  `set_employee_claimed_periods` (write paths)
+
+**Anti-griefing.** TTL bumps only ever extend keys the contract already owns and writes,
+and the caller pays the rent for the extension, so they cannot be abused to keep
+adversarial entries alive cheaply or to inflate another party's storage rent.
+
+Coverage: `tests/test_state_machine.rs` (`test_get_agreement_bumps_ttl`,
+`test_escrow_balance_ttl_survives_ledger_advance`) configures a finite TTL window,
+advances the ledger near expiry, and asserts the entries remain live and are re-bumped.
+
 ## Conclusion
 
 These storage optimizations provide significant improvements in:

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1921,12 +1921,19 @@ pub fn convert_currency(
 
 /// Retrieves an agreement by ID
 ///
+/// Bumps the agreement entry's TTL on read (see [`crate::storage::extend_persistent_ttl`])
+/// so an active agreement that is accessed but not rewritten for a long time is
+/// not archived under Soroban's state-archival model.
+///
 /// # Returns
 /// Some(Agreement) if found, None otherwise
 pub fn get_agreement(env: &Env, agreement_id: u128) -> Option<Agreement> {
-    env.storage()
-        .persistent()
-        .get(&StorageKey::Agreement(agreement_id))
+    let key = StorageKey::Agreement(agreement_id);
+    let agreement = env.storage().persistent().get(&key);
+    if agreement.is_some() {
+        crate::storage::extend_persistent_ttl(env, &key);
+    }
+    agreement
 }
 
 /// Retrieves all employees for an agreement

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -9,6 +9,42 @@ use soroban_sdk::{contracterror, contracttype, Address, Env, Vec};
 /// late Soroban resource exhaustion after partial state changes.
 pub const MAX_BATCH_SIZE: u32 = 20;
 
+/// Number of ledgers below which a long-lived persistent entry is bumped.
+///
+/// Under Soroban's state-archival model, persistent entries that are not bumped
+/// can be archived once their time-to-live (TTL) lapses, which would make active
+/// payroll agreements, escrow balances, and employee records inaccessible
+/// mid-lifecycle. When a long-lived key's remaining TTL drops below this
+/// threshold, [`extend_persistent_ttl`] extends it back up to
+/// [`PERSISTENT_BUMP_AMOUNT`].
+///
+/// ~30 days at 5s/ledger (≈ 17,280 ledgers/day).
+pub const PERSISTENT_TTL_THRESHOLD: u32 = 30 * 17_280;
+
+/// Target TTL (in ledgers) that long-lived persistent keys are extended to.
+///
+/// ~90 days at 5s/ledger. Kept comfortably above [`PERSISTENT_TTL_THRESHOLD`] so
+/// that a single access well before expiry restores a long runway without
+/// bumping on every read.
+pub const PERSISTENT_BUMP_AMOUNT: u32 = 90 * 17_280;
+
+/// Bumps the TTL of a single long-lived persistent entry if it exists.
+///
+/// This is a no-op when the entry is absent. Centralizing the thresholds here
+/// keeps the archival strategy consistent across agreements, escrow balances,
+/// and employee records. TTL bumps cannot be used to keep adversarial entries
+/// alive cheaply: they only ever extend keys the contract itself already owns
+/// and writes, and the caller pays the rent for the extension.
+pub fn extend_persistent_ttl<K>(env: &Env, key: &K)
+where
+    K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
+    let storage = env.storage().persistent();
+    if storage.has(key) {
+        storage.extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+    }
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Milestone {
@@ -491,10 +527,11 @@ impl DataKey {
         env.storage().persistent().get(&key)
     }
 
-    /// Set salary per period for an employee at a specific index
+    /// Set salary per period for an employee at a specific index, bumping its TTL.
     pub fn set_employee_salary(env: &Env, agreement_id: u128, employee_index: u32, salary: i128) {
         let key: DataKey = DataKey::EmployeeSalary(agreement_id, employee_index);
         env.storage().persistent().set(&key, &salary);
+        extend_persistent_ttl(env, &key);
     }
 
     /// Get number of claimed periods for an employee at a specific index
@@ -512,6 +549,7 @@ impl DataKey {
     ) {
         let key: DataKey = DataKey::EmployeeClaimedPeriods(agreement_id, employee_index);
         env.storage().persistent().set(&key, &periods);
+        extend_persistent_ttl(env, &key);
     }
 
     /// Get activation timestamp for an agreement
@@ -562,13 +600,18 @@ impl DataKey {
         env.storage().persistent().set(&key, &amount);
     }
 
-    /// Get escrow balance for an agreement and token
+    /// Get escrow balance for an agreement and token.
+    ///
+    /// Bumps the entry's TTL on read so an escrow balance that is referenced but
+    /// not rewritten for a long time does not get archived.
     pub fn get_agreement_escrow_balance(env: &Env, agreement_id: u128, token: &Address) -> i128 {
         let key: DataKey = DataKey::AgreementEscrowBalance(agreement_id, token.clone());
-        env.storage().persistent().get(&key).unwrap_or(0i128)
+        let balance = env.storage().persistent().get(&key).unwrap_or(0i128);
+        extend_persistent_ttl(env, &key);
+        balance
     }
 
-    /// Set escrow balance for an agreement and token
+    /// Set escrow balance for an agreement and token, bumping its TTL.
     pub fn set_agreement_escrow_balance(
         env: &Env,
         agreement_id: u128,
@@ -577,6 +620,7 @@ impl DataKey {
     ) {
         let key: DataKey = DataKey::AgreementEscrowBalance(agreement_id, token.clone());
         env.storage().persistent().set(&key, &amount);
+        extend_persistent_ttl(env, &key);
     }
 
     /// Get the configured FX rate for a `(base, quote)` currency pair, if any.

--- a/onchain/contracts/stello_pay_contract/tests/test_state_machine.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_state_machine.rs
@@ -991,3 +991,126 @@ fn test_full_lifecycle_created_to_finalized() {
         AgreementStatus::Cancelled
     );
 }
+
+// ============================================================================
+// STORAGE TTL (STATE-ARCHIVAL) TESTS (#503)
+// ============================================================================
+
+use soroban_sdk::testutils::storage::Persistent as _;
+use stello_pay_contract::storage::{StorageKey, PERSISTENT_BUMP_AMOUNT, PERSISTENT_TTL_THRESHOLD};
+
+/// Configures a finite ledger TTL window so archival behavior can be exercised
+/// in tests. Production ledgers enforce this; the default test ledger does not.
+fn configure_ttl_window(env: &Env) {
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 1;
+        li.min_persistent_entry_ttl = 1;
+        // Headroom above the bump target so a bump is never clamped below it.
+        li.max_entry_ttl = PERSISTENT_BUMP_AMOUNT + 100_000;
+    });
+}
+
+/// Advances far enough that a freshly-bumped entry's remaining TTL drops just
+/// below `PERSISTENT_TTL_THRESHOLD`, so the next access must re-bump it.
+fn advance_until_near_expiry(env: &Env) {
+    advance_ledgers(env, PERSISTENT_BUMP_AMOUNT - 1_000);
+}
+
+/// Advances the ledger sequence number by `n` ledgers (TTL is measured in ledgers).
+fn advance_ledgers(env: &Env, n: u32) {
+    env.ledger().with_mut(|li| {
+        li.sequence_number += n;
+    });
+}
+
+/// Reading an agreement bumps its persistent TTL back up to the configured
+/// target, so an active-but-infrequently-touched agreement is not archived.
+#[test]
+fn test_get_agreement_bumps_ttl() {
+    let env = create_test_env();
+    configure_ttl_window(&env);
+    let (cid, client) = setup_contract(&env);
+    let employer = create_address(&env);
+    let token = create_address(&env);
+    let employee = create_address(&env);
+
+    let id = client.create_payroll_agreement(&employer, &token, &ONE_WEEK);
+    client.add_employee_to_agreement(&id, &employee, &SALARY);
+    client.activate_agreement(&id);
+
+    // Let almost the whole TTL window elapse so the entry is near expiry.
+    advance_until_near_expiry(&env);
+    env.as_contract(&cid, || {
+        let ttl_before = env
+            .storage()
+            .persistent()
+            .get_ttl(&StorageKey::Agreement(id));
+        assert!(
+            ttl_before < PERSISTENT_TTL_THRESHOLD,
+            "precondition: entry should be near expiry ({} >= {})",
+            ttl_before,
+            PERSISTENT_TTL_THRESHOLD
+        );
+    });
+
+    // Accessing the agreement keeps it live and re-bumps its TTL.
+    let a = client.get_agreement(&id).expect("agreement must still be live");
+    assert_eq!(a.status, AgreementStatus::Active);
+
+    env.as_contract(&cid, || {
+        let ttl = env
+            .storage()
+            .persistent()
+            .get_ttl(&StorageKey::Agreement(id));
+        assert!(
+            ttl >= PERSISTENT_BUMP_AMOUNT - 10,
+            "agreement TTL not bumped: {} < {}",
+            ttl,
+            PERSISTENT_BUMP_AMOUNT
+        );
+    });
+}
+
+/// Writing/reading an escrow balance bumps its TTL, and the entry survives a
+/// ledger advance that would otherwise archive it.
+#[test]
+fn test_escrow_balance_ttl_survives_ledger_advance() {
+    let env = create_test_env();
+    configure_ttl_window(&env);
+    let (cid, client) = setup_contract(&env);
+    let employer = create_address(&env);
+    let contributor = create_address(&env);
+    let token = create_token(&env);
+    let total = SALARY * 4;
+
+    let id =
+        client.create_escrow_agreement(&employer, &contributor, &token, &SALARY, &ONE_DAY, &4u32);
+    client.activate_agreement(&id);
+
+    mint(&env, &token, &cid, total);
+    env.as_contract(&cid, || {
+        DataKey::set_agreement_escrow_balance(&env, id, &token, total);
+        let ttl = env.storage().persistent().get_ttl(
+            &DataKey::AgreementEscrowBalance(id, token.clone()),
+        );
+        assert!(ttl >= PERSISTENT_BUMP_AMOUNT, "escrow TTL not bumped on write");
+    });
+
+    // Advance until near expiry, then access through the read helper.
+    advance_until_near_expiry(&env);
+    let balance = env.as_contract(&cid, || {
+        DataKey::get_agreement_escrow_balance(&env, id, &token)
+    });
+    assert_eq!(balance, total, "escrow balance must remain live and correct");
+
+    // The read bumped the TTL back up.
+    env.as_contract(&cid, || {
+        let ttl = env.storage().persistent().get_ttl(
+            &DataKey::AgreementEscrowBalance(id, token.clone()),
+        );
+        assert!(
+            ttl >= PERSISTENT_BUMP_AMOUNT - 10,
+            "escrow TTL not bumped on read"
+        );
+    });
+}


### PR DESCRIPTION
Persistent payroll keys (agreements, escrow balances, employee salary/claimed-period records) were never TTL-bumped, so under Soroban's state-archival model active-but-infrequently-accessed entries could be archived mid-lifecycle and break later claims.

Changes:
- Centralized TTL constants in `storage.rs`: `PERSISTENT_TTL_THRESHOLD` (~30d) and `PERSISTENT_BUMP_AMOUNT` (~90d), plus an `extend_persistent_ttl` helper (no-op when key absent).
- Applied bumps on read/write of long-lived keys: `get_agreement` and `get/set_agreement_escrow_balance` (read+write), and `set_employee_salary` / `set_employee_claimed_periods` (write).
- Anti-griefing: bumps only extend keys the contract already owns/writes and the caller pays the rent, so they cannot keep adversarial entries alive cheaply.
- Documented the archival/TTL strategy in docs/storage-optimization-summary.md.

Tests (test_state_machine.rs): configure a finite TTL window, advance the ledger near expiry, and assert agreement and escrow entries remain live and are re-bumped to the target TTL. All 37 state-machine tests pass.

Closes #503