### PR TITLE
fix(payment_retry): reject contradictory retry config with zero attempts and non-empty intervals (#511)

### DIFF
--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -886,9 +886,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expense_reimbursement"

--- a/onchain/contracts/payment_retry/src/lib.rs
+++ b/onchain/contracts/payment_retry/src/lib.rs
@@ -265,6 +265,15 @@ fn validate_retry_configuration(max_retry_attempts: u32, retry_intervals: &Vec<u
         );
     }
 
+    // Guard against contradictory configuration where intervals exist
+    // but no retries can occur (max_retry_attempts = 0).
+    if retry_intervals.len() > 0 {
+        assert!(
+            max_retry_attempts > 0,
+            "Max retry attempts must be positive when retry intervals are specified"
+        );
+    }
+
     let mut i: u32 = 0;
     while i < retry_intervals.len() {
         let interval = retry_intervals.get(i).expect("Retry interval missing");


### PR DESCRIPTION
## Summary
Closes #511

Rejects the contradictory configuration where `max_retry_attempts = 0` but `retry_intervals` is non-empty. This configuration silently disables retries while operators believe intervals are active.

## Change
- Added assertion in `validate_retry_configuration`: when `max_retry_attempts == 0`, require `retry_intervals` to be empty

## Rationale
Semantically, zero attempts means no retry policy. A non-empty interval list in this context is necessarily unused and misleading.