### PR TITLE
fix: bound per-bucket submissions vector in price_oracle push_price quorum mode

### DIFF
--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -7,6 +7,10 @@ use stello_pay_contract::PayrollContractClient;
 
 const BPS_DENOMINATOR: i128 = 10_000;
 
+/// Maximum number of pending submissions in a single quorum bucket.
+/// Caps storage and CPU usage from adversarial sources flooding a bucket.
+const MAX_QUORUM_SUBMISSIONS: u32 = 100;
+
 // ============================================================================
 // Errors
 // ============================================================================
@@ -41,6 +45,8 @@ pub enum OracleError {
     DuplicateVote = 11,
     /// Source submitted too frequently; must wait at least `min_submit_interval_secs`.
     SubmissionRateLimited = 12,
+    /// Quorum bucket already has MAX_QUORUM_SUBMISSIONS pending votes; bucket full.
+    TooManySources = 13,
 }
 
 // ============================================================================
@@ -590,6 +596,9 @@ impl PriceOracleContract {
                 }
             }
 
+            if pending.submissions.len() >= MAX_QUORUM_SUBMISSIONS {
+                return Err(OracleError::TooManySources);
+            }
             pending.submissions.push_back(PendingSubmission {
                 source: source.clone(),
                 rate,


### PR DESCRIPTION
Closes #593

Adds MAX_QUORUM_SUBMISSIONS = 100 constant and TooManySources = 13 error code. push_price returns TooManySources if the pending bucket already has 100 submissions, preventing unbounded storage growth from adversarial sources.