### PR TITLE
feat: extend CI to run tests for all satellite contracts

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -31,17 +31,9 @@ jobs:
       - name: Install Stellar CLI
         run: cargo install stellar-cli --locked
 
-      - name: Run tests (stello_pay_contract)
+      - name: Run tests (all workspace crates)
         working-directory: onchain
-        run: cargo test -p stello_pay_contract --verbose
-
-      - name: Run tests (integration_tests)
-        working-directory: onchain
-        run: cargo test -p integration_tests --verbose
-
-      - name: Run tests (template_versioning)
-        working-directory: onchain
-        run: cargo test -p template_versioning --verbose
+        run: cargo test --workspace --verbose
 
       - name: Build Soroban contract (WASM)
         working-directory: onchain/contracts/stello_pay_contract


### PR DESCRIPTION
Fixes #471

Replaces the three separate `cargo test -p <crate>` steps with a single `cargo test --workspace --verbose` so all 27+ crates under `onchain/contracts/` are covered by CI — including audit_logger, bonus_system, compliance_checker, governance, rate_limiter, salary_adjustment, slashing_penalty, tax_withholding, token_vesting, withdrawal_timelock, and all others that have test suites.