### PR TITLE
Add pagination to badges_of in nft_payroll_badge to bound memory on high-volume holders

### DIFF
--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -1277,6 +1277,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nft-payroll-badge"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/onchain/contracts/nft_payroll_badge/Cargo.toml
+++ b/onchain/contracts/nft_payroll_badge/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nft-payroll-badge"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }

--- a/onchain/contracts/nft_payroll_badge/src/lib.rs
+++ b/onchain/contracts/nft_payroll_badge/src/lib.rs
@@ -1,0 +1,229 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+
+/// Maximum number of badge IDs returned in a single paginated query.
+/// Clamps any caller-supplied `limit` to prevent memory/instruction exhaustion.
+pub const MAX_PAGE_SIZE: u32 = 50;
+
+#[contract]
+pub struct NftPayrollBadgeContract;
+
+/// Represents a single payroll badge held by an address.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Badge {
+    /// Unique badge identifier.
+    pub id: u64,
+    /// Address that received this badge.
+    pub owner: Address,
+    /// Human-readable badge name (e.g., "Q1 2025 Payroll").
+    pub name: soroban_sdk::String,
+    /// Ledger timestamp at which the badge was minted.
+    pub issued_at: u64,
+}
+
+/// Result returned by [`NftPayrollBadgeContract::badges_of_paged`].
+///
+/// ## Cursor semantics
+/// - `next_cursor` is `Some(n)` when more badges exist after the current page.
+///   Pass that value as `start` in the next call to retrieve the subsequent page.
+/// - `next_cursor` is `None` when the returned page is the final (or only) page.
+/// - Badges are returned in ascending badge-ID order, which is stable and
+///   deterministic across calls as long as no badges are removed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PagedBadges {
+    /// Badge IDs in the current page (length <= MAX_PAGE_SIZE).
+    pub items: Vec<u64>,
+    /// Cursor to pass as `start` for the next page, or `None` if this is the last page.
+    pub next_cursor: Option<u32>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum StorageKey {
+    Initialized,
+    Owner,
+    NextBadgeId,
+    Badge(u64),
+    /// Maps an owner address to the count of badges they hold.
+    OwnerBadgeCount(Address),
+    /// Maps (owner, index) to a badge id — the owner's badge list stored as individual entries.
+    OwnerBadgeAt(Address, u32),
+}
+
+fn require_initialized(env: &Env) {
+    let initialized = env
+        .storage()
+        .persistent()
+        .get::<_, bool>(&StorageKey::Initialized)
+        .unwrap_or(false);
+    assert!(initialized, "Contract not initialized");
+}
+
+fn next_badge_id(env: &Env) -> u64 {
+    let current = env
+        .storage()
+        .persistent()
+        .get::<_, u64>(&StorageKey::NextBadgeId)
+        .unwrap_or(0);
+    let next = current.checked_add(1).expect("Badge id overflow");
+    env.storage()
+        .persistent()
+        .set(&StorageKey::NextBadgeId, &next);
+    next
+}
+
+fn owner_badge_count(env: &Env, owner: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get::<_, u32>(&StorageKey::OwnerBadgeCount(owner.clone()))
+        .unwrap_or(0)
+}
+
+fn append_badge_to_owner(env: &Env, owner: &Address, badge_id: u64) {
+    let count = owner_badge_count(env, owner);
+    env.storage()
+        .persistent()
+        .set(&StorageKey::OwnerBadgeAt(owner.clone(), count), &badge_id);
+    env.storage()
+        .persistent()
+        .set(&StorageKey::OwnerBadgeCount(owner.clone()), &(count + 1));
+}
+
+#[contractimpl]
+impl NftPayrollBadgeContract {
+    /// Initializes the contract and designates an admin owner.
+    pub fn initialize(env: Env, owner: Address) {
+        owner.require_auth();
+        let initialized = env
+            .storage()
+            .persistent()
+            .get::<_, bool>(&StorageKey::Initialized)
+            .unwrap_or(false);
+        assert!(!initialized, "Contract already initialized");
+
+        env.storage().persistent().set(&StorageKey::Owner, &owner);
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Initialized, &true);
+    }
+
+    /// Mints a new payroll badge and assigns it to `recipient`.
+    ///
+    /// Only the contract owner may mint badges.
+    ///
+    /// # Returns
+    /// The newly assigned badge ID.
+    pub fn mint(env: Env, caller: Address, recipient: Address, name: soroban_sdk::String) -> u64 {
+        require_initialized(&env);
+        caller.require_auth();
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::Owner)
+            .expect("Owner not set");
+        assert!(caller == owner, "Only owner can mint badges");
+
+        let badge_id = next_badge_id(&env);
+        let badge = Badge {
+            id: badge_id,
+            owner: recipient.clone(),
+            name,
+            issued_at: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Badge(badge_id), &badge);
+        append_badge_to_owner(&env, &recipient, badge_id);
+
+        badge_id
+    }
+
+    /// Returns ALL badge IDs held by `owner` in a single call.
+    ///
+    /// **Deprecated** — for high-volume holders this may exhaust memory or
+    /// instruction budgets.  Prefer [`badges_of_paged`] for bounded reads.
+    ///
+    /// [`badges_of_paged`]: NftPayrollBadgeContract::badges_of_paged
+    pub fn badges_of(env: Env, owner: Address) -> Vec<u64> {
+        require_initialized(&env);
+        let count = owner_badge_count(&env, &owner);
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for i in 0..count {
+            if let Some(badge_id) = env
+                .storage()
+                .persistent()
+                .get::<_, u64>(&StorageKey::OwnerBadgeAt(owner.clone(), i))
+            {
+                ids.push_back(badge_id);
+            }
+        }
+        ids
+    }
+
+    /// Returns a bounded, paginated slice of badge IDs held by `owner`.
+    ///
+    /// ## Arguments
+    /// - `owner`  – Address whose badges to query.
+    /// - `start`  – Zero-based index into the owner's badge list (cursor from a
+    ///              previous call, or `0` for the first page).
+    /// - `limit`  – Maximum number of items to return.  Values above
+    ///              [`MAX_PAGE_SIZE`] are silently clamped to `MAX_PAGE_SIZE`.
+    ///
+    /// ## Returns
+    /// A [`PagedBadges`] struct containing:
+    /// - `items` — badge IDs for positions `[start, start + effective_limit)`.
+    /// - `next_cursor` — `Some(start + effective_limit)` when more items follow;
+    ///   `None` when the page covers the end of the list.
+    ///
+    /// ## Ordering
+    /// Badges are returned in the order they were minted (ascending badge-ID),
+    /// which is stable and deterministic; cursors never skip or duplicate entries.
+    pub fn badges_of_paged(env: Env, owner: Address, start: u32, limit: u32) -> PagedBadges {
+        require_initialized(&env);
+        let effective_limit = if limit == 0 || limit > MAX_PAGE_SIZE {
+            MAX_PAGE_SIZE
+        } else {
+            limit
+        };
+
+        let count = owner_badge_count(&env, &owner);
+        let mut items: Vec<u64> = Vec::new(&env);
+
+        let end = start.saturating_add(effective_limit).min(count);
+        for i in start..end {
+            if let Some(badge_id) = env
+                .storage()
+                .persistent()
+                .get::<_, u64>(&StorageKey::OwnerBadgeAt(owner.clone(), i))
+            {
+                items.push_back(badge_id);
+            }
+        }
+
+        let next_cursor = if end < count { Some(end) } else { None };
+
+        PagedBadges { items, next_cursor }
+    }
+
+    /// Returns the badge metadata for a given `badge_id`, or `None` if not found.
+    pub fn get_badge(env: Env, badge_id: u64) -> Option<Badge> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::Badge(badge_id))
+    }
+
+    /// Returns the total number of badges held by `owner`.
+    pub fn badge_count(env: Env, owner: Address) -> u32 {
+        require_initialized(&env);
+        owner_badge_count(&env, &owner)
+    }
+
+    /// Returns the contract owner address.
+    pub fn get_owner(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&StorageKey::Owner)
+    }
+}

--- a/onchain/contracts/nft_payroll_badge/tests/test_badge.rs
+++ b/onchain/contracts/nft_payroll_badge/tests/test_badge.rs
@@ -1,0 +1,270 @@
+//! Comprehensive test suite for nft_payroll_badge contract.
+//!
+//! Covers: initialization, minting, `badges_of`, `badges_of_paged` (empty,
+//! single page, multi-page, exact-multiple-of-limit, oversized-limit clamping).
+
+#![cfg(test)]
+
+use nft_payroll_badge::{NftPayrollBadgeContract, NftPayrollBadgeContractClient, MAX_PAGE_SIZE};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn create_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn setup(env: &Env) -> (Address, NftPayrollBadgeContractClient<'static>) {
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, NftPayrollBadgeContract);
+    let client = NftPayrollBadgeContractClient::new(env, &contract_id);
+    let owner = Address::generate(env);
+    client.initialize(&owner);
+    (owner, client)
+}
+
+fn mint_n(env: &Env, client: &NftPayrollBadgeContractClient, owner: &Address, recipient: &Address, n: u32) {
+    for _ in 0..n {
+        let name = String::from_str(env, "Payroll Badge");
+        client.mint(owner, recipient, &name);
+    }
+}
+
+// ============================================================================
+// Initialization tests
+// ============================================================================
+
+#[test]
+fn test_initialize_sets_owner() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    assert_eq!(client.get_owner(), Some(owner));
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_double_initialize_panics() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    client.initialize(&owner);
+}
+
+// ============================================================================
+// Minting tests
+// ============================================================================
+
+#[test]
+fn test_mint_assigns_sequential_ids() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+
+    let id1 = client.mint(&owner, &recipient, &String::from_str(&env, "First"));
+    let id2 = client.mint(&owner, &recipient, &String::from_str(&env, "Second"));
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn test_mint_records_badge_metadata() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    let name = String::from_str(&env, "Q1 2025 Payroll");
+
+    let id = client.mint(&owner, &recipient, &name);
+    let badge = client.get_badge(&id).expect("badge should exist");
+
+    assert_eq!(badge.id, id);
+    assert_eq!(badge.owner, recipient);
+    assert_eq!(badge.name, name);
+}
+
+#[test]
+#[should_panic(expected = "Only owner can mint badges")]
+fn test_non_owner_cannot_mint() {
+    let env = create_env();
+    let (_owner, client) = setup(&env);
+    let attacker = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.mint(&attacker, &recipient, &String::from_str(&env, "Fake"));
+}
+
+// ============================================================================
+// badges_of tests
+// ============================================================================
+
+#[test]
+fn test_badges_of_empty_owner() {
+    let env = create_env();
+    let (_owner, client) = setup(&env);
+    let stranger = Address::generate(&env);
+    let result = client.badges_of(&stranger);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn test_badges_of_returns_all() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 5);
+
+    let ids = client.badges_of(&recipient);
+    assert_eq!(ids.len(), 5);
+    // IDs should be 1..=5 in order
+    for (i, id) in ids.iter().enumerate() {
+        assert_eq!(id, (i as u64) + 1);
+    }
+}
+
+// ============================================================================
+// badges_of_paged edge-case tests
+// ============================================================================
+
+#[test]
+fn test_paged_empty_owner_returns_empty_page() {
+    let env = create_env();
+    let (_owner, client) = setup(&env);
+    let stranger = Address::generate(&env);
+
+    let page = client.badges_of_paged(&stranger, &0, &10);
+    assert_eq!(page.items.len(), 0);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_paged_single_page_no_cursor() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 3);
+
+    let page = client.badges_of_paged(&recipient, &0, &10);
+    assert_eq!(page.items.len(), 3);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_paged_first_page_has_cursor() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 5);
+
+    let page = client.badges_of_paged(&recipient, &0, &3);
+    assert_eq!(page.items.len(), 3);
+    assert_eq!(page.next_cursor, Some(3));
+}
+
+#[test]
+fn test_paged_second_page_no_cursor() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 5);
+
+    let page = client.badges_of_paged(&recipient, &3, &3);
+    assert_eq!(page.items.len(), 2); // only 2 remain
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_paged_exact_multiple_of_limit() {
+    // 6 badges, page size 3 → page 0 has cursor=3; page 1 has cursor=None
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 6);
+
+    let page0 = client.badges_of_paged(&recipient, &0, &3);
+    assert_eq!(page0.items.len(), 3);
+    assert_eq!(page0.next_cursor, Some(3));
+
+    let page1 = client.badges_of_paged(&recipient, &3, &3);
+    assert_eq!(page1.items.len(), 3);
+    assert_eq!(page1.next_cursor, None);
+}
+
+#[test]
+fn test_paged_oversized_limit_clamped_to_max() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    // Mint fewer than MAX_PAGE_SIZE badges so the result is all of them
+    mint_n(&env, &client, &owner, &recipient, 10);
+
+    // Pass a limit larger than MAX_PAGE_SIZE
+    let huge_limit = MAX_PAGE_SIZE + 100;
+    let page = client.badges_of_paged(&recipient, &0, &huge_limit);
+    assert_eq!(page.items.len(), 10);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_paged_zero_limit_clamped_to_max() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 5);
+
+    let page = client.badges_of_paged(&recipient, &0, &0);
+    // 0 is clamped to MAX_PAGE_SIZE; 5 < MAX_PAGE_SIZE so all returned
+    assert_eq!(page.items.len(), 5);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn test_paged_cursor_ordering_is_stable() {
+    // Walk all pages and reconstruct the full list; compare with badges_of.
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 11);
+
+    let mut all_ids: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+    let mut cursor: u32 = 0;
+    loop {
+        let page = client.badges_of_paged(&recipient, &cursor, &4);
+        for id in page.items.iter() {
+            all_ids.push_back(id);
+        }
+        match page.next_cursor {
+            Some(next) => cursor = next,
+            None => break,
+        }
+    }
+
+    let expected = client.badges_of(&recipient);
+    assert_eq!(all_ids.len(), expected.len());
+    for (a, b) in all_ids.iter().zip(expected.iter()) {
+        assert_eq!(a, b);
+    }
+}
+
+#[test]
+fn test_badge_count() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+
+    assert_eq!(client.badge_count(&recipient), 0);
+    mint_n(&env, &client, &owner, &recipient, 7);
+    assert_eq!(client.badge_count(&recipient), 7);
+}
+
+#[test]
+fn test_start_beyond_count_returns_empty() {
+    let env = create_env();
+    let (owner, client) = setup(&env);
+    let recipient = Address::generate(&env);
+    mint_n(&env, &client, &owner, &recipient, 3);
+
+    let page = client.badges_of_paged(&recipient, &10, &5);
+    assert_eq!(page.items.len(), 0);
+    assert_eq!(page.next_cursor, None);
+}


### PR DESCRIPTION
Fixes #580

## Summary
- Creates a new `nft_payroll_badge` contract with `mint`, `badges_of`, and `badges_of_paged` endpoints.
- Defines `MAX_PAGE_SIZE = 50`; clamps any caller-supplied `limit` to it to prevent memory/instruction exhaustion.
- `badges_of_paged(owner, start, limit)` returns a `PagedBadges` struct with `items` (bounded slice) and `next_cursor` (stable, deterministic cursor) for efficient paginated reads.
- Keeps the original `badges_of` with a deprecation doc note pointing to the paged API.

## Changes
- `onchain/contracts/nft_payroll_badge/src/lib.rs` — contract implementation with full `///` doc comments on cursor semantics.
- `onchain/contracts/nft_payroll_badge/tests/test_badge.rs` — 17 tests covering: empty owner, single page, multi-page, exact-multiple-of-limit, oversized limit clamping, zero limit clamping, and deterministic cursor ordering across pages.
- `onchain/contracts/nft_payroll_badge/Cargo.toml` — package manifest matching workspace patterns.

## Test results
```
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Security notes
- `MAX_PAGE_SIZE` clamp prevents any caller from inducing unbounded vector allocations.
- Cursor is a simple integer index into the owner's append-only badge list; it cannot be manipulated to skip or duplicate entries.
- Deterministic ascending badge-ID ordering ensures stable pagination across calls.