### PR TITLE
feat: add rustfmt.toml and clippy.toml with CI enforcement

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: llvm-tools-preview
+          components: rustfmt, clippy, llvm-tools-preview
 
       - name: Install system dependencies
         run: |
@@ -30,6 +30,14 @@ jobs:
 
       - name: Install Stellar CLI
         run: cargo install stellar-cli --locked
+
+      - name: Check formatting (rustfmt)
+        working-directory: onchain
+        run: cargo fmt --all -- --check
+
+      - name: Clippy lint gate
+        working-directory: onchain
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Run tests (stello_pay_contract)
         working-directory: onchain

--- a/onchain/clippy.toml
+++ b/onchain/clippy.toml
@@ -1,0 +1,10 @@
+# clippy configuration for stellopay-core/onchain workspace.
+# Applied via: cargo clippy --workspace --all-targets -- -D warnings
+# CI enforces this via the Clippy lint gate step.
+
+# Restrict maximum function complexity (cyclomatic). Soroban contract
+# functions tend to have many storage reads; raise slightly above the default.
+cognitive-complexity-threshold = 30
+
+# Set the MSRV so version-gated lints are accurate.
+msrv = "1.77.0"

--- a/onchain/rustfmt.toml
+++ b/onchain/rustfmt.toml
@@ -1,0 +1,26 @@
+# rustfmt configuration for stellopay-core/onchain workspace.
+# Run: cargo fmt --all
+# Check (no writes): cargo fmt --all -- --check
+# This file is picked up automatically by rustfmt when run from the workspace root.
+
+edition = "2021"
+
+# Line width — keep long function signatures readable.
+max_width = 100
+
+# Imports: merge use statements for cleaner groupings.
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+
+# Function arguments — put each argument on its own line when they don't fit.
+fn_params_layout = "Tall"
+
+# Comments — wrap at max_width.
+wrap_comments = true
+comment_width = 100
+
+# Trailing commas in multi-line constructs for cleaner diffs.
+trailing_comma = "Vertical"
+
+# Normalize doc comments: convert /// to //! only where appropriate (leave as-is).
+normalize_doc_attributes = false


### PR DESCRIPTION
Fixes #500

- Adds `onchain/rustfmt.toml`: max_width=100, Crate-level import grouping, trailing commas, wrap_comments
- Adds `onchain/clippy.toml`: cognitive-complexity-threshold=30, MSRV=1.77.0
- Updates `.github/workflows/contracts.yml`:
  - Adds `rustfmt` and `clippy` components to the Rust toolchain install step
  - Adds `cargo fmt --all -- --check` gate before tests
  - Adds `cargo clippy --workspace --all-targets -- -D warnings` gate before tests