### PR TITLE
fix: enforce CEI ordering and add reentrancy guard in payroll claim paths

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -828,7 +828,12 @@ impl PayrollContract {
     /// - Requires `caller` to be the employee at `employee_index` (`Unauthorized` otherwise).
     /// - Rejects claims when the contract is emergency-paused or the agreement is paused.
     /// - Large payments above `LargePaymentThreshold` require `claim_payroll_multisig`.
-    /// - Updates escrow balance and claimed-period counters before token transfer (CEI).
+    /// - Enforces checks-effects-interactions: escrow balance, `claimed_periods`,
+    ///   and `paid_amount` are persisted BEFORE the external token transfer.
+    /// - Protected by a transient reentrancy guard (temporary storage, cleared per
+    ///   transaction). A reentrant call during transfer fails with
+    ///   `PayrollError::ReentrancyDetected`, preventing double-payment of a period
+    ///   via a hostile or hook-enabled token.
     ///
     /// # Gas
     /// Benchmarked at 1, 10, and 50 elapsed payroll periods. See `docs/gas-benchmarks.md`.

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -153,6 +153,35 @@ fn enforce_rate_limit(env: &Env, caller: &Address) -> Result<(), PayrollError> {
 /// Fixed-point scaling factor for FX rates: 1e6 precision.
 const FX_SCALE: i128 = 1_000_000;
 
+/// Acquires the transient reentrancy guard, returning [`PayrollError::ReentrancyDetected`]
+/// if a guarded claim path is already in progress within this transaction.
+///
+/// The guard lives in **temporary** storage so it is cleared automatically at
+/// the end of the transaction; a panic mid-transfer therefore cannot strand it.
+/// Callers must pair a successful acquire with [`release_reentrancy_guard`] on
+/// every (non-panicking) return path.
+fn acquire_reentrancy_guard(env: &Env) -> Result<(), PayrollError> {
+    if env
+        .storage()
+        .temporary()
+        .get::<_, bool>(&StorageKey::ReentrancyGuard)
+        .unwrap_or(false)
+    {
+        return Err(PayrollError::ReentrancyDetected);
+    }
+    env.storage()
+        .temporary()
+        .set(&StorageKey::ReentrancyGuard, &true);
+    Ok(())
+}
+
+/// Releases the transient reentrancy guard set by [`acquire_reentrancy_guard`].
+fn release_reentrancy_guard(env: &Env) {
+    env.storage()
+        .temporary()
+        .remove(&StorageKey::ReentrancyGuard);
+}
+
 pub fn create_milestone_agreement(
     env: Env,
     employer: Address,
@@ -1984,6 +2013,21 @@ pub fn claim_payroll(
     agreement_id: u128,
     employee_index: u32,
 ) -> Result<(), PayrollError> {
+    // Guard the entire claim against cross-contract reentrancy (e.g. a hostile
+    // token re-entering during `transfer`). The guard is released on every
+    // return path; a panic clears it automatically via temporary storage.
+    acquire_reentrancy_guard(env)?;
+    let result = claim_payroll_inner(env, caller, agreement_id, employee_index);
+    release_reentrancy_guard(env);
+    result
+}
+
+fn claim_payroll_inner(
+    env: &Env,
+    caller: &Address,
+    agreement_id: u128,
+    employee_index: u32,
+) -> Result<(), PayrollError> {
     enforce_rate_limit(env, caller)?;
 
     // Check emergency pause
@@ -2109,7 +2153,25 @@ pub fn claim_payroll(
     // Get contract address (this contract)
     let contract_address = env.current_contract_address();
 
-    // Transfer tokens from escrow to employee.
+    // === EFFECTS BEFORE INTERACTION (checks-effects-interactions) ===
+    // Persist the new escrow balance, claimed periods, and paid amount BEFORE
+    // the external token transfer, so a malicious or hook-enabled token cannot
+    // re-enter and observe stale state to double-claim a period. The transient
+    // reentrancy guard (acquired by the caller) is the primary defense; this
+    // ordering is defense-in-depth.
+    let new_escrow_balance = escrow_balance - amount;
+    DataKey::set_agreement_escrow_balance(env, agreement_id, &token, new_escrow_balance);
+
+    let new_claimed_periods = claimed_periods + periods_to_pay;
+    DataKey::set_employee_claimed_periods(env, agreement_id, employee_index, new_claimed_periods);
+
+    let current_paid = DataKey::get_agreement_paid_amount(env, agreement_id);
+    let new_paid = current_paid
+        .checked_add(amount)
+        .ok_or(PayrollError::InvalidData)?;
+    DataKey::set_agreement_paid_amount(env, agreement_id, new_paid);
+
+    // === INTERACTION: transfer tokens from escrow to employee ===
     //
     // IMPORTANT: Token `transfer(from=contract_address, ...)` requires `from.require_auth()`.
     // When the token contract calls `require_auth()` on a contract address, the calling
@@ -2134,21 +2196,6 @@ pub fn claim_payroll(
         })],
     ));
     token_client.transfer(&contract_address, &employee, &amount);
-
-    // Update escrow balance
-    let new_escrow_balance = escrow_balance - amount;
-    DataKey::set_agreement_escrow_balance(env, agreement_id, &token, new_escrow_balance);
-
-    // Update employee's claimed periods
-    let new_claimed_periods = claimed_periods + periods_to_pay;
-    DataKey::set_employee_claimed_periods(env, agreement_id, employee_index, new_claimed_periods);
-
-    // Update agreement total paid amount
-    let current_paid = DataKey::get_agreement_paid_amount(env, agreement_id);
-    let new_paid = current_paid
-        .checked_add(amount)
-        .ok_or(PayrollError::InvalidData)?;
-    DataKey::set_agreement_paid_amount(env, agreement_id, new_paid);
 
     // Emit events
     emit_payroll_claimed(
@@ -2253,6 +2300,21 @@ pub fn claim_payroll_in_token(
     employee_index: u32,
     payout_token: Address,
 ) -> Result<(), PayrollError> {
+    // Reentrancy guard mirrors `claim_payroll`; released on every return path.
+    acquire_reentrancy_guard(env)?;
+    let result =
+        claim_payroll_in_token_inner(env, caller, agreement_id, employee_index, payout_token);
+    release_reentrancy_guard(env);
+    result
+}
+
+fn claim_payroll_in_token_inner(
+    env: &Env,
+    caller: &Address,
+    agreement_id: u128,
+    employee_index: u32,
+    payout_token: Address,
+) -> Result<(), PayrollError> {
     enforce_rate_limit(env, caller)?;
 
     // Validate employee index
@@ -2309,8 +2371,10 @@ pub fn claim_payroll_in_token(
         DataKey::get_agreement_token(env, agreement_id).ok_or(PayrollError::AgreementNotFound)?;
 
     // Shortcut to the single-currency path if payout token == base token.
+    // Call the inner (unguarded) variant because the guard is already held by
+    // this function's wrapper; re-acquiring would self-trip the guard.
     if payout_token == base_token {
-        return claim_payroll(env, caller, agreement_id, employee_index);
+        return claim_payroll_inner(env, caller, agreement_id, employee_index);
     }
 
     // Get current timestamp
@@ -2358,7 +2422,22 @@ pub fn claim_payroll_in_token(
     // Get contract address (this contract)
     let contract_address = env.current_contract_address();
 
-    // Transfer tokens from escrow to employee in payout currency.
+    // === EFFECTS BEFORE INTERACTION (checks-effects-interactions) ===
+    // Persist payout-currency escrow, claimed periods, and base-currency paid
+    // amount BEFORE the external transfer (defense-in-depth alongside the guard).
+    let new_escrow_payout = escrow_balance_payout - amount_payout;
+    DataKey::set_agreement_escrow_balance(env, agreement_id, &payout_token, new_escrow_payout);
+
+    let new_claimed_periods = claimed_periods + periods_to_pay;
+    DataKey::set_employee_claimed_periods(env, agreement_id, employee_index, new_claimed_periods);
+
+    let current_paid = DataKey::get_agreement_paid_amount(env, agreement_id);
+    let new_paid = current_paid
+        .checked_add(amount_base)
+        .ok_or(PayrollError::InvalidData)?;
+    DataKey::set_agreement_paid_amount(env, agreement_id, new_paid);
+
+    // === INTERACTION: transfer tokens from escrow to employee in payout currency ===
     //
     // Token `transfer(from=contract_address, ...)` requires `from.require_auth()`.
     // We pre-authorize via `authorize_as_current_contract` as in the base path.
@@ -2382,21 +2461,6 @@ pub fn claim_payroll_in_token(
         })],
     ));
     token_client.transfer(&contract_address, &employee, &amount_payout);
-
-    // Update escrow balance for payout currency
-    let new_escrow_payout = escrow_balance_payout - amount_payout;
-    DataKey::set_agreement_escrow_balance(env, agreement_id, &payout_token, new_escrow_payout);
-
-    // Update employee's claimed periods
-    let new_claimed_periods = claimed_periods + periods_to_pay;
-    DataKey::set_employee_claimed_periods(env, agreement_id, employee_index, new_claimed_periods);
-
-    // Update agreement total paid amount in base currency
-    let current_paid = DataKey::get_agreement_paid_amount(env, agreement_id);
-    let new_paid = current_paid
-        .checked_add(amount_base)
-        .ok_or(PayrollError::InvalidData)?;
-    DataKey::set_agreement_paid_amount(env, agreement_id, new_paid);
 
     // Emit events: `PayrollClaimed` remains in base currency units, while the
     // payment events reflect the actual payout asset and amount.
@@ -2468,6 +2532,20 @@ pub fn claim_payroll_in_token(
 /// * Token client constructed once and reused.
 /// * Completion / status updates are batched where possible.
 pub fn batch_claim_payroll(
+    env: &Env,
+    caller: &Address,
+    agreement_id: u128,
+    employee_indices: Vec<u32>,
+) -> Result<BatchPayrollResult, PayrollError> {
+    // Reentrancy guard covers the whole batch (each per-employee transfer is a
+    // potential reentry point); released on every return path.
+    acquire_reentrancy_guard(env)?;
+    let result = batch_claim_payroll_inner(env, caller, agreement_id, employee_indices);
+    release_reentrancy_guard(env);
+    result
+}
+
+fn batch_claim_payroll_inner(
     env: &Env,
     caller: &Address,
     agreement_id: u128,
@@ -2657,6 +2735,28 @@ pub fn batch_claim_payroll(
             continue;
         }
 
+        // === EFFECTS BEFORE INTERACTION (checks-effects-interactions) ===
+        // Decrement the in-memory escrow and persist per-employee claimed
+        // periods and the agreement paid amount BEFORE the external transfer,
+        // so a hostile token cannot re-enter and observe stale per-employee
+        // state. The transaction-level reentrancy guard is the primary defense.
+        escrow_balance -= amount;
+        total_claimed += amount;
+        successful_claims += 1;
+
+        DataKey::set_employee_claimed_periods(
+            env,
+            agreement_id,
+            employee_index,
+            claimed_periods + periods_to_pay,
+        );
+
+        let new_paid = DataKey::get_agreement_paid_amount(env, agreement_id)
+            .checked_add(amount)
+            .unwrap_or(DataKey::get_agreement_paid_amount(env, agreement_id));
+        DataKey::set_agreement_paid_amount(env, agreement_id, new_paid);
+
+        // === INTERACTION: transfer tokens from escrow to employee ===
         env.authorize_as_current_contract(Vec::from_array(
             env,
             [InvokerContractAuthEntry::Contract(SubContractInvocation {
@@ -2676,24 +2776,6 @@ pub fn batch_claim_payroll(
             })],
         ));
         token_client.transfer(&contract_address, &employee, &amount);
-
-        // Update in-memory balance
-        escrow_balance -= amount;
-        total_claimed += amount;
-        successful_claims += 1;
-
-        // Persist per-employee state
-        DataKey::set_employee_claimed_periods(
-            env,
-            agreement_id,
-            employee_index,
-            claimed_periods + periods_to_pay,
-        );
-
-        let new_paid = DataKey::get_agreement_paid_amount(env, agreement_id)
-            .checked_add(amount)
-            .unwrap_or(DataKey::get_agreement_paid_amount(env, agreement_id));
-        DataKey::set_agreement_paid_amount(env, agreement_id, new_paid);
 
         // Events — identical to claim_payroll
         emit_payroll_claimed(

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -205,6 +205,10 @@ pub enum StorageKey {
     RateLimiterContract,
     /// Optional salary adjustment contract address for dynamic salary overrides.
     SalaryAdjustmentContract,
+    /// Transient reentrancy guard for the claim paths. Stored in temporary
+    /// storage so it is automatically cleared at the end of each transaction;
+    /// a panic mid-transfer therefore cannot strand the guard.
+    ReentrancyGuard,
 }
 
 #[contracttype]
@@ -374,6 +378,10 @@ pub enum PayrollError {
     MilestoneNotApproved = 40,
     /// Milestone has already been claimed.
     MilestoneAlreadyClaimed = 41,
+    /// A reentrant call into a guarded claim path was detected. The transient
+    /// reentrancy guard was already set, indicating an in-progress claim
+    /// re-entered (e.g. via a hostile or hook-enabled token during transfer).
+    ReentrancyDetected = 42,
 }
 
 /// Caps for how much a cancelled agreement's grace/dispute window may be extended on-chain.

--- a/onchain/contracts/stello_pay_contract/tests/test_reentrancy.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_reentrancy.rs
@@ -8,7 +8,7 @@
 
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env};
-use stello_pay_contract::storage::DataKey;
+use stello_pay_contract::storage::{DataKey, PayrollError, StorageKey};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
 const ONE_DAY: u64 = 86400;
@@ -101,6 +101,109 @@ fn test_claim_payroll_state_updated_prevents_double_claim() {
         res2.is_err() || res2.as_ref().ok().and_then(|r| r.as_ref().err()).is_some(),
         "second claim must fail (no periods to claim)"
     );
+}
+
+/// Verifies that the transient reentrancy guard rejects a claim while a claim
+/// is already in progress. We simulate the in-progress state by setting the
+/// guard in temporary storage (exactly what `acquire_reentrancy_guard` does at
+/// the top of a claim), then assert the entry point fails deterministically
+/// with `ReentrancyDetected` and that no state changes.
+#[test]
+fn test_reentrant_claim_payroll_rejected() {
+    let env = create_env();
+    let (contract_id, client) = setup_contract(&env);
+    let employer = create_address(&env);
+    let token = create_token(&env);
+    let employee = create_address(&env);
+    let salary = 1000i128;
+    let grace = 604800u64;
+
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &grace);
+    client.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    client.activate_agreement(&agreement_id);
+
+    fund_agreement_escrow(&env, &contract_id, agreement_id, &token, 10000);
+    mint(&env, &token, &contract_id, 10000);
+
+    env.as_contract(&contract_id, || {
+        DataKey::set_agreement_activation_time(&env, agreement_id, env.ledger().timestamp());
+        DataKey::set_agreement_period_duration(&env, agreement_id, ONE_DAY);
+        DataKey::set_agreement_token(&env, agreement_id, &token);
+        DataKey::set_employee(&env, agreement_id, 0, &employee);
+        DataKey::set_employee_salary(&env, agreement_id, 0, salary);
+        DataKey::set_employee_claimed_periods(&env, agreement_id, 0, 0);
+        DataKey::set_employee_count(&env, agreement_id, 1);
+        // Simulate an in-progress claim by pre-setting the transient guard.
+        env.storage()
+            .temporary()
+            .set(&StorageKey::ReentrancyGuard, &true);
+    });
+
+    advance_time(&env, ONE_DAY + 1);
+
+    let res = client.try_claim_payroll(&employee, &agreement_id, &0);
+    assert_eq!(
+        res,
+        Err(Ok(PayrollError::ReentrancyDetected)),
+        "reentrant claim must be rejected"
+    );
+
+    // No state changed: no period was claimed and escrow is untouched.
+    assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0), 0);
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            DataKey::get_agreement_escrow_balance(&env, agreement_id, &token),
+            10000
+        );
+    });
+}
+
+/// Verifies that the guard is released after a successful claim, so a later
+/// legitimate claim (after time advances) is not blocked by a stranded guard.
+#[test]
+fn test_guard_released_allows_subsequent_claim() {
+    let env = create_env();
+    let (contract_id, client) = setup_contract(&env);
+    let employer = create_address(&env);
+    let token = create_token(&env);
+    let employee = create_address(&env);
+    let salary = 1000i128;
+    let grace = 604800u64;
+
+    let agreement_id = client.create_payroll_agreement(&employer, &token, &grace);
+    client.add_employee_to_agreement(&agreement_id, &employee, &salary);
+    client.activate_agreement(&agreement_id);
+
+    fund_agreement_escrow(&env, &contract_id, agreement_id, &token, 10000);
+    mint(&env, &token, &contract_id, 10000);
+
+    env.as_contract(&contract_id, || {
+        DataKey::set_agreement_activation_time(&env, agreement_id, env.ledger().timestamp());
+        DataKey::set_agreement_period_duration(&env, agreement_id, ONE_DAY);
+        DataKey::set_agreement_token(&env, agreement_id, &token);
+        DataKey::set_employee(&env, agreement_id, 0, &employee);
+        DataKey::set_employee_salary(&env, agreement_id, 0, salary);
+        DataKey::set_employee_claimed_periods(&env, agreement_id, 0, 0);
+        DataKey::set_employee_count(&env, agreement_id, 1);
+    });
+
+    advance_time(&env, ONE_DAY + 1);
+    assert!(client.try_claim_payroll(&employee, &agreement_id, &0).is_ok());
+    assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0), 1);
+
+    // Escrow was decremented (effect persisted), confirming a real claim ran.
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            DataKey::get_agreement_escrow_balance(&env, agreement_id, &token),
+            9000
+        );
+    });
+
+    // After another period elapses, a second claim succeeds — proving the guard
+    // was cleared and not stranded by the first claim.
+    advance_time(&env, ONE_DAY + 1);
+    assert!(client.try_claim_payroll(&employee, &agreement_id, &0).is_ok());
+    assert_eq!(client.get_employee_claimed_periods(&agreement_id, &0), 2);
 }
 
 /// Verifies that after claim_time_based, claimed periods are updated so


### PR DESCRIPTION
`claim_payroll` transferred tokens BEFORE decrementing escrow / incrementing `claimed_periods`, violating checks-effects-interactions and allowing a hostile or hook-enabled token to re-enter and double-pay a period. `claim_payroll_in_token` and the `batch_claim_payroll` loop had the same shape.

Changes:
- Reordered all three claim paths to persist escrow balance, `claimed_periods`, and `paid_amount` (and the in-memory batch escrow) BEFORE the external `token_client.transfer`.
- Added a transient reentrancy guard in **temporary** storage (`StorageKey::ReentrancyGuard`), acquired at entry and released on every return path of `claim_payroll`, `claim_payroll_in_token`, and `batch_claim_payroll` via inner-fn wrappers. Temporary storage clears per-transaction, so a panic mid-transfer cannot strand the guard.
- New `PayrollError::ReentrancyDetected` (appended, discriminant 42).
- The `claim_payroll_in_token` base-token shortcut calls the inner (unguarded) variant to avoid self-tripping the guard. `authorize_as_current_contract` scoping is unchanged.
- Events still fire with correct final amounts.

Tests (test_reentrancy.rs): a claim with the guard already held fails with `ReentrancyDetected` and changes no state; a normal claim succeeds, persists effects, and a later claim succeeds (guard not stranded). Regressions pass: test_payment_failures (39), test_concurrent_operations (12), test_payroll_claims, test_time_based_claims, test_multisig_integration, test_multi_currency, test_batch_creation.

Closes #469