### PR TITLE
fix: validate tolerance_bps <= 10_000 in price_oracle configure_pair

### DIFF
--- a/onchain/contracts/price_oracle/src/lib.rs
+++ b/onchain/contracts/price_oracle/src/lib.rs
@@ -367,6 +367,9 @@ impl PriceOracleContract {
         if max_staleness_seconds == 0 || quorum_n == 0 || quorum_window_seconds == 0 {
             return Err(OracleError::InvalidPairConfig);
         }
+        if tolerance_bps > 10_000 {
+            return Err(OracleError::InvalidPairConfig);
+        }
 
         let cfg = PairConfig {
             min_rate,


### PR DESCRIPTION
Closes #594

Adds a tolerance_bps > 10_000 guard in configure_pair that returns InvalidPairConfig. Prevents nonsensical configurations where the spread tolerance exceeds 100%, which would trivially accept any quorum without meaningful agreement.