### PR TITLE
feat: emit ExchangeRateChangedEvent from set_exchange_rate for off-chain indexers

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -256,3 +256,21 @@ pub struct MilestoneFundedEvent {
 pub fn emit_milestone_funded(env: &Env, event: MilestoneFundedEvent) {
     event.publish(env);
 }
+
+/// Event: Exchange rate set via `set_exchange_rate` or `set_exchange_rate_admin`.
+/// Emitted whenever a rate is updated so off-chain indexers can track FX history.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct ExchangeRateChangedEvent {
+    pub base: Address,
+    pub quote: Address,
+    pub new_rate: i128,
+    /// Previous rate, or 0 if this is the first time the pair is set.
+    pub prev_rate: i128,
+    /// Ledger timestamp when this event was emitted.
+    pub updated_at: u64,
+}
+
+pub fn emit_exchange_rate_changed(env: &Env, event: ExchangeRateChangedEvent) {
+    event.publish(env);
+}

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -6,13 +6,13 @@ use crate::events::{
     emit_agreement_activated, emit_agreement_cancelled, emit_agreement_created,
     emit_agreement_paused, emit_agreement_resumed, emit_dsipute_raised, emit_dsipute_resolved,
     emit_employee_added, emit_grace_period_extended, emit_grace_period_finalized,
-    emit_milestone_funded, emit_payment_received, emit_payment_sent, emit_payroll_claimed,
-    emit_set_arbiter, AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent,
-    AgreementPausedEvent, AgreementResumedEvent, ArbiterSetEvent, BatchMilestoneClaimedEvent,
-    BatchPayrollClaimedEvent, DisputeRaisedEvent, DisputeResolvedEvent, EmployeeAddedEvent,
-    GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved,
-    MilestoneClaimed, MilestoneFundedEvent, PaymentReceivedEvent, PaymentSentEvent,
-    PayrollClaimedEvent,
+    emit_exchange_rate_changed, emit_milestone_funded, emit_payment_received, emit_payment_sent,
+    emit_payroll_claimed, emit_set_arbiter, AgreementActivatedEvent, AgreementCancelledEvent,
+    AgreementCreatedEvent, AgreementPausedEvent, AgreementResumedEvent, ArbiterSetEvent,
+    BatchMilestoneClaimedEvent, BatchPayrollClaimedEvent, DisputeRaisedEvent,
+    DisputeResolvedEvent, EmployeeAddedEvent, ExchangeRateChangedEvent, GracePeriodExtendedEvent,
+    GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved, MilestoneClaimed,
+    MilestoneFundedEvent, PaymentReceivedEvent, PaymentSentEvent, PayrollClaimedEvent,
 };
 use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,
@@ -1903,7 +1903,19 @@ pub fn set_exchange_rate(
         }
     }
 
+    let prev_rate = DataKey::get_exchange_rate(env, &base, &quote)
+        .map(|r| r.rate)
+        .unwrap_or(0);
+
     DataKey::set_exchange_rate(env, &base, &quote, rate);
+
+    emit_exchange_rate_changed(env, ExchangeRateChangedEvent {
+        base,
+        quote,
+        new_rate: rate,
+        prev_rate,
+        updated_at: env.ledger().timestamp(),
+    });
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #488

- Adds `ExchangeRateChangedEvent` struct (base, quote, new_rate, prev_rate, updated_at) to `events.rs`
- Emits the event at the end of `set_exchange_rate` after persisting the new rate
- `prev_rate` is 0 when the pair is set for the first time