### PR TITLE
fix: conserve funds and validate real escrow balance in resolve_dispute_core

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ The on-chain workspace uses GitHub Actions to build and test Soroban contracts o
 
 This repository contains smart contract code. Review migrations, upgrades, and deployment steps carefully before using any live network or production asset. Keep private keys, RPC credentials, wallet secrets, and production database or ledger data out of commits, issue comments, and logs.
 
+### Dispute payout conservation
+
+`resolve_dispute` / `resolve_dispute_multisig` (in `onchain/contracts/stello_pay_contract`) conserve funds deterministically:
+
+- `pay_employee` is split equally across employees; the integer-division remainder (dust) is added to the **last** employee so the employee transfers sum to `pay_employee` exactly and no tokens are stranded.
+- `pay_employee` and `refund_employer` must be non-negative, and their sum must not exceed the agreement's `total_amount` nor (when tracked) its real per-agreement escrow balance; the escrow balance is decremented by the distributed total after transfers. Out-of-range or negative payouts return `PayrollError::InvalidPayout`.
+
 For upgrade and migration planning, start with [Migrations](docs/migrations.md) and [Upgrade and migration strategy](docs/upgrade-migration-strategy.md).
 
 ## License

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1663,6 +1663,17 @@ pub fn raise_dispute(env: &Env, caller: Address, agreement_id: u128) -> Result<(
 /// * `pay_employee` - Total amount to distribute equally across employees (payroll) or to contributor (escrow)
 /// * `refund_employer` - Amount to refund the employer
 ///
+/// # Conservation of funds
+/// The payout is deterministic and conserves funds. `pay_employee` is divided
+/// equally across employees using integer division; the integer-division
+/// **remainder (dust)** is added to the **last** employee's transfer so that the
+/// sum of all employee transfers equals `pay_employee` exactly and no tokens are
+/// stranded in the contract. Both `pay_employee` and `refund_employer` must be
+/// non-negative, and `pay_employee + refund_employer` must not exceed either the
+/// agreement's `total_amount` or its **real escrow balance** for the agreement's
+/// token; the per-agreement escrow balance is decremented by the distributed
+/// total after the transfers succeed.
+///
 /// # Access Control
 /// Requires arbiter authentication
 pub fn resolve_dispute(
@@ -1751,8 +1762,32 @@ fn resolve_dispute_core(
         return Err(PayrollError::NoDispute);
     }
 
+    // Reject negative payouts (griefing / accounting corruption).
+    if pay_employee < 0 || refund_employer < 0 {
+        return Err(PayrollError::InvalidPayout);
+    }
+
+    let total_payout = pay_employee
+        .checked_add(refund_employer)
+        .ok_or(PayrollError::InvalidPayout)?;
+
+    // Validate against the agreement's nominal total AND, when a real
+    // per-agreement escrow balance is tracked, against that balance too.
+    // Validating only against `total_amount` could desync internal accounting
+    // from actual token balances and over-distribute across disputes.
+    //
+    // `escrow_balance == 0` is treated as "untracked" (e.g. legacy agreements
+    // whose escrow was never recorded via `set_agreement_escrow_balance`); for
+    // those we fall back to the `total_amount` bound and do not decrement, to
+    // avoid driving a never-tracked balance negative.
     let total_locked = agreement.total_amount;
-    if pay_employee + refund_employer > total_locked {
+    if total_payout > total_locked {
+        return Err(PayrollError::InvalidPayout);
+    }
+    let escrow_balance =
+        DataKey::get_agreement_escrow_balance(env, agreement_id, &agreement.token);
+    let escrow_tracked = escrow_balance > 0;
+    if escrow_tracked && total_payout > escrow_balance {
         return Err(PayrollError::InvalidPayout);
     }
 
@@ -1764,19 +1799,36 @@ fn resolve_dispute_core(
         .get(&StorageKey::AgreementEmployees(agreement_id))
         .unwrap_or(Vec::new(env));
 
-    // Execute transfers
+    // Track what is actually transferred out so the escrow balance can be
+    // decremented by the exact distributed total (conservation of funds).
+    let mut distributed: i128 = 0;
+
+    // Execute transfers. The integer-division remainder (dust) is allocated
+    // deterministically to the LAST employee so the employee transfers sum to
+    // `pay_employee` exactly and nothing is stranded.
     if pay_employee > 0 {
         let num_employees = employees.len() as i128;
         if num_employees > 0 {
             let amount_per_employee = pay_employee / num_employees;
-            for employee in employees.iter() {
-                token.transfer(
-                    &env.current_contract_address(),
-                    &employee.address,
-                    &amount_per_employee,
-                );
+            let dust = pay_employee - amount_per_employee * num_employees;
+            let last_index = employees.len() - 1;
+            for (i, employee) in employees.iter().enumerate() {
+                let mut amount = amount_per_employee;
+                if i as u32 == last_index {
+                    amount += dust;
+                }
+                if amount > 0 {
+                    token.transfer(
+                        &env.current_contract_address(),
+                        &employee.address,
+                        &amount,
+                    );
+                    distributed += amount;
+                }
             }
         }
+        // If there are no employees, `pay_employee` cannot be distributed and is
+        // left as part of the (unchanged) escrow rather than silently lost.
     }
 
     if refund_employer > 0 {
@@ -1784,6 +1836,19 @@ fn resolve_dispute_core(
             &env.current_contract_address(),
             &agreement.employer,
             &refund_employer,
+        );
+        distributed += refund_employer;
+    }
+
+    // Decrement the per-agreement escrow balance by exactly what was distributed,
+    // keeping internal accounting consistent with real token balances. Skipped
+    // when escrow was never tracked (balance was 0) so it is not driven negative.
+    if escrow_tracked {
+        DataKey::set_agreement_escrow_balance(
+            env,
+            agreement_id,
+            &agreement.token,
+            escrow_balance - distributed,
         );
     }
 

--- a/onchain/contracts/stello_pay_contract/tests/test_disputes.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_disputes.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     testutils::Address as _,
     token, Address, Env,
 };
-use stello_pay_contract::storage::{DisputeStatus, PayrollError};
+use stello_pay_contract::storage::{DataKey, DisputeStatus, PayrollError};
 use stello_pay_contract::{PayrollContract, PayrollContractClient};
 
 /// Helper to set up the main payroll contract
@@ -148,4 +148,110 @@ fn test_multi_employee_payout_split() {
     assert_eq!(token_client.balance(&employee1), 75);
     assert_eq!(token_client.balance(&employee2), 75);
     assert_eq!(token_client.balance(&employer), 50);
+}
+
+/// @notice An indivisible employee payout strands no dust: the remainder is
+/// allocated to the last employee so transfers sum exactly to `pay_employee`.
+#[test]
+fn test_dispute_dust_allocated_to_last_employee() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (payroll_id, payroll_client) = setup_payroll(&env);
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_address, token_client, token_admin_client) = setup_token(&env, &token_admin);
+    let e1 = Address::generate(&env);
+    let e2 = Address::generate(&env);
+    let e3 = Address::generate(&env);
+
+    payroll_client.set_arbiter(&employer, &arbiter);
+    let agreement_id = payroll_client.create_payroll_agreement(&employer, &token_address, &86400);
+    payroll_client.add_employee_to_agreement(&agreement_id, &e1, &100);
+    payroll_client.add_employee_to_agreement(&agreement_id, &e2, &100);
+    payroll_client.add_employee_to_agreement(&agreement_id, &e3, &100);
+    token_admin_client.mint(&payroll_id, &300);
+
+    payroll_client.raise_dispute(&employer, &agreement_id);
+
+    // 100 / 3 = 33 each, remainder 1 -> last employee gets 34.
+    let pay_employee = 100_i128;
+    payroll_client.resolve_dispute(&arbiter, &agreement_id, &pay_employee, &0_i128);
+
+    assert_eq!(token_client.balance(&e1), 33);
+    assert_eq!(token_client.balance(&e2), 33);
+    assert_eq!(token_client.balance(&e3), 34);
+    // Conservation: nothing stranded in the contract from this split.
+    let distributed =
+        token_client.balance(&e1) + token_client.balance(&e2) + token_client.balance(&e3);
+    assert_eq!(distributed, pay_employee);
+    assert_eq!(token_client.balance(&payroll_id), 300 - pay_employee);
+}
+
+/// @notice Negative payout amounts are rejected with `InvalidPayout`.
+#[test]
+fn test_dispute_rejects_negative_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, payroll_client) = setup_payroll(&env);
+    let employer = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    payroll_client.set_arbiter(&employer, &arbiter);
+    let agreement_id =
+        payroll_client.create_escrow_agreement(&employer, &contributor, &token, &1000, &86400, &1);
+    payroll_client.raise_dispute(&employer, &agreement_id);
+
+    let neg_pay = payroll_client.try_resolve_dispute(&arbiter, &agreement_id, &-1_i128, &0_i128);
+    assert_eq!(neg_pay, Err(Ok(PayrollError::InvalidPayout)));
+
+    let neg_refund =
+        payroll_client.try_resolve_dispute(&arbiter, &agreement_id, &0_i128, &-1_i128);
+    assert_eq!(neg_refund, Err(Ok(PayrollError::InvalidPayout)));
+}
+
+/// @notice When a real escrow balance is tracked, a payout that fits within
+/// `total_amount` but exceeds the actual escrow balance is rejected, and a valid
+/// resolution decrements the tracked escrow by exactly the distributed amount.
+#[test]
+fn test_dispute_validates_and_decrements_real_escrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (payroll_id, payroll_client) = setup_payroll(&env);
+    let employer = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_address, _token_client, token_admin_client) = setup_token(&env, &token_admin);
+    let employee = Address::generate(&env);
+
+    payroll_client.set_arbiter(&employer, &arbiter);
+    let agreement_id = payroll_client.create_payroll_agreement(&employer, &token_address, &86400);
+    // total_amount becomes 1000 from the employee salary.
+    payroll_client.add_employee_to_agreement(&agreement_id, &employee, &1000);
+
+    // Real escrow deposited is only 400 (less than total_amount 1000).
+    let deposited = 400_i128;
+    token_admin_client.mint(&payroll_id, &deposited);
+    env.as_contract(&payroll_id, || {
+        DataKey::set_agreement_escrow_balance(&env, agreement_id, &token_address, deposited);
+    });
+
+    payroll_client.raise_dispute(&employer, &agreement_id);
+
+    // 600 <= total_amount (1000) but > real escrow (400): must be rejected.
+    let over = payroll_client.try_resolve_dispute(&arbiter, &agreement_id, &600_i128, &0_i128);
+    assert_eq!(over, Err(Ok(PayrollError::InvalidPayout)));
+
+    // A payout within the escrow succeeds and decrements the tracked balance.
+    payroll_client.resolve_dispute(&arbiter, &agreement_id, &300_i128, &50_i128);
+    let remaining = env.as_contract(&payroll_id, || {
+        DataKey::get_agreement_escrow_balance(&env, agreement_id, &token_address)
+    });
+    // deposited (400) - distributed (350) == 50.
+    assert_eq!(remaining, deposited - 350);
 }


### PR DESCRIPTION
`resolve_dispute_core` (shared by `resolve_dispute` and `resolve_dispute_multisig`) split `pay_employee` with plain integer division, stranding the remainder as dust, validated payouts only against `total_amount` (not the real escrow balance), and never decremented the per-agreement escrow balance.

Changes:
- **Dust allocation**: the integer-division remainder is added to the last employee's transfer, so employee transfers sum to `pay_employee` exactly and nothing is stranded.
- **Real-escrow validation**: `pay_employee + refund_employer` is checked against `total_amount` and, when a per-agreement escrow balance is tracked (> 0), against that balance too. Untracked (legacy, balance 0) agreements fall back to the `total_amount` bound and are not decremented (so a never-tracked balance can't go negative).
- **Escrow decrement**: when tracked, the escrow balance is decremented by exactly the distributed total after transfers, keeping internal accounting in sync with real balances.
- **Negative guard**: `pay_employee < 0` or `refund_employer < 0` now returns `InvalidPayout`; the sum uses checked arithmetic.
- Documented the dust rule and conservation invariant in `///` doc comments and the README.

Both entrypoints are fixed via the shared core. Tests (test_disputes.rs): dust-to-last-employee conservation; over-escrow payout (<= total_amount but > escrow) rejected with `InvalidPayout`; escrow decremented to deposited-minus-distributed; negative-amount rejection. All 7 dispute tests pass; test_dispute_integration (2) and test_multisig_integration (9) pass unchanged.

Closes #470