### PR TITLE
Validate withdrawal OperationKind parameters in withdrawal_timelock queue

### DIFF
--- a/onchain/contracts/withdrawal_timelock/src/lib.rs
+++ b/onchain/contracts/withdrawal_timelock/src/lib.rs
@@ -38,6 +38,13 @@ pub enum TimelockError {
     NotReady = 7,
     /// Operation is no longer in `Queued` status.
     AlreadyExecutedOrCancelled = 8,
+    /// `Withdrawal` amount must be greater than zero.
+    ///
+    /// Queuing a zero-amount withdrawal would create a no-op that still
+    /// consumes a timelock slot and pollutes the audit trail.  Only
+    /// `Withdrawal` amounts are validated; `AdminChange` payloads are
+    /// opaque commitments that the timelock cannot interpret.
+    InvalidWithdrawalAmount = 9,
 }
 
 // ─── Domain Types ─────────────────────────────────────────────────────────────
@@ -301,6 +308,16 @@ impl WithdrawalTimelock {
     ///      receives a unique monotone id. Emits:
     ///        `("timelock_queued", op_id) → kind`
     ///      which off-chain monitors should subscribe to for alerting.
+    ///
+    ///      **Validated fields** (fields this contract can interpret):
+    ///      - `Withdrawal(_, _, amount)`: `amount` must be `> 0`.
+    ///
+    ///      **Opaque fields** (not validated by this contract):
+    ///      - `Withdrawal(token, to, _)`: token and recipient addresses are
+    ///        forwarded verbatim to the external orchestrator.
+    ///      - `AdminChange(target_contract, payload_hash)`: entirely opaque;
+    ///        off-chain tooling is responsible for verifying the hash.
+    ///
     /// @param caller Admin address queuing the operation; must authenticate.
     /// @param kind   `Withdrawal(token, to, amount)` or
     ///               `AdminChange(target_contract, payload_hash)`.
@@ -308,6 +325,15 @@ impl WithdrawalTimelock {
     pub fn queue(env: Env, caller: Address, kind: OperationKind) -> Result<u128, TimelockError> {
         require_initialized(&env)?;
         require_admin(&env, &caller)?;
+
+        // Validate fields the timelock can interpret.  AdminChange carries an
+        // opaque payload_hash; only the external orchestrator can verify it, so
+        // we deliberately leave it unvalidated here.
+        if let OperationKind::Withdrawal(_, _, amount) = &kind {
+            if *amount <= 0 {
+                return Err(TimelockError::InvalidWithdrawalAmount);
+            }
+        }
 
         let min_delay = read_min_delay(&env);
         // Defensive belt-and-suspenders: min_delay can only be 0 if the

--- a/onchain/contracts/withdrawal_timelock/tests/test_timelock.rs
+++ b/onchain/contracts/withdrawal_timelock/tests/test_timelock.rs
@@ -10,6 +10,8 @@ use withdrawal_timelock::{
     WithdrawalTimelockClient, MAX_DELAY_SECONDS,
 };
 
+// ─── Group G: Withdrawal amount validation (issue #586) ──────────────────────
+
 // ─── Shared Test Helpers ──────────────────────────────────────────────────────
 
 /// Creates a clean environment with all auth mocked out.
@@ -762,4 +764,68 @@ fn get_operations_for_invalid_start_returns_empty() {
     let page = client.get_operations_for(&admin, &None, &Some(5), &None);
     assert_eq!(page.operations.len(), 0);
     assert_eq!(page.next_cursor, None);
+}
+
+// ─── Group G: Withdrawal amount validation (issue #586) ──────────────────────
+
+/// Zero-amount withdrawal must be rejected at queue time.
+/// A zero-amount withdrawal is a no-op that would consume a timelock slot
+/// and pollute the audit trail without any actual economic effect.
+#[test]
+fn queue_withdrawal_zero_amount_fails() {
+    let env = create_env();
+    let (client, admin) = setup(&env);
+
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let kind = OperationKind::Withdrawal(token, to, 0i128);
+
+    let res = client.try_queue(&admin, &kind);
+    assert_eq!(res, Err(Ok(TimelockError::InvalidWithdrawalAmount)));
+}
+
+/// Negative-amount withdrawal must also be rejected at queue time.
+#[test]
+fn queue_withdrawal_negative_amount_fails() {
+    let env = create_env();
+    let (client, admin) = setup(&env);
+
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let kind = OperationKind::Withdrawal(token, to, -1i128);
+
+    let res = client.try_queue(&admin, &kind);
+    assert_eq!(res, Err(Ok(TimelockError::InvalidWithdrawalAmount)));
+}
+
+/// A positive-amount withdrawal must succeed and be recorded.
+#[test]
+fn queue_withdrawal_positive_amount_succeeds() {
+    let env = create_env();
+    let (client, admin) = setup(&env);
+
+    let token = Address::generate(&env);
+    let to = Address::generate(&env);
+    let kind = OperationKind::Withdrawal(token, to, 1i128);
+
+    let op_id = client.queue(&admin, &kind);
+    let op: TimelockedOperation = client.get_operation(&op_id).unwrap();
+    assert_eq!(op.status, OperationStatus::Queued);
+}
+
+/// Non-withdrawal kinds (AdminChange) must not be affected by amount validation.
+/// Their opaque payload_hash is outside the timelock's interpretation scope.
+#[test]
+fn queue_admin_change_not_affected_by_withdrawal_validation() {
+    let env = create_env();
+    let (client, admin) = setup(&env);
+
+    let target = Address::generate(&env);
+    let payload: BytesN<32> = BytesN::from_array(&env, &[0u8; 32]);
+    let kind = OperationKind::AdminChange(target, payload);
+
+    // Must succeed regardless of the payload content.
+    let op_id = client.queue(&admin, &kind);
+    let op: TimelockedOperation = client.get_operation(&op_id).unwrap();
+    assert_eq!(op.status, OperationStatus::Queued);
 }


### PR DESCRIPTION
Closes #586

## Summary
- Add `InvalidWithdrawalAmount = 9` typed error with doc comment clarifying validated vs opaque fields
- Reject `Withdrawal(_, _, amount <= 0)` in `queue()` before any storage writes, preventing no-op operations from consuming timelock slots and polluting the audit trail
- Document which `OperationKind` fields are validated (amount) vs opaque (token, recipient, AdminChange payload_hash) in the `queue` doc comment
- Add 4 focused tests: zero-amount rejected, negative-amount rejected, positive-amount accepted, AdminChange unaffected

All 49 tests pass (`cargo test -p withdrawal_timelock`).

🤖 Generated with Claude Code