### PR TITLE
feat: add exchange rate sanity bound for set_exchange_rate

### DIFF
--- a/onchain/contracts/stello_pay_contract/src/lib.rs
+++ b/onchain/contracts/stello_pay_contract/src/lib.rs
@@ -780,6 +780,30 @@ impl PayrollContract {
         payroll::set_exchange_rate(&env, caller, base, quote, rate)
     }
 
+    /// Sets an absolute upper-bound sanity limit for exchange rates.
+    /// Any `set_exchange_rate` call with a rate above this value will be rejected.
+    /// Caller must be the contract owner.
+    pub fn set_fx_rate_sanity_bound(
+        env: Env,
+        caller: Address,
+        max_rate: i128,
+    ) -> Result<(), PayrollError> {
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&StorageKey::Owner)
+            .ok_or(PayrollError::Unauthorized)?;
+        caller.require_auth();
+        if caller != owner {
+            return Err(PayrollError::Unauthorized);
+        }
+        if max_rate <= 0 {
+            return Err(PayrollError::ExchangeRateInvalid);
+        }
+        storage::DataKey::set_exchange_rate_max_rate_sanity_bound(&env, max_rate);
+        Ok(())
+    }
+
     /// Converts an `amount` from one token into another using the configured
     /// FX rate, without performing any on-chain transfer. This is useful for
     /// off-chain estimation and validation of multi-currency payouts.

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -1883,6 +1883,13 @@ pub fn set_exchange_rate(
         return Err(PayrollError::Unauthorized);
     }
 
+    // Enforce absolute sanity bound if configured.
+    if let Some(max_rate) = DataKey::get_exchange_rate_max_rate_sanity_bound(env) {
+        if rate > max_rate {
+            return Err(PayrollError::ExchangeRateInvalid);
+        }
+    }
+
     // Enforce max-deviation if configured: compare with previous rate.
     if let Some(max_dev_bps) = DataKey::get_exchange_rate_max_deviation_bps(env) {
         if let Some(prev) = DataKey::get_exchange_rate(env, &base, &quote) {

--- a/onchain/contracts/stello_pay_contract/src/storage.rs
+++ b/onchain/contracts/stello_pay_contract/src/storage.rs
@@ -190,6 +190,10 @@ pub enum StorageKey {
     /// If set, a new update that changes the rate by more than this fraction
     /// relative to the previous stored rate will be rejected.
     ExchangeRateMaxDeviationBps,
+    /// Optional absolute upper-bound on any FX rate (inclusive). If set, any
+    /// `set_exchange_rate` call with a rate above this value is rejected as
+    /// a sanity guard against oracle bugs or mis-configured rates.
+    ExchangeRateMaxRateSanityBound,
     /// Cumulative grace extension (seconds) applied on top of `Agreement::grace_period_seconds`
     /// for cancelled agreements (`agreement_id` -> u64).
     GracePeriodExtensionSeconds(u128),
@@ -631,5 +635,19 @@ impl DataKey {
         env.storage()
             .persistent()
             .set(&StorageKey::ExchangeRateMaxDeviationBps, &bps);
+    }
+
+    /// Get optional absolute upper-bound sanity limit for FX rates.
+    pub fn get_exchange_rate_max_rate_sanity_bound(env: &Env) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&StorageKey::ExchangeRateMaxRateSanityBound)
+    }
+
+    /// Set optional absolute upper-bound sanity limit for FX rates.
+    pub fn set_exchange_rate_max_rate_sanity_bound(env: &Env, max_rate: i128) {
+        env.storage()
+            .persistent()
+            .set(&StorageKey::ExchangeRateMaxRateSanityBound, &max_rate);
     }
 }


### PR DESCRIPTION
Fixes #475

- Adds `ExchangeRateMaxRateSanityBound` storage key to `storage.rs` with getter/setter
- Enforces the sanity bound in `set_exchange_rate`: rejects any rate above the configured absolute ceiling with `ExchangeRateInvalid`
- Exposes `set_fx_rate_sanity_bound(caller, max_rate)` entry point in `lib.rs` (owner-only)
- Staleness check (via `ExchangeRateMaxAgeSeconds`) was already present in `convert_amount`; no changes needed there