### PR TITLE
feat(payroll): emit per-employee failure events in batch claims (#505)

### DIFF
--- a/onchain/Cargo.lock
+++ b/onchain/Cargo.lock
@@ -886,9 +886,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "expense_reimbursement"

--- a/onchain/contracts/stello_pay_contract/src/events.rs
+++ b/onchain/contracts/stello_pay_contract/src/events.rs
@@ -239,6 +239,28 @@ pub fn emit_batch_milestone_claimed(env: &Env, event: BatchMilestoneClaimedEvent
     event.publish(env);
 }
 
+/// Event: A single entry in `batch_claim_payroll` / `batch_claim_milestones` failed.
+///
+/// Emitted once per failed employee/milestone so off-chain indexers and
+/// dashboards can surface partial-batch failures without re-simulating the
+/// batch. Only the claimant (`employee`) and the `error_code` are revealed —
+/// never another party's balance.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct BatchClaimFailedEvent {
+    pub agreement_id: u128,
+    /// The claimant for the failed entry (payroll employee or milestone contributor).
+    pub employee: Address,
+    /// Which entry failed: the employee index (payroll) or milestone id (milestones).
+    pub entry_id: u32,
+    /// The same error code recorded in the batch result vector for this entry.
+    pub error_code: u32,
+}
+
+pub fn emit_batch_claim_failed(env: &Env, event: BatchClaimFailedEvent) {
+    event.publish(env);
+}
+
 /// Event: Milestone agreement funded by employer.
 ///
 /// Emitted when an employer deposits tokens into the contract for a specific

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -4,16 +4,17 @@ use soroban_sdk::{Address, Env, Vec};
 use crate::audit::{record_entry, AuditEvent};
 use crate::events::{
     emit_agreement_activated, emit_agreement_cancelled, emit_agreement_created,
-    emit_agreement_paused, emit_agreement_resumed, emit_dsipute_raised, emit_dsipute_resolved,
-    emit_employee_added, emit_exchange_rate_changed, emit_grace_period_extended,
-    emit_grace_period_finalized, emit_milestone_funded, emit_multisig_config_changed,
-    emit_payment_received, emit_payment_sent, emit_payroll_claimed, emit_set_arbiter,
-    AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent, AgreementPausedEvent,
-    AgreementResumedEvent, ArbiterSetEvent, BatchClaimFailedEvent, BatchMilestoneClaimedEvent,
-    BatchPayrollClaimedEvent, DisputeRaisedEvent, DisputeResolvedEvent, EmployeeAddedEvent,
-    ExchangeRateChangedEvent, GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded,
-    MilestoneApproved, MilestoneClaimed, MilestoneFundedEvent, MultisigConfigChangedEvent,
-    PaymentReceivedEvent, PaymentSentEvent, PayrollClaimedEvent,
+    emit_agreement_paused, emit_agreement_resumed, emit_batch_claim_failed, emit_dsipute_raised,
+    emit_dsipute_resolved, emit_employee_added, emit_exchange_rate_changed,
+    emit_grace_period_extended, emit_grace_period_finalized, emit_milestone_funded,
+    emit_multisig_config_changed, emit_payment_received, emit_payment_sent, emit_payroll_claimed,
+    emit_set_arbiter, AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent,
+    AgreementPausedEvent, AgreementResumedEvent, ArbiterSetEvent, BatchClaimFailedEvent,
+    BatchMilestoneClaimedEvent, BatchPayrollClaimedEvent, DisputeRaisedEvent, DisputeResolvedEvent,
+    EmployeeAddedEvent, ExchangeRateChangedEvent, GracePeriodExtendedEvent,
+    GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved, MilestoneClaimed,
+    MilestoneFundedEvent, MultisigConfigChangedEvent, PaymentReceivedEvent, PaymentSentEvent,
+    PayrollClaimedEvent,
 };
 use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -9,12 +9,11 @@ use crate::events::{
     emit_grace_period_finalized, emit_milestone_funded, emit_multisig_config_changed,
     emit_payment_received, emit_payment_sent, emit_payroll_claimed, emit_set_arbiter,
     AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent, AgreementPausedEvent,
-    AgreementResumedEvent, ArbiterSetEvent, BatchMilestoneClaimedEvent, BatchPayrollClaimedEvent,
-    BatchClaimFailedEvent,
-    DisputeRaisedEvent, DisputeResolvedEvent, EmployeeAddedEvent, ExchangeRateChangedEvent,
-    GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved,
-    MilestoneClaimed, MilestoneFundedEvent, MultisigConfigChangedEvent, PaymentReceivedEvent,
-    PaymentSentEvent, PayrollClaimedEvent,
+    AgreementResumedEvent, ArbiterSetEvent, BatchClaimFailedEvent, BatchMilestoneClaimedEvent,
+    BatchPayrollClaimedEvent, DisputeRaisedEvent, DisputeResolvedEvent, EmployeeAddedEvent,
+    ExchangeRateChangedEvent, GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded,
+    MilestoneApproved, MilestoneClaimed, MilestoneFundedEvent, MultisigConfigChangedEvent,
+    PaymentReceivedEvent, PaymentSentEvent, PayrollClaimedEvent,
 };
 use crate::storage::{
     Agreement, AgreementMode, AgreementStatus, BatchEscrowCreateResult, BatchMilestoneResult,

--- a/onchain/contracts/stello_pay_contract/src/payroll.rs
+++ b/onchain/contracts/stello_pay_contract/src/payroll.rs
@@ -10,6 +10,7 @@ use crate::events::{
     emit_payment_received, emit_payment_sent, emit_payroll_claimed, emit_set_arbiter,
     AgreementActivatedEvent, AgreementCancelledEvent, AgreementCreatedEvent, AgreementPausedEvent,
     AgreementResumedEvent, ArbiterSetEvent, BatchMilestoneClaimedEvent, BatchPayrollClaimedEvent,
+    BatchClaimFailedEvent,
     DisputeRaisedEvent, DisputeResolvedEvent, EmployeeAddedEvent, ExchangeRateChangedEvent,
     GracePeriodExtendedEvent, GracePeriodFinalizedEvent, MilestoneAdded, MilestoneApproved,
     MilestoneClaimed, MilestoneFundedEvent, MultisigConfigChangedEvent, PaymentReceivedEvent,
@@ -844,6 +845,15 @@ pub fn batch_claim_milestones(
         // Duplicate guard
         if processed.iter().any(|p| p == milestone_id) {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: contributor.clone(),
+                    entry_id: milestone_id,
+                    error_code: 1,
+                },
+            );
             results.push_back(MilestoneClaimResult {
                 milestone_id,
                 success: false,
@@ -857,6 +867,15 @@ pub fn batch_claim_milestones(
         // Bounds check (1-based, mirrors claim_milestone)
         if milestone_id == 0 || milestone_id > count {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: contributor.clone(),
+                    entry_id: milestone_id,
+                    error_code: 2,
+                },
+            );
             results.push_back(MilestoneClaimResult {
                 milestone_id,
                 success: false,
@@ -874,6 +893,15 @@ pub fn batch_claim_milestones(
             .unwrap_or(false);
         if !approved {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: contributor.clone(),
+                    entry_id: milestone_id,
+                    error_code: 3,
+                },
+            );
             results.push_back(MilestoneClaimResult {
                 milestone_id,
                 success: false,
@@ -891,6 +919,15 @@ pub fn batch_claim_milestones(
             .unwrap_or(false);
         if already_claimed {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: contributor.clone(),
+                    entry_id: milestone_id,
+                    error_code: 4,
+                },
+            );
             results.push_back(MilestoneClaimResult {
                 milestone_id,
                 success: false,
@@ -911,6 +948,15 @@ pub fn batch_claim_milestones(
                 // would abort the batch after earlier milestones in this loop
                 // had already transferred funds.
                 failed_claims += 1;
+                emit_batch_claim_failed(
+                    env,
+                    BatchClaimFailedEvent {
+                        agreement_id,
+                        employee: contributor.clone(),
+                        entry_id: milestone_id,
+                        error_code: 2,
+                    },
+                );
                 results.push_back(MilestoneClaimResult {
                     milestone_id,
                     success: false,
@@ -2802,6 +2848,15 @@ fn batch_claim_payroll_inner(
         // Duplicate guard
         if processed.iter().any(|p| p == employee_index) {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: caller.clone(),
+                    entry_id: employee_index,
+                    error_code: PayrollError::InvalidData as u32,
+                },
+            );
             results.push_back(PayrollClaimResult {
                 employee_index,
                 success: false,
@@ -2815,6 +2870,15 @@ fn batch_claim_payroll_inner(
         // Bounds check
         if employee_index >= employee_count {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: caller.clone(),
+                    entry_id: employee_index,
+                    error_code: PayrollError::InvalidEmployeeIndex as u32,
+                },
+            );
             results.push_back(PayrollClaimResult {
                 employee_index,
                 success: false,
@@ -2829,6 +2893,15 @@ fn batch_claim_payroll_inner(
             Some(addr) => addr,
             None => {
                 failed_claims += 1;
+                emit_batch_claim_failed(
+                    env,
+                    BatchClaimFailedEvent {
+                        agreement_id,
+                        employee: caller.clone(),
+                        entry_id: employee_index,
+                        error_code: PayrollError::AgreementNotFound as u32,
+                    },
+                );
                 results.push_back(PayrollClaimResult {
                     employee_index,
                     success: false,
@@ -2842,6 +2915,15 @@ fn batch_claim_payroll_inner(
         // Caller must be this specific employee (same check as claim_payroll)
         if *caller != employee {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: caller.clone(),
+                    entry_id: employee_index,
+                    error_code: PayrollError::Unauthorized as u32,
+                },
+            );
             results.push_back(PayrollClaimResult {
                 employee_index,
                 success: false,
@@ -2865,6 +2947,15 @@ fn batch_claim_payroll_inner(
 
         if total_elapsed_periods <= claimed_periods {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: caller.clone(),
+                    entry_id: employee_index,
+                    error_code: PayrollError::NoPeriodsToClaim as u32,
+                },
+            );
             results.push_back(PayrollClaimResult {
                 employee_index,
                 success: false,
@@ -2882,6 +2973,15 @@ fn batch_claim_payroll_inner(
                 Some(s) => s,
                 None => {
                     failed_claims += 1;
+                    emit_batch_claim_failed(
+                        env,
+                        BatchClaimFailedEvent {
+                            agreement_id,
+                            employee: caller.clone(),
+                            entry_id: employee_index,
+                            error_code: PayrollError::AgreementNotFound as u32,
+                        },
+                    );
                     results.push_back(PayrollClaimResult {
                         employee_index,
                         success: false,
@@ -2908,6 +3008,15 @@ fn batch_claim_payroll_inner(
             Some(a) => a,
             None => {
                 failed_claims += 1;
+                emit_batch_claim_failed(
+                    env,
+                    BatchClaimFailedEvent {
+                        agreement_id,
+                        employee: caller.clone(),
+                        entry_id: employee_index,
+                        error_code: PayrollError::InvalidData as u32,
+                    },
+                );
                 results.push_back(PayrollClaimResult {
                     employee_index,
                     success: false,
@@ -2921,6 +3030,15 @@ fn batch_claim_payroll_inner(
         // Check in-memory escrow
         if escrow_balance < amount {
             failed_claims += 1;
+            emit_batch_claim_failed(
+                env,
+                BatchClaimFailedEvent {
+                    agreement_id,
+                    employee: caller.clone(),
+                    entry_id: employee_index,
+                    error_code: PayrollError::InsufficientEscrowBalance as u32,
+                },
+            );
             results.push_back(PayrollClaimResult {
                 employee_index,
                 success: false,

--- a/onchain/contracts/stello_pay_contract/tests/test_batch_claim_failure_events.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_batch_claim_failure_events.rs
@@ -177,7 +177,7 @@ fn batch_claim_milestones_emits_failure_event_per_failed_entry() {
 
     // caller = contributor (valid id 1, duplicate id 1, out-of-bounds id 99)
     let ids = Vec::from_array(&env, [1u32, 1u32, 99u32]);
-    let result = client.batch_claim_milestones(&contributor, &agreement_id, &ids);
+    let result = client.batch_claim_milestones(&agreement_id, &ids);
 
     assert_eq!(result.successful_claims, 1);
     assert_eq!(result.failed_claims, 2);

--- a/onchain/contracts/stello_pay_contract/tests/test_batch_claim_failure_events.rs
+++ b/onchain/contracts/stello_pay_contract/tests/test_batch_claim_failure_events.rs
@@ -1,0 +1,209 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, Symbol, TryFromVal, Vec,
+};
+use stello_pay_contract::storage::{
+    Agreement, AgreementMode, AgreementStatus, DataKey, DisputeStatus, PayrollError, StorageKey,
+};
+use stello_pay_contract::{PayrollContract, PayrollContractClient};
+
+const PERIOD_SECONDS: u64 = 86_400;
+const GRACE_SECONDS: u64 = PERIOD_SECONDS * 7;
+
+fn setup() -> (
+    Env,
+    PayrollContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(&env, &contract_id);
+    let employer = Address::generate(&env);
+    let employee0 = Address::generate(&env);
+    let employee1 = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    (env, client, employer, employee0, employee1, token)
+}
+
+/// Seeds a payroll agreement with per-employee claim metadata so the money path
+/// can be exercised without relying on the higher-level creation flow.
+fn create_funded_payroll(
+    env: &Env,
+    client: &PayrollContractClient,
+    employer: &Address,
+    employees: &[(Address, i128)],
+    token: &Address,
+    escrow_amount: i128,
+) -> u128 {
+    let agreement_id = 1u128;
+    let now = env.ledger().timestamp();
+
+    env.as_contract(&client.address, || {
+        let agreement = Agreement {
+            id: agreement_id,
+            employer: employer.clone(),
+            token: token.clone(),
+            mode: AgreementMode::Payroll,
+            status: AgreementStatus::Active,
+            total_amount: employees.iter().map(|(_, salary)| *salary).sum(),
+            paid_amount: 0,
+            created_at: now,
+            activated_at: Some(now),
+            cancelled_at: None,
+            grace_period_seconds: GRACE_SECONDS,
+            amount_per_period: None,
+            period_seconds: Some(PERIOD_SECONDS),
+            num_periods: None,
+            claimed_periods: None,
+            dispute_raised_at: None,
+            dispute_status: DisputeStatus::None,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&StorageKey::Agreement(agreement_id), &agreement);
+        DataKey::set_employee_count(env, agreement_id, employees.len() as u32);
+        DataKey::set_agreement_activation_time(env, agreement_id, now);
+        DataKey::set_agreement_period_duration(env, agreement_id, PERIOD_SECONDS);
+        DataKey::set_agreement_token(env, agreement_id, token);
+        DataKey::set_agreement_escrow_balance(env, agreement_id, token, escrow_amount);
+
+        for (index, (employee, salary)) in employees.iter().enumerate() {
+            let index = index as u32;
+            DataKey::set_employee(env, agreement_id, index, employee);
+            DataKey::set_employee_salary(env, agreement_id, index, *salary);
+            DataKey::set_employee_claimed_periods(env, agreement_id, index, 0);
+        }
+    });
+
+    StellarAssetClient::new(env, token).mint(&client.address, &escrow_amount);
+    agreement_id
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|ledger| {
+        ledger.timestamp += seconds;
+    });
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+/// Counts events whose topic symbol equals `event_name`.
+fn count_events(env: &Env, event_name: &str) -> usize {
+    env.events()
+        .all()
+        .iter()
+        .filter(|e| {
+            if e.1.len() > 0 {
+                let topic = e.1.get(0).unwrap();
+                if let Ok(sym) = Symbol::try_from_val(env, &topic) {
+                    return sym.to_string() == event_name;
+                }
+            }
+            false
+        })
+        .count()
+}
+
+/// `batch_claim_payroll` must emit one `batch_claim_failed_event` per failed
+/// entry and still pay out the valid entries (partial success, no abort).
+#[test]
+fn batch_claim_payroll_emits_failure_event_per_failed_entry() {
+    let (env, client, employer, employee0, employee1, token) = setup();
+    let salary0 = 1_000i128;
+    let salary1 = 2_500i128;
+    let agreement_id = create_funded_payroll(
+        &env,
+        &client,
+        &employer,
+        &[(employee0.clone(), salary0), (employee1.clone(), salary1)],
+        &token,
+        30_000,
+    );
+
+    advance_time(&env, PERIOD_SECONDS); // one period elapsed -> employee0 can claim
+
+    // caller = employee0 (valid for index 0, not employee1, and index 99 is OOB)
+    let indices = Vec::from_array(&env, [0u32, 1u32, 99u32]);
+    let result = client.batch_claim_payroll(&employee0, &agreement_id, &indices);
+
+    // index 0 succeeds; index 1 (Unauthorized) and index 99 (InvalidEmployeeIndex) fail.
+    assert_eq!(result.successful_claims, 1);
+    assert_eq!(result.failed_claims, 2);
+
+    // One per-failure event, counted before any contract read resets the buffer.
+    assert_eq!(count_events(&env, "batch_claim_failed_event"), 2);
+
+    // The batch continues: valid employee got paid for the elapsed period.
+    assert_eq!(TokenClient::new(&env, &token).balance(&employee0), salary0);
+    assert_eq!(TokenClient::new(&env, &token).balance(&employee1), 0);
+}
+
+/// `batch_claim_milestones` must emit one `batch_claim_failed_event` per failed
+/// entry (duplicate + out-of-bounds) while still claiming the valid milestone.
+#[test]
+fn batch_claim_milestones_emits_failure_event_per_failed_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, PayrollContract);
+    let client = PayrollContractClient::new(&env, &contract_id);
+    let employer = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    let agreement_id = client.create_milestone_agreement(&employer, &contributor, &token);
+    let amount = 5_000i128;
+    client.add_milestone(&agreement_id, &amount);
+    mint(&env, &token, &employer, amount);
+    client.fund_milestone_agreement(&agreement_id, &employer, &amount);
+    client.approve_milestone(&agreement_id, &1);
+
+    // caller = contributor (valid id 1, duplicate id 1, out-of-bounds id 99)
+    let ids = Vec::from_array(&env, [1u32, 1u32, 99u32]);
+    let result = client.batch_claim_milestones(&contributor, &agreement_id, &ids);
+
+    assert_eq!(result.successful_claims, 1);
+    assert_eq!(result.failed_claims, 2);
+    assert_eq!(count_events(&env, "batch_claim_failed_event"), 2);
+}
+
+#[test]
+fn batch_claim_failed_event_reveals_only_claimant() {
+    let (env, client, employer, employee0, employee1, token) = setup();
+    let agreement_id = create_funded_payroll(
+        &env,
+        &client,
+        &employer,
+        &[(employee0.clone(), 1_000), (employee1.clone(), 1_000)],
+        &token,
+        10_000,
+    );
+    advance_time(&env, PERIOD_SECONDS);
+
+    // All-fail batch: index 99 OOB + index 1 unauthorized (caller is employee0).
+    let indices = Vec::from_array(&env, [99u32, 1u32]);
+    let result = client.batch_claim_payroll(&employee0, &agreement_id, &indices);
+    assert_eq!(result.failed_claims, 2);
+    assert_eq!(count_events(&env, "batch_claim_failed_event"), 2);
+
+    // No tokens moved despite two failure events.
+    assert_eq!(TokenClient::new(&env, &token).balance(&employee0), 0);
+    assert_eq!(TokenClient::new(&env, &token).balance(&employee1), 0);
+}


### PR DESCRIPTION
## Summary
Closes #505. Emits a `BatchClaimFailedEvent` for **every** failed entry in `batch_claim_payroll` and `batch_claim_milestones`, so off-chain indexers and dashboards can surface partial-batch failures without re-simulating the batch.

## What changed
- `events.rs`: new `BatchClaimFailedEvent { agreement_id, employee, entry_id, error_code }` with `emit_batch_claim_failed` helper.
- `payroll.rs`: emit the event in all 8 `batch_claim_payroll` failure branches and all 5 `batch_claim_milestones` failure branches (duplicate / out-of-bounds / not-approved / already-claimed / not-found / unauthorized / no-periods / insufficient-escrow).
- The existing `BatchPayrollResult` / `BatchMilestoneResult` return values are untouched and the batch still continues after a failure (no early abort).

## Security
Each event reveals only the **claimant** (`employee`/`contributor`) and the **error code** for that entry — never another employee's balance.

## Tests added (`test_batch_claim_failure_events.rs`)
- Mixed payroll batch (1 success + 2 failures) asserts exactly 2 `batch_claim_failed_event` and that the valid employee is paid.
- Mixed milestone batch (1 success + 2 failures) asserts exactly 2 failure events.
- All-fail batch asserts 2 events and that no tokens move.
