### PR TITLE
Emit a deprecation event from template_versioning deprecate_version

### DIFF
--- a/onchain/contracts/template_versioning/src/lib.rs
+++ b/onchain/contracts/template_versioning/src/lib.rs
@@ -9,7 +9,8 @@
 //! window so reviewers can enforce that only current schemas are used for new payrolls.
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    String,
 };
 
 /// Persistent storage keys.
@@ -54,6 +55,26 @@ pub struct AgreementBinding {
     pub creator: Address,
     pub label: String,
     pub created_at: u64,
+}
+
+/// Emitted when a template version is deprecated via [`TemplateVersioning::deprecate_version`].
+///
+/// Off-chain indexers should subscribe to this event to detect deprecations
+/// immediately rather than polling the contract state.
+///
+/// # Fields
+/// - `template_id` – Stable identifier of the owning template.
+/// - `version`     – Version number that was deprecated.
+/// - `timestamp`   – Ledger timestamp at the moment of deprecation.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TemplateVersionDeprecated {
+    /// Owning template id.
+    pub template_id: u64,
+    /// The version number that was deprecated.
+    pub version: u32,
+    /// Ledger timestamp at the moment of deprecation.
+    pub timestamp: u64,
 }
 
 #[contracterror]
@@ -163,6 +184,17 @@ impl TemplateVersioning {
         let mut rec: TemplateVersionRecord = storage.get(&key).ok_or(VersioningError::VersionNotFound)?;
         rec.deprecated = true;
         storage.set(&key, &rec);
+
+        let now = env.ledger().timestamp();
+        env.events().publish(
+            (symbol_short!("tmpl_dep"), template_id, version),
+            TemplateVersionDeprecated {
+                template_id,
+                version,
+                timestamp: now,
+            },
+        );
+
         Ok(())
     }
 

--- a/onchain/contracts/template_versioning/tests/test_versioning.rs
+++ b/onchain/contracts/template_versioning/tests/test_versioning.rs
@@ -1,8 +1,11 @@
 use soroban_sdk::{
-    testutils::{Address as _, Ledger, LedgerInfo},
-    Address, BytesN, Env, String,
+    testutils::{Address as _, Events, Ledger, LedgerInfo},
+    Address, BytesN, Env, IntoVal, String, Vec,
 };
-use template_versioning::{AgreementBinding, TemplateVersionRecord, TemplateVersioning, TemplateVersioningClient};
+use template_versioning::{
+    AgreementBinding, TemplateVersionDeprecated, TemplateVersionRecord, TemplateVersioning,
+    TemplateVersioningClient,
+};
 
 fn ledger_ts(env: &Env, ts: u64) {
     env.ledger().set(LedgerInfo {
@@ -162,4 +165,162 @@ fn non_owner_cannot_publish() {
             )
             .is_err()
     );
+}
+
+/// Deprecating a version should emit a `TemplateVersionDeprecated` event
+/// with the correct template id, version, and timestamp.
+#[test]
+fn deprecate_version_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    ledger_ts(&env, 2_000_000);
+
+    let contract_id = env.register(TemplateVersioning, ());
+    let client = TemplateVersioningClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let tid = client
+        .try_register_template(&owner, &String::from_str(&env, "Payroll v1"))
+        .unwrap()
+        .unwrap();
+
+    let hash = BytesN::from_array(&env, &[7u8; 32]);
+    let ver = client
+        .try_publish_template_version(
+            &owner,
+            &tid,
+            &hash,
+            &String::from_str(&env, "initial"),
+            &false,
+        )
+        .unwrap()
+        .unwrap();
+
+    client
+        .try_deprecate_version(&owner, &tid, &ver)
+        .unwrap()
+        .unwrap();
+
+    // Inspect emitted events
+    let all_events = env.events().all();
+    let last = all_events.last().unwrap();
+
+    // Verify event data
+    let emitted: TemplateVersionDeprecated = last.2.into_val(&env);
+    assert_eq!(emitted.template_id, tid);
+    assert_eq!(emitted.version, ver);
+    assert_eq!(emitted.timestamp, 2_000_000u64);
+}
+
+/// Deprecating an already-deprecated version should still emit the event.
+#[test]
+fn deprecate_already_deprecated_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    ledger_ts(&env, 3_000_000);
+
+    let contract_id = env.register(TemplateVersioning, ());
+    let client = TemplateVersioningClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let tid = client
+        .try_register_template(&owner, &String::from_str(&env, "Template"))
+        .unwrap()
+        .unwrap();
+
+    let hash = BytesN::from_array(&env, &[3u8; 32]);
+    let ver = client
+        .try_publish_template_version(
+            &owner,
+            &tid,
+            &hash,
+            &String::from_str(&env, "notes"),
+            &false,
+        )
+        .unwrap()
+        .unwrap();
+
+    // First deprecation
+    client
+        .try_deprecate_version(&owner, &tid, &ver)
+        .unwrap()
+        .unwrap();
+
+    // Second deprecation (idempotent flag flip, event still emitted)
+    client
+        .try_deprecate_version(&owner, &tid, &ver)
+        .unwrap()
+        .unwrap();
+
+    let all_events = env.events().all();
+    // Two deprecation events should have been emitted
+    let count = all_events
+        .iter()
+        .filter(|e| {
+            let data: Result<TemplateVersionDeprecated, _> = e.2.clone().into_val(&env);
+            data.map(|d| d.template_id == tid && d.version == ver)
+                .unwrap_or(false)
+        })
+        .count();
+    assert_eq!(count, 2);
+}
+
+/// Non-owner cannot deprecate, so no event is emitted.
+#[test]
+fn non_owner_cannot_deprecate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    ledger_ts(&env, 1_000_000);
+
+    let contract_id = env.register(TemplateVersioning, ());
+    let client = TemplateVersioningClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let tid = client
+        .try_register_template(&owner, &String::from_str(&env, "T"))
+        .unwrap()
+        .unwrap();
+
+    let hash = BytesN::from_array(&env, &[5u8; 32]);
+    let ver = client
+        .try_publish_template_version(
+            &owner,
+            &tid,
+            &hash,
+            &String::from_str(&env, "v1"),
+            &false,
+        )
+        .unwrap()
+        .unwrap();
+
+    // Attacker attempt should fail
+    assert!(
+        client
+            .try_deprecate_version(&attacker, &tid, &ver)
+            .is_err()
+    );
+
+    // No deprecation event should exist
+    let all_events = env.events().all();
+    let dep_count = all_events
+        .iter()
+        .filter(|e| {
+            let data: Result<TemplateVersionDeprecated, _> = e.2.clone().into_val(&env);
+            data.map(|d| d.template_id == tid).unwrap_or(false)
+        })
+        .count();
+    assert_eq!(dep_count, 0);
 }


### PR DESCRIPTION
Closes #585

## Summary
- Define `TemplateVersionDeprecated` event struct with `template_id`, `version`, and `timestamp` fields
- Emit the event inside `deprecate_version` after the deprecated flag is set, using `symbol_short!("tmpl_dep")` as the topic
- Add 3 new tests: `deprecate_version_emits_event` (happy path), `deprecate_already_deprecated_emits_event` (idempotent edge case), and `non_owner_cannot_deprecate` (auth guard)

🤖 Generated with Claude Code